### PR TITLE
remove  unimported function

### DIFF
--- a/plugins/modules/oracle_ping.py
+++ b/plugins/modules/oracle_ping.py
@@ -90,8 +90,7 @@ def main():
         supports_check_mode=True
     )
 
-    oc = oracleConnection(module)
-    db = check_directory_exists(oc)
+    oracleConnection(module)
     module.exit_json(msg="Connection successful", changed=False)
 
 


### PR DESCRIPTION
Dunno if the call of check_directory_exists in ping module is wanted.

But anyway the methood signature is not good, and the function is not imported. I do not have the knowledge in oracle system to say if to validate ping, you need to check if a directory exist, but for common stuff, you do not need it.