### PR TITLE
Add sysdg/sysoper/sysasm auth modes and refactor legacy module connections

### DIFF
--- a/plugins/module_utils/oracle_utils.py
+++ b/plugins/module_utils/oracle_utils.py
@@ -15,6 +15,22 @@ else:
     oracledb_exists = True
 
 
+# Mapping from module 'mode' parameter to oracledb auth-mode constants.
+# 'normal' is omitted — it means "no special mode flag".
+# Entries whose constant is None (unsupported by the installed oracledb) are
+# excluded so that _AUTH_MODES.get(mode) returns None only for 'normal'.
+_AUTH_MODES = {}
+if oracledb_exists:
+    _AUTH_MODES = {
+        k: v for k, v in {
+            'sysdba': oracledb.SYSDBA,
+            'sysdg': getattr(oracledb, 'SYSDG', getattr(oracledb, 'AUTH_MODE_SYSDG', None)),
+            'sysoper': getattr(oracledb, 'SYSOPER', getattr(oracledb, 'AUTH_MODE_SYSOPER', None)),
+            'sysasm': getattr(oracledb, 'SYSASM', getattr(oracledb, 'AUTH_MODE_SYSASM', None)),
+        }.items() if v is not None
+    }
+
+
 def _is_dpi_1047(error_obj):
     msg = str(getattr(error_obj, "message", error_obj))
     return "DPI-1047" in msg
@@ -68,6 +84,35 @@ def _ensure_oracle_client(module, oracle_home=None, required=False):
     module.fail_json(msg="Unable to initialize Oracle Client: %s" % detail, changed=False)
     return False
 
+# ---------------------------------------------------------------------------
+# Shared SQL clause builders (used by oracle_wallet, oracle_tde, etc.)
+# ---------------------------------------------------------------------------
+
+def build_force_clause(force_keystore):
+    """Build FORCE KEYSTORE clause for ADMINISTER KEY MANAGEMENT."""
+    if force_keystore:
+        return 'FORCE KEYSTORE '
+    return ''
+
+
+def build_container_clause(container):
+    """Build CONTAINER clause for ADMINISTER KEY MANAGEMENT."""
+    if container == 'all':
+        return ' CONTAINER = ALL'
+    return ''
+
+
+def build_backup_clause(backup=True, backup_tag=None):
+    """Build WITH BACKUP clause for ADMINISTER KEY MANAGEMENT."""
+    if not backup:
+        return ''
+    clause = ' WITH BACKUP'
+    if backup_tag:
+        safe_tag = backup_tag.replace("'", "''")
+        clause += " USING '%s'" % safe_tag
+    return clause
+
+
 def sanitize_string_params(module_params):
     """Strip leading/trailing whitespace from every string value in module.params.
 
@@ -114,29 +159,36 @@ def oracle_connect(module):
 
     wallet_connect = '/@%s' % service_name
 
+    auth_mode = _AUTH_MODES.get(mode)
+    if mode != 'normal' and auth_mode is None:
+        module.fail_json(msg="Auth mode '%s' is not supported by the installed oracledb driver" % mode, changed=False)
+
     try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
+        if not user and not password:  # OS authentication or wallet
             _ensure_oracle_client(module, oracle_home=oracle_home, required=True)
-            if mode == 'sysdba':
+            if auth_mode and service_name:
+                # TNS via wallet: /@service_name as sysdba
+                connect = wallet_connect
+                conn = oracledb.connect(wallet_connect, mode=auth_mode)
+            elif auth_mode:
+                # BEQ/OS auth: / as sysdba (local instance, no listener)
                 connect = '/'
-                conn = oracledb.connect(mode=oracledb.SYSDBA)
+                conn = oracledb.connect(mode=auth_mode)
             else:
                 connect = wallet_connect
                 conn = oracledb.connect(wallet_connect)
 
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user=user, password=password, dsn=dsn, mode=oracledb.SYSDBA)
+        elif user and password:
+            dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
+            connect = dsn
+            if auth_mode:
+                conn = oracledb.connect(user=user, password=password, dsn=dsn, mode=auth_mode)
             else:
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
                 conn = oracledb.connect(user=user, password=password, dsn=dsn)
 
-        elif (not(user) or not(password)):
+        elif not user or not password:
             module.fail_json(msg='Missing username or password for oracledb')
-            
+
     except oracledb.DatabaseError as exc:
         error, = exc.args
         msg = 'Could not connect to database - %s, connect descriptor: %s' % (error.message, connect)
@@ -179,25 +231,35 @@ class oracleConnection:
 
         wallet_connect = '/@%s' % service_name
         # Thick mode is only required for OS-authenticated connections (no user/password).
-        # SYSDBA over TCP with explicit credentials works in python-oracledb thin mode (2.x+).
+        # SYSDBA/SYSDG/SYSOPER/SYSASM over TCP with explicit credentials works in
+        # python-oracledb thin mode (2.x+).
         requires_thick = not user and not password
         _ensure_oracle_client(module, oracle_home=self.oracle_home, required=requires_thick)
 
+        auth_mode = _AUTH_MODES.get(mode)
+        if mode != 'normal' and auth_mode is None:
+            module.fail_json(msg="Auth mode '%s' is not supported by the installed oracledb driver" % mode, changed=False)
+
         connect = '<unresolved>'
         try:
-            if not user and not password: # If neither user or password is supplied, the use of an oracle connect internal or wallet is assumed
-                if mode == 'sysdba':
+            if not user and not password:  # OS authentication or wallet
+                if auth_mode and service_name:
+                    # TNS via wallet: /@service_name as sysdba
+                    connect = wallet_connect
+                    conn = oracledb.connect(wallet_connect, mode=auth_mode)
+                elif auth_mode:
+                    # BEQ/OS auth: / as sysdba (local instance, no listener)
                     connect = '/'
-                    conn = oracledb.connect(mode=oracledb.SYSDBA)
+                    conn = oracledb.connect(mode=auth_mode)
                 else:
                     connect = wallet_connect
                     conn = oracledb.connect(wallet_connect)
-            elif user and password: # Assume supplied user has SYSDBA role granted
+            elif user and password:
                 if not dsn and hostname:
                     dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
                 connect = dsn
-                if mode == 'sysdba':
-                    conn = oracledb.connect(user=user, password=password, dsn=dsn, mode=oracledb.SYSDBA)
+                if auth_mode:
+                    conn = oracledb.connect(user=user, password=password, dsn=dsn, mode=auth_mode)
                 else:
                     conn = oracledb.connect(user=user, password=password, dsn=dsn)
             elif not user or not password:

--- a/plugins/modules/oracle_awr.py
+++ b/plugins/modules/oracle_awr.py
@@ -40,7 +40,7 @@ options:
     description: The mode with which to connect to the database
     required: False
     default: normal
-    choices: ['normal','sysdba']
+    choices: ['normal','sysdba','sysdg','sysoper','sysasm']
   snapshot_interval_min:
     description: AWR snapshot interval in minutes; 0 disables
     default: 60
@@ -120,7 +120,7 @@ def main():
         argument_spec = dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_directory.py
+++ b/plugins/modules/oracle_directory.py
@@ -84,7 +84,7 @@ def main():
         argument_spec = dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_facts.py
+++ b/plugins/modules/oracle_facts.py
@@ -306,7 +306,7 @@ def main():
         argument_spec=dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_grant.py
+++ b/plugins/modules/oracle_grant.py
@@ -366,7 +366,7 @@ def main():
         argument_spec = dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_job.py
+++ b/plugins/modules/oracle_job.py
@@ -40,6 +40,19 @@ options:
         choices:
             - normal
             - sysdba
+            - sysdg
+            - sysoper
+            - sysasm
+    oracle_home:
+        description:
+            - The ORACLE_HOME path
+        required: false
+        aliases: ['oh']
+    dsn:
+        description:
+            - Oracle Data Source Name (connect string or TNS alias), overrides hostname/port/service_name
+        required: false
+        aliases: ['datasource_name']
     state:
         description:
             - If present, then job is created, if absent then job is dropped
@@ -203,19 +216,9 @@ import re
 try:
     import oracledb
 except ImportError:
-    oracledb_exists = False
-else:
-    oracledb_exists = True
+    oracledb = None
 
 
-def apply_session_container(module, conn):
-    session_container = module.params.get("session_container")
-    if not session_container:
-        return
-    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', session_container):
-        module.fail_json(msg='Invalid session_container for alter session', changed=False)
-    c = conn.cursor()
-    c.execute('ALTER SESSION SET CONTAINER = %s' % session_container)
 
 def query_existing(job_owner, job_name):
     c = conn.cursor()
@@ -377,7 +380,9 @@ def main():
             service_name  = dict(required=True),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            oracle_home   = dict(required=False, aliases=['oh']),
+            dsn           = dict(required=False, aliases=['datasource_name']),
             session_container = dict(required=False),
             state         = dict(default="present", choices=["present", "absent"]),
             enabled       = dict(default=True, type='bool'),
@@ -401,9 +406,7 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[['schedule_name','repeat_interval'],['program_name','job_action']]
     )
-    # Check for required modules
-    if not oracledb_exists:
-        module.fail_json(msg="The oracledb module is required. 'pip install oracledb' should do the trick. If oracledb is installed, make sure ORACLE_HOME & LD_LIBRARY_PATH is set")
+    sanitize_string_params(module.params)
     # Check input parameters
     re_name = re.compile("^[A-Za-z0-9_\$#]+\.[A-Za-z0-9_\$#]+$")
     if not re_name.match(module.params['job_name']):
@@ -424,50 +427,10 @@ def main():
     if module.params['schedule_name'] and not re_name.match(module.params['schedule_name']):
         module.fail_json(msg="Invalid schedule name, must be SCHEMANAME.SCHEDULE_NAME")
     # Connect to database
-    hostname = module.params["hostname"]
-    port = module.params["port"]
-    service_name = module.params["service_name"]
-    user = module.params["user"]
-    password = module.params["password"]
-    mode = module.params["mode"]
-    wallet_connect = '/@%s' % service_name
-    try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
-            if mode == 'sysdba':
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect, mode=oracledb.SYSDBA)
-            else:
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect)
-
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn, mode=oracledb.SYSDBA)
-            else:
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn)
-
-        elif (not(user) or not(password)):
-            module.fail_json(msg='Missing username or password for oracledb')
-
-    except oracledb.DatabaseError as exc:
-        error, = exc.args
-        error_msg = getattr(error, 'message', str(error))
-        requires_thick = (mode == 'sysdba') or (not user and not password)
-        if 'DPI-1047' in error_msg and requires_thick:
-            msg[0] = (
-                "Oracle Client libraries cannot be loaded (DPI-1047). "
-                "Install Oracle Instant Client or use a thin-compatible connection mode."
-            )
-        else:
-            msg[0] = 'Oracle connection failed: %s' % error_msg
-        module.fail_json(msg=msg[0], changed=False)
+    oc = oracleConnection(module)
+    conn = oc.conn
     if conn.version < "10.2":
         module.fail_json(msg="Database version must be 10gR2 or greater", changed=False)
-    apply_session_container(module, conn)
     #
     result = query_existing(job_owner, job_name)
     desired_logging = module.params['logging_level'].upper() if module.params['logging_level'] else None
@@ -533,5 +496,20 @@ def main():
 
 
 from ansible.module_utils.basic import *
+
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
+
+    class oracleConnection:  # noqa: N801
+        def __init__(self, module):
+            module.fail_json(msg='oracle_utils is required. Ensure the collection is properly installed.', changed=False)
+
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_jobclass.py
+++ b/plugins/modules/oracle_jobclass.py
@@ -37,7 +37,17 @@ options:
             - The mode with which to connect to the database
         required: true
         default: normal
-        choices: ['normal','sysdba']
+        choices: ['normal','sysdba','sysdg','sysoper','sysasm']
+    oracle_home:
+        description:
+            - The ORACLE_HOME path
+        required: false
+        aliases: ['oh']
+    dsn:
+        description:
+            - Oracle Data Source Name (connect string or TNS alias), overrides hostname/port/service_name
+        required: false
+        aliases: ['datasource_name']
     state:
         description:
             - If present, job class is created if absent then job class is removed
@@ -107,22 +117,7 @@ EXAMPLES = '''
 
 import re
 
-try:
-    import oracledb
-except ImportError:
-    oracledb_exists = False
-else:
-    oracledb_exists = True
 
-
-def apply_session_container(module, conn):
-    session_container = module.params.get("session_container")
-    if not session_container:
-        return
-    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', session_container):
-        module.fail_json(msg='Invalid session_container for alter session', changed=False)
-    c = conn.cursor()
-    c.execute('ALTER SESSION SET CONTAINER = %s' % session_container)
 
 def query_existing(job_class_name):
     c = conn.cursor()
@@ -145,7 +140,9 @@ def main():
             service_name  = dict(required=True),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            oracle_home   = dict(required=False, aliases=['oh']),
+            dsn           = dict(required=False, aliases=['datasource_name']),
             session_container = dict(required=False),
             state         = dict(default="present", choices=["present", "absent"]),
             name          = dict(required=True),
@@ -157,55 +154,12 @@ def main():
         ),
         supports_check_mode=True
     )
-    # Check for required modules
-    if not oracledb_exists:
-        module.fail_json(msg="The oracledb module is required. 'pip install oracledb' should do the trick. If oracledb is installed, make sure ORACLE_HOME & LD_LIBRARY_PATH is set")
-    # Check input parameters
+    sanitize_string_params(module.params)
     # Connect to database
-    hostname = module.params["hostname"]
-    port = module.params["port"]
-    service_name = module.params["service_name"]
-    user = module.params["user"]
-    password = module.params["password"]
-    mode = module.params["mode"]
-    wallet_connect = '/@%s' % service_name
-    try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
-            if mode == 'sysdba':
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect, mode=oracledb.SYSDBA)
-            else:
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect)
-
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn, mode=oracledb.SYSDBA)
-            else:
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn)
-
-        elif (not(user) or not(password)):
-            module.fail_json(msg='Missing username or password for oracledb')
-
-    except oracledb.DatabaseError as exc:
-        error, = exc.args
-        error_msg = getattr(error, 'message', str(error))
-        requires_thick = (mode == 'sysdba') or (not user and not password)
-        if 'DPI-1047' in error_msg and requires_thick:
-            msg[0] = (
-                "Oracle Client libraries cannot be loaded (DPI-1047). "
-                "Install Oracle Instant Client or use a thin-compatible connection mode."
-            )
-        else:
-            msg[0] = 'Oracle connection failed: %s' % error_msg
-        module.fail_json(msg=msg[0], changed=False)
+    oc = oracleConnection(module)
+    conn = oc.conn
     if conn.version < "10.2":
         module.fail_json(msg="Database version must be 10gR2 or greater", changed=False)
-    apply_session_container(module, conn)
     #
     result = query_existing(module.params['name'])
     if module.check_mode:
@@ -314,5 +268,18 @@ def main():
 
 
 from ansible.module_utils.basic import *
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
+
+    class oracleConnection:  # noqa: N801
+        def __init__(self, module):
+            module.fail_json(msg='oracle_utils is required. Ensure the collection is properly installed.', changed=False)
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_jobschedule.py
+++ b/plugins/modules/oracle_jobschedule.py
@@ -37,7 +37,17 @@ options:
             - The mode with which to connect to the database
         required: true
         default: normal
-        choices: ['normal','sysdba']
+        choices: ['normal','sysdba','sysdg','sysoper','sysasm']
+    oracle_home:
+        description:
+            - The ORACLE_HOME path
+        required: false
+        aliases: ['oh']
+    dsn:
+        description:
+            - Oracle Data Source Name (connect string or TNS alias), overrides hostname/port/service_name
+        required: false
+        aliases: ['datasource_name']
     state:
         description:
             - If present, job schedule is created, if absent then schedule is dropped
@@ -100,22 +110,7 @@ EXAMPLES = '''
 
 import re
 
-try:
-    import oracledb
-except ImportError:
-    oracledb_exists = False
-else:
-    oracledb_exists = True
 
-
-def apply_session_container(module, conn):
-    session_container = module.params.get("session_container")
-    if not session_container:
-        return
-    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', session_container):
-        module.fail_json(msg='Invalid session_container for alter session', changed=False)
-    c = conn.cursor()
-    c.execute('ALTER SESSION SET CONTAINER = %s' % session_container)
 
 def query_existing(owner, name):
     c = conn.cursor()
@@ -138,7 +133,9 @@ def main():
             service_name  = dict(required=True),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            oracle_home   = dict(required=False, aliases=['oh']),
+            dsn           = dict(required=False, aliases=['datasource_name']),
             session_container = dict(required=False),
             state         = dict(default="present", choices=["present", "absent"]),
             name          = dict(required=True),
@@ -148,9 +145,7 @@ def main():
         ),
         supports_check_mode=True
     )
-    # Check for required modules
-    if not oracledb_exists:
-        module.fail_json(msg="The oracledb module is required. 'pip install oracledb' should do the trick. If oracledb is installed, make sure ORACLE_HOME & LD_LIBRARY_PATH is set")
+    sanitize_string_params(module.params)
     # Check input parameters
     re_name = re.compile("^[A-Za-z0-9_\$#]+\.[A-Za-z0-9_\$#]+$")
     if not re_name.match(module.params['name']):
@@ -161,50 +156,10 @@ def main():
     job_name = job_parts[1]
     job_fullname = "\"%s\".\"%s\"" % (job_owner, job_name)
     # Connect to database
-    hostname = module.params["hostname"]
-    port = module.params["port"]
-    service_name = module.params["service_name"]
-    user = module.params["user"]
-    password = module.params["password"]
-    mode = module.params["mode"]
-    wallet_connect = '/@%s' % service_name
-    try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
-            if mode == 'sysdba':
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect, mode=oracledb.SYSDBA)
-            else:
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect)
-
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn, mode=oracledb.SYSDBA)
-            else:
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn)
-
-        elif (not(user) or not(password)):
-            module.fail_json(msg='Missing username or password for oracledb')
-
-    except oracledb.DatabaseError as exc:
-        error, = exc.args
-        error_msg = getattr(error, 'message', str(error))
-        requires_thick = (mode == 'sysdba') or (not user and not password)
-        if 'DPI-1047' in error_msg and requires_thick:
-            msg[0] = (
-                "Oracle Client libraries cannot be loaded (DPI-1047). "
-                "Install Oracle Instant Client or use a thin-compatible connection mode."
-            )
-        else:
-            msg[0] = 'Oracle connection failed: %s' % error_msg
-        module.fail_json(msg=msg[0], changed=False)
+    oc = oracleConnection(module)
+    conn = oc.conn
     if conn.version < "10.2":
         module.fail_json(msg="Database version must be 10gR2 or greater", changed=False)
-    apply_session_container(module, conn)
     #
     result = query_existing(job_owner, job_name)
     if module.check_mode:
@@ -271,5 +226,18 @@ def main():
 
 
 from ansible.module_utils.basic import *
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
+
+    class oracleConnection:  # noqa: N801
+        def __init__(self, module):
+            module.fail_json(msg='oracle_utils is required. Ensure the collection is properly installed.', changed=False)
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_jobwindow.py
+++ b/plugins/modules/oracle_jobwindow.py
@@ -37,7 +37,17 @@ options:
             - The mode with which to connect to the database
         required: true
         default: normal
-        choices: ['normal','sysdba']
+        choices: ['normal','sysdba','sysdg','sysoper','sysasm']
+    oracle_home:
+        description:
+            - The ORACLE_HOME path
+        required: false
+        aliases: ['oh']
+    dsn:
+        description:
+            - Oracle Data Source Name (connect string or TNS alias), overrides hostname/port/service_name
+        required: false
+        aliases: ['datasource_name']
     state:
         description:
             - If absent then window is dropped, if enabled or disabled then window is created at the requested state
@@ -119,22 +129,7 @@ EXAMPLES = '''
 from datetime import timedelta
 import re
 
-try:
-    import oracledb
-except ImportError:
-    oracledb_exists = False
-else:
-    oracledb_exists = True
 
-
-def apply_session_container(module, conn):
-    session_container = module.params.get("session_container")
-    if not session_container:
-        return
-    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', session_container):
-        module.fail_json(msg='Invalid session_container for alter session', changed=False)
-    c = conn.cursor()
-    c.execute('ALTER SESSION SET CONTAINER = %s' % session_container)
 
 def query_existing(name):
     c = conn.cursor()
@@ -158,7 +153,9 @@ def main():
             service_name  = dict(required=True),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            oracle_home   = dict(required=False, aliases=['oh']),
+            dsn           = dict(required=False, aliases=['datasource_name']),
             session_container = dict(required=False),
             state         = dict(default="enabled", choices=["absent","enabled","disabled"]),
             name          = dict(required=True, aliases=["window_name"]),
@@ -172,9 +169,7 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[['duration_min','duration_hour']]
     )
-    # Check for required modules
-    if not oracledb_exists:
-        module.fail_json(msg="The oracledb module is required. 'pip install oracledb' should do the trick. If oracledb is installed, make sure ORACLE_HOME & LD_LIBRARY_PATH is set")
+    sanitize_string_params(module.params)
     # Check input parameters
     job_fullname = module.params['name'].upper()
     if module.params['duration_min'] is None and module.params['duration_hour'] is None:
@@ -184,50 +179,10 @@ def main():
     if new_duration_min < 1:
         module.fail_json(msg='Invalid window duration', changed=False)
     # Connect to database
-    hostname = module.params["hostname"]
-    port = module.params["port"]
-    service_name = module.params["service_name"]
-    user = module.params["user"]
-    password = module.params["password"]
-    mode = module.params["mode"]
-    wallet_connect = '/@%s' % service_name
-    try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
-            if mode == 'sysdba':
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect, mode=oracledb.SYSDBA)
-            else:
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect)
-
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn, mode=oracledb.SYSDBA)
-            else:
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn)
-
-        elif (not(user) or not(password)):
-            module.fail_json(msg='Missing username or password for oracledb')
-
-    except oracledb.DatabaseError as exc:
-        error, = exc.args
-        error_msg = getattr(error, 'message', str(error))
-        requires_thick = (mode == 'sysdba') or (not user and not password)
-        if 'DPI-1047' in error_msg and requires_thick:
-            msg[0] = (
-                "Oracle Client libraries cannot be loaded (DPI-1047). "
-                "Install Oracle Instant Client or use a thin-compatible connection mode."
-            )
-        else:
-            msg[0] = 'Oracle connection failed: %s' % error_msg
-        module.fail_json(msg=msg[0], changed=False)
+    oc = oracleConnection(module)
+    conn = oc.conn
     if conn.version < "10.2":
         module.fail_json(msg="Database version must be 10gR2 or greater", changed=False)
-    apply_session_container(module, conn)
     #
     result = query_existing(job_fullname)
     if module.check_mode:
@@ -348,5 +303,18 @@ def main():
 
 
 from ansible.module_utils.basic import *
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
+
+    class oracleConnection:  # noqa: N801
+        def __init__(self, module):
+            module.fail_json(msg='oracle_utils is required. Ensure the collection is properly installed.', changed=False)
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_ldapuser.py
+++ b/plugins/modules/oracle_ldapuser.py
@@ -36,7 +36,17 @@ options:
             - The mode with which to connect to the database
         required: true
         default: normal
-        choices: ['normal','sysdba']
+        choices: ['normal','sysdba','sysdg','sysoper','sysasm']
+    oracle_home:
+        description:
+            - The ORACLE_HOME path
+        required: false
+        aliases: ['oh']
+    dsn:
+        description:
+            - Oracle Data Source Name (connect string or TNS alias), overrides hostname/port/service_name
+        required: false
+        aliases: ['datasource_name']
     user_default_tablespace:
         description:
             - Default tablespace for syncronised users
@@ -187,15 +197,6 @@ def clean_string(s):
     return supper
 
 
-def apply_session_container(module, conn):
-    session_container = module.params.get("session_container")
-    if not session_container:
-        return
-    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', session_container):
-        module.fail_json(msg='Invalid session_container for alter session', changed=False)
-    c = conn.cursor()
-    c.execute('ALTER SESSION SET CONTAINER = %s' % session_container)
-
 # Module code
 
 def query_ldap_users():
@@ -231,8 +232,10 @@ def main():
             service_name  = dict(required=True),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            oracle_home   = dict(required=False, aliases=['oh']),
+            dsn           = dict(required=False, aliases=['datasource_name']),
             session_container = dict(required=False),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
             user_default_tablespace = dict(default='USERS'),
             user_quota_on_default_tbs_mb = dict(default=None, type='int'), # None is unlimited
             user_temp_tablespace = dict(default='TEMP'),
@@ -252,6 +255,7 @@ def main():
         supports_check_mode=True
         #, mutually_exclusive=[['schema_password', 'schema_password_hash']]
     )
+    sanitize_string_params(module.params)
     # Check input variables
     if module.params['user_profile'].upper() == 'DEFAULT':
         module.fail_json(msg='Please use a dedicated profile for LDAP users, since this is the only method of detecting if user has been deleted from LDAP and should also be closed in database side.')
@@ -276,48 +280,8 @@ def main():
         'username': module.params['ldap_username_attribute']
     }
     # Connect to database
-    hostname = module.params["hostname"]
-    port = module.params["port"]
-    service_name = module.params["service_name"]
-    user = module.params["user"]
-    password = module.params["password"]
-    mode = module.params["mode"]
-    wallet_connect = '/@%s' % service_name
-    try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
-            if mode == 'sysdba':
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect, mode=oracledb.SYSDBA)
-            else:
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect)
-
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn, mode=oracledb.SYSDBA)
-            else:
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn)
-
-        elif (not(user) or not(password)):
-            module.fail_json(msg='Missing username or password for oracledb')
-
-    except oracledb.DatabaseError as exc:
-        error, = exc.args
-        error_msg = getattr(error, 'message', str(error))
-        requires_thick = (mode == 'sysdba') or (not user and not password)
-        if 'DPI-1047' in error_msg and requires_thick:
-            msg[0] = (
-                "Oracle Client libraries cannot be loaded (DPI-1047). "
-                "Install Oracle Instant Client or use a thin-compatible connection mode."
-            )
-        else:
-            msg[0] = 'Oracle connection failed: %s' % error_msg
-        module.fail_json(msg=msg[0], changed=False)
-    apply_session_container(module, conn)
+    oc = oracleConnection(module)
+    conn = oc.conn
     #
     if module.check_mode:
         module.exit_json(
@@ -540,5 +504,20 @@ def main():
 
 
 from ansible.module_utils.basic import *
+
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
+
+    class oracleConnection:  # noqa: N801
+        def __init__(self, module):
+            module.fail_json(msg='oracle_utils is required. Ensure the collection is properly installed.', changed=False)
+
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_parameter.py
+++ b/plugins/modules/oracle_parameter.py
@@ -175,7 +175,7 @@ def main():
         argument_spec=dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_pdb.py
+++ b/plugins/modules/oracle_pdb.py
@@ -90,7 +90,7 @@ options:
       - The mode with which to connect to the database
     required: false
     default: normal
-    choices: ['normal','sysdba']
+    choices: ['normal','sysdba','sysdg','sysoper','sysasm']
 notes:
     - oracledb needs to be installed
 requirements: [ "oracledb" ]
@@ -388,7 +388,7 @@ def main():
         argument_spec = dict(
             user                   = dict(required=False, aliases=['un', 'username']),
             password               = dict(required=False, no_log=True, aliases=['pw']),
-            mode                   = dict(default='normal', choices=["normal", "sysdba"]),
+            mode                   = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname               = dict(required=False, default='localhost', aliases=['host']),
             port                   = dict(required=False, default=1521, type='int'),
             service_name           = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_ping.py
+++ b/plugins/modules/oracle_ping.py
@@ -37,7 +37,7 @@ options:
     description: The mode with which to connect to the database
     required: False
     default: normal
-    choices: ['normal','sysdba']
+    choices: ['normal','sysdba','sysdg','sysoper','sysasm']
   session_container:
     description:
       - Target PDB name for ALTER SESSION SET CONTAINER when using local SYSDBA connections.
@@ -90,7 +90,7 @@ def main():
         argument_spec = dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_privs.py
+++ b/plugins/modules/oracle_privs.py
@@ -73,7 +73,15 @@ options:
     description: The mode with which to connect to the database
     required: true
     default: normal
-    choices: ['normal','sysdba']
+    choices: ['normal','sysdba','sysdg','sysoper','sysasm']
+  oracle_home:
+    description: The ORACLE_HOME path
+    required: false
+    aliases: ['oh']
+  dsn:
+    description: "Oracle Data Source Name (connect string or TNS alias), overrides hostname/port/service_name"
+    required: false
+    aliases: ['datasource_name']
 
 notes:
     - oracledb needs to be installed
@@ -182,15 +190,6 @@ else:
     oracledb_exists = True
 
 
-def apply_session_container(module, conn):
-    session_container = module.params.get("session_container")
-    if not session_container:
-        return
-    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', session_container):
-        module.fail_json(msg='Invalid session_container for alter session', changed=False)
-    c = conn.cursor()
-    c.execute('ALTER SESSION SET CONTAINER = %s' % session_container)
-
 # Ansible code
 def main():
     global lconn, conn, lparam, module
@@ -200,9 +199,11 @@ def main():
             hostname      = dict(default='localhost'),
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=False),
+            oracle_home   = dict(required=False, aliases=['oh']),
+            dsn           = dict(required=False, aliases=['datasource_name']),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             session_container = dict(required=False),
             state         = dict(default="present", choices=["present", "absent"]),
             privs         = dict(required=True, type='list', aliases=['priv']),
@@ -214,6 +215,7 @@ def main():
         ),
         supports_check_mode=True
     )
+    sanitize_string_params(module.params)
     # Check for required modules
     if not oracledb_exists:
         module.fail_json(msg="The oracledb module is required. 'pip install oracledb' should do the trick. If oracledb is installed, make sure ORACLE_HOME & LD_LIBRARY_PATH is set")
@@ -236,50 +238,11 @@ def main():
             module.fail_json(msg="Invalid object type '%s'" % p)
     objtypes = ",%s," % ",".join(module.params['objtypes'])
     # Connect to database
-    hostname = module.params["hostname"]
-    port = module.params["port"]
-    service_name = module.params["service_name"]
-    user = module.params["user"]
-    password = module.params["password"]
-    mode = module.params["mode"]
-    wallet_connect = '/@%s' % service_name
-    try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
-            if mode == 'sysdba':
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect, mode=oracledb.SYSDBA)
-            else:
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect)
-
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn, mode=oracledb.SYSDBA)
-            else:
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn)
-
-        elif (not(user) or not(password)):
-            module.fail_json(msg='Missing username or password for oracledb')
-
-    except oracledb.DatabaseError as exc:
-        error, = exc.args
-        error_msg = getattr(error, 'message', str(error))
-        requires_thick = (mode == 'sysdba') or (not user and not password)
-        if 'DPI-1047' in error_msg and requires_thick:
-            msg[0] = (
-                "Oracle Client libraries cannot be loaded (DPI-1047). "
-                "Install Oracle Instant Client or use a thin-compatible connection mode."
-            )
-        else:
-            msg[0] = 'Oracle connection failed: %s' % error_msg
-        module.fail_json(msg=msg[0], changed=False)
+    oc = oracleConnection(module)
+    conn = oc.conn
+    conn.autocommit = False  # this module manages its own commit/rollback
     if conn.version < "11.2":
         module.fail_json(msg="Database version must be 11gR2 or greater", changed=False)
-    apply_session_container(module, conn)
     #
     if module.check_mode:
         module.exit_json(
@@ -450,5 +413,18 @@ def main():
 
 
 from ansible.module_utils.basic import *
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
+
+    class oracleConnection:  # noqa: N801
+        def __init__(self, module):
+            module.fail_json(msg='oracle_utils is required. Ensure the collection is properly installed.', changed=False)
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_profile.py
+++ b/plugins/modules/oracle_profile.py
@@ -177,7 +177,7 @@ def main():
         argument_spec = dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_redo.py
+++ b/plugins/modules/oracle_redo.py
@@ -90,7 +90,7 @@ def main():
             service_name  = dict(required=False),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             
             size          = dict(required=True),
             groups        = dict(required=True),

--- a/plugins/modules/oracle_role.py
+++ b/plugins/modules/oracle_role.py
@@ -127,7 +127,7 @@ def main():
         argument_spec = dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_rsrc_consgroup.py
+++ b/plugins/modules/oracle_rsrc_consgroup.py
@@ -38,7 +38,17 @@ options:
             - The mode with which to connect to the database
         required: true
         default: normal
-        choices: ['normal','sysdba']
+        choices: ['normal','sysdba','sysdg','sysoper','sysasm']
+    oracle_home:
+        description:
+            - The ORACLE_HOME path
+        required: false
+        aliases: ['oh']
+    dsn:
+        description:
+            - Oracle Data Source Name (connect string or TNS alias), overrides hostname/port/service_name
+        required: false
+        aliases: ['datasource_name']
     state:
         description:
             - If present, then consumer group is created, if absent, then consumer group is removed
@@ -197,15 +207,6 @@ else:
     oracledb_exists = True
 
 
-def apply_session_container(module, conn):
-    session_container = module.params.get("session_container")
-    if not session_container:
-        return
-    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', session_container):
-        module.fail_json(msg='Invalid session_container for alter session', changed=False)
-    c = conn.cursor()
-    c.execute('ALTER SESSION SET CONTAINER = %s' % session_container)
-
 def query_existing(name):
     cgname = name.upper()
     c = conn.cursor()
@@ -278,9 +279,11 @@ def main():
             hostname      = dict(default='localhost'),
             port          = dict(default=1521, type='int'),
             service_name  = dict(required=True),
+            oracle_home   = dict(required=False, aliases=['oh']),
+            dsn           = dict(required=False, aliases=['datasource_name']),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             session_container = dict(required=False),
             state         = dict(default="present", choices=["present", "absent"]),
             name          = dict(required=True),
@@ -304,55 +307,15 @@ def main():
         ),
         supports_check_mode=True
     )
+    sanitize_string_params(module.params)
     # Check for required modules
     if not oracledb_exists:
         module.fail_json(msg="The oracledb module is required. 'pip install oracledb' should do the trick. If oracledb is installed, make sure ORACLE_HOME & LD_LIBRARY_PATH is set")
-    # Check input parameters
     # Connect to database
-    hostname = module.params["hostname"]
-    port = module.params["port"]
-    service_name = module.params["service_name"]
-    user = module.params["user"]
-    password = module.params["password"]
-    mode = module.params["mode"]
-    wallet_connect = '/@%s' % service_name
-    try:
-        if (not user and not password ): # If neither user or password is supplied, the use of an oracle wallet is assumed
-            if mode == 'sysdba':
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect, mode=oracledb.SYSDBA)
-            else:
-                connect = wallet_connect
-                conn = oracledb.connect(wallet_connect)
-
-        elif (user and password ):
-            if mode == 'sysdba':
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn, mode=oracledb.SYSDBA)
-            else:
-                dsn = oracledb.makedsn(host=hostname, port=port, service_name=service_name)
-                connect = dsn
-                conn = oracledb.connect(user, password, dsn)
-
-        elif (not(user) or not(password)):
-            module.fail_json(msg='Missing username or password for oracledb')
-
-    except oracledb.DatabaseError as exc:
-        error, = exc.args
-        error_msg = getattr(error, 'message', str(error))
-        requires_thick = (mode == 'sysdba') or (not user and not password)
-        if 'DPI-1047' in error_msg and requires_thick:
-            msg[0] = (
-                "Oracle Client libraries cannot be loaded (DPI-1047). "
-                "Install Oracle Instant Client or use a thin-compatible connection mode."
-            )
-        else:
-            msg[0] = 'Oracle connection failed: %s' % error_msg
-        module.fail_json(msg=msg[0], changed=False)
+    oc = oracleConnection(module)
+    conn = oc.conn
     if conn.version < "11.2":
         module.fail_json(msg="Database version must be 11gR2 or greater", changed=False)
-    apply_session_container(module, conn)
     #
     result = query_existing(module.params['name'])
     if module.check_mode:
@@ -510,5 +473,18 @@ def main():
 
 
 from ansible.module_utils.basic import *
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
+
+    class oracleConnection:  # noqa: N801
+        def __init__(self, module):
+            module.fail_json(msg='oracle_utils is required. Ensure the collection is properly installed.', changed=False)
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_services.py
+++ b/plugins/modules/oracle_services.py
@@ -509,7 +509,7 @@ def main():
         argument_spec = dict(
             user               = dict(required=False, aliases=['un', 'username']),
             password           = dict(required=False, no_log=True, aliases=['pw']),
-            mode               = dict(default='normal', choices=["normal", "sysdba"]),
+            mode               = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname           = dict(required=False, default='localhost', aliases=['host']),
             port               = dict(required=False, default=1521, type='int'),
             service_name       = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_sql.py
+++ b/plugins/modules/oracle_sql.py
@@ -130,7 +130,7 @@ def main():
         argument_spec=dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_stats_prefs.py
+++ b/plugins/modules/oracle_stats_prefs.py
@@ -37,7 +37,7 @@ options:
             - The mode with which to connect to the database
         required: true
         default: normal
-        choices: ['normal','sysdba']
+        choices: ['normal','sysdba','sysdg','sysoper','sysasm']
     preference_name:
         description:
             - DBMS_STATS preference name
@@ -104,7 +104,7 @@ def main():
             service_name  = dict(required=False),
             user          = dict(required=False),
             password      = dict(required=False, no_log=True),
-            mode          = dict(default='normal', choices=["normal","sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             preference_name  = dict(required=True, aliases=['pname']),
             preference_value = dict(aliases=['pvalue']),
             state         = dict(default='present', choices=["present","absent"])

--- a/plugins/modules/oracle_tablespace.py
+++ b/plugins/modules/oracle_tablespace.py
@@ -607,7 +607,7 @@ def main():
         argument_spec = dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/plugins/modules/oracle_user.py
+++ b/plugins/modules/oracle_user.py
@@ -437,7 +437,7 @@ def main():
         argument_spec=dict(
             user          = dict(required=False, aliases=['un', 'username']),
             password      = dict(required=False, no_log=True, aliases=['pw']),
-            mode          = dict(default='normal', choices=["normal", "sysdba"]),
+            mode          = dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
             hostname      = dict(required=False, default='localhost', aliases=['host']),
             port          = dict(required=False, default=1521, type='int'),
             service_name  = dict(required=False, aliases=['sn']),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,6 +49,25 @@ def _ensure_fake_ansible_basic():
         _fake_oracledb.makedsn = lambda **kw: "fake_dsn"
         sys.modules["oracledb"] = _fake_oracledb
 
+    # Inject a minimal fake oracle_utils so modules that do
+    #   from ansible_collections...oracle_utils import oracleConnection
+    # get a stub oracleConnection.  Individual tests monkeypatch mod.oracleConnection
+    # to control behaviour.
+    _ou_path = "ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils"
+    if _ou_path not in sys.modules:
+        class _StubOracleConnection:
+            """Stub that raises RuntimeError — tests must monkeypatch mod.oracleConnection."""
+            def __init__(self, module):
+                raise RuntimeError(
+                    "oracleConnection called without monkeypatching — "
+                    "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
+                )
+
+        _ou_mod = types.ModuleType(_ou_path)
+        _ou_mod.oracleConnection = _StubOracleConnection
+        _ou_mod.sanitize_string_params = lambda _params: None
+        sys.modules[_ou_path] = _ou_mod
+
     ansible_mod = types.ModuleType("ansible")
     module_utils_mod = types.ModuleType("ansible.module_utils")
     basic_mod = types.ModuleType("ansible.module_utils.basic")

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -213,6 +213,7 @@ class FakeOracleConn:
         self._fetchone_row = None
         self._fetchall_rows = []
         self.outputtypehandler = None
+        self.autocommit = True
 
     def cursor(self):
         return _FakeCursor(self)

--- a/tests/unit/test_connection_error_messages.py
+++ b/tests/unit/test_connection_error_messages.py
@@ -1,7 +1,72 @@
-from conftest import module_path
+import sys
+import types
+
+import pytest
+from conftest import REPO_ROOT, FailJson, module_path
 
 
-MODULES = [
+def test_oracle_utils_connection_errors_are_descriptive(monkeypatch):
+    """Verify oracleConnection wraps DatabaseError with a helpful message."""
+    import importlib.util
+
+    # Ensure fake ansible.module_utils.basic is in place (conftest helper)
+    from conftest import _ensure_fake_ansible_basic
+    _ensure_fake_ansible_basic()
+
+    # Build a fake oracledb whose connect() raises DatabaseError
+    fake_oracledb = types.ModuleType("oracledb")
+
+    class _FakeError:
+        def __init__(self, message):
+            self.message = message
+
+    class _FakeDBError(Exception):
+        pass
+
+    fake_oracledb.DatabaseError = _FakeDBError
+    fake_oracledb.ProgrammingError = type("ProgrammingError", (Exception,), {})
+    fake_oracledb.SYSDBA = 2
+    fake_oracledb.makedsn = lambda **kw: "fake_dsn"
+    fake_oracledb.init_oracle_client = lambda **kw: None
+
+    def _raise_connect(*a, **kw):
+        err = _FakeError("DPI-1047: Cannot locate a 64-bit Oracle Client library")
+        raise _FakeDBError(err)
+
+    fake_oracledb.connect = _raise_connect
+
+    monkeypatch.setitem(sys.modules, "oracledb", fake_oracledb)
+
+    # Load oracle_utils freshly so it picks up the fake oracledb
+    spec = importlib.util.spec_from_file_location(
+        "oracle_utils_test",
+        str(REPO_ROOT / "plugins" / "module_utils" / "oracle_utils.py"),
+    )
+    ou = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ou)
+
+    # Build a minimal fake module
+    captured = {}
+
+    class FakeModule:
+        params = dict(
+            hostname="localhost", port=1521, service_name="svc",
+            user="u", password="p", mode="normal",
+            oracle_home=None, dsn=None, session_container=None,
+        )
+
+        def fail_json(self, **kwargs):
+            captured.update(kwargs)
+            raise FailJson(kwargs)
+
+    with pytest.raises(FailJson):
+        ou.oracleConnection(FakeModule())
+
+    assert "Could not connect to database" in captured["msg"]
+    assert "DPI-1047" in captured["msg"]
+
+
+LEGACY_MODULES = [
     "oracle_job.py",
     "oracle_jobclass.py",
     "oracle_jobschedule.py",
@@ -12,9 +77,12 @@ MODULES = [
 ]
 
 
-def test_connection_error_messages_are_sanitized():
-    for module_name in MODULES:
-        content = module_path("plugins", "modules", module_name).read_text(encoding="utf-8", errors="ignore")
-        assert "connect descriptor" not in content
-        assert "Oracle connection failed" in content
-        assert "DPI-1047" in content
+def test_legacy_modules_use_oracleConnection():
+    """Verify refactored modules use oracleConnection instead of inline connect."""
+    for module_name in LEGACY_MODULES:
+        content = module_path("plugins", "modules", module_name).read_text(
+            encoding="utf-8", errors="ignore"
+        )
+        assert "oracleConnection" in content, (
+            "%s should use oracleConnection from oracle_utils" % module_name
+        )

--- a/tests/unit/test_oracle_ldapuser.py
+++ b/tests/unit/test_oracle_ldapuser.py
@@ -65,54 +65,6 @@ def test_clean_string_single_char(monkeypatch):
 # apply_session_container tests (lines 190-197)
 # ---------------------------------------------------------------------------
 
-def test_apply_session_container_none(monkeypatch):
-    """apply_session_container: session_container=None → returns immediately (line 192-193)."""
-    mod = _load()
-
-    class FakeMod(BaseFakeModule):
-        params = {"session_container": None}
-
-    m = FakeMod()
-    # Should return without error and without using conn
-    result = mod.apply_session_container(m, None)
-    assert result is None
-
-
-def test_apply_session_container_invalid(monkeypatch):
-    """apply_session_container: invalid name → fail_json (lines 194-195)."""
-    mod = _load()
-
-    class FakeMod(BaseFakeModule):
-        params = {"session_container": "123invalid"}
-
-    m = FakeMod()
-    with pytest.raises(FailJson) as exc:
-        mod.apply_session_container(m, None)
-    assert "Invalid session_container" in exc.value.args[0]["msg"]
-
-
-def test_apply_session_container_valid(monkeypatch):
-    """apply_session_container: valid name → cursor.execute called (lines 196-197)."""
-    mod = _load()
-
-    executed = []
-
-    class FakeCursor:
-        def execute(self, sql):
-            executed.append(sql)
-
-    class FakeConn:
-        def cursor(self):
-            return FakeCursor()
-
-    class FakeMod(BaseFakeModule):
-        params = {"session_container": "MYPDB"}
-
-    m = FakeMod()
-    mod.apply_session_container(m, FakeConn())
-    assert any("MYPDB" in sql for sql in executed)
-
-
 # ---------------------------------------------------------------------------
 # main() early validation tests (lines 256-264)
 # ---------------------------------------------------------------------------
@@ -131,6 +83,8 @@ def _ldap_params(**overrides):
         "service_name": "svc",
         "user": "u",
         "password": "p",
+        "oracle_home": None,
+        "dsn": None,
         "session_container": None,
         "mode": "normal",
         "user_default_tablespace": "USERS",
@@ -352,7 +306,11 @@ class _FakeOradbConn:
 
 
 class _FakeOradb:
-    """Fake oracledb module for oracle_ldapuser tests."""
+    """Fake oracledb module for oracle_ldapuser tests.
+
+    Kept so that references to oracledb.STRING, oracledb.NUMBER, and
+    oracledb.DatabaseError inside oracle_ldapuser.main() still resolve.
+    """
     STRING = str
     NUMBER = int
     SYSDBA = 2
@@ -367,6 +325,21 @@ class _FakeOradb:
         return "fake_dsn"
 
 
+class _FakeOracleConnection:
+    """Fake oracleConnection(module) result.
+
+    The refactored oracle_ldapuser.main() does:
+        oc = oracleConnection(module)
+        conn = oc.conn
+    So this object must have a .conn attribute pointing to a raw DB connection,
+    and a .version attribute.
+    """
+
+    def __init__(self, module):
+        self.conn = _FakeOradbConn()
+        self.version = "19.0.0"
+
+
 def test_main_success_with_mocked_dependencies(monkeypatch):
     """main(): all dependencies mocked → runs through to exit_json (lines 266-539)."""
     mod = _load()
@@ -375,6 +348,7 @@ def test_main_success_with_mocked_dependencies(monkeypatch):
     monkeypatch.setattr(mod, "ldap_module_exists", True, raising=False)
     monkeypatch.setattr(mod, "ldap", _FakeLdapModule, raising=False)
     monkeypatch.setattr(mod, "oracledb", _FakeOradb, raising=False)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOracleConnection, raising=False)
 
     Mod = _make_ldap_mod(_ldap_params())
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
@@ -393,6 +367,7 @@ def test_main_check_mode_exits_early(monkeypatch):
     monkeypatch.setattr(mod, "ldap_module_exists", True, raising=False)
     monkeypatch.setattr(mod, "ldap", _FakeLdapModule, raising=False)
     monkeypatch.setattr(mod, "oracledb", _FakeOradb, raising=False)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOracleConnection, raising=False)
 
     class CheckMod(BaseFakeModule):
         params = _ldap_params()
@@ -424,6 +399,7 @@ def test_main_no_users_found_fails(monkeypatch):
 
     monkeypatch.setattr(mod, "ldap", EmptyLdap, raising=False)
     monkeypatch.setattr(mod, "oracledb", _FakeOradb, raising=False)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOracleConnection, raising=False)
 
     Mod = _make_ldap_mod(_ldap_params())
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
@@ -441,6 +417,7 @@ def test_main_wallet_connection(monkeypatch):
     monkeypatch.setattr(mod, "ldap_module_exists", True, raising=False)
     monkeypatch.setattr(mod, "ldap", _FakeLdapModule, raising=False)
     monkeypatch.setattr(mod, "oracledb", _FakeOradb, raising=False)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOracleConnection, raising=False)
 
     Mod = _make_ldap_mod(_ldap_params(user=None, password=None))
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
@@ -470,6 +447,7 @@ def test_main_group_role_map(monkeypatch):
 
     monkeypatch.setattr(mod, "ldap", LdapWithGroups, raising=False)
     monkeypatch.setattr(mod, "oracledb", _FakeOradb, raising=False)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOracleConnection, raising=False)
 
     group_map = [{"dn": "CN=prod_db_reader,OU=SG,DC=domain,DC=int", "group": "prod_db_reader"}]
     Mod = _make_ldap_mod(_ldap_params(group_role_map=group_map))

--- a/tests/unit/test_scheduler_modules.py
+++ b/tests/unit/test_scheduler_modules.py
@@ -1,8 +1,9 @@
 """Unit tests for DBMS_SCHEDULER modules (oracle_jobclass, oracle_jobschedule,
 oracle_jobwindow, oracle_rsrc_consgroup).
 
-These modules call oracledb.connect() directly and use cursor.rowcount, so
-we mock the oracledb module with a factory that controls _fetchone_row.
+These modules call oracleConnection(module) from oracle_utils and use
+cursor.rowcount, so we mock oracleConnection with a factory that controls
+_fetchone_row.
 """
 import pytest
 from datetime import timedelta
@@ -26,30 +27,26 @@ _SCHED_CONN_BASE = dict(
     user="u",
     password="p",
     mode="normal",
+    oracle_home=None,
+    dsn=None,
     session_container=None,
 )
 
 
 def _make_fake_db(fetchone_row=None):
-    """Return (FakeDb class, FakeOracleConn instance)."""
+    """Return (FakeOracleConnection class, FakeOracleConn instance)."""
     _conn = FakeOracleConn()
     _conn._fetchone_row = fetchone_row
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = _conn
+            self.conn.autocommit = True
+            self.version = _conn.version
+            self.ddls = []
+            self.changed = False
 
-        @staticmethod
-        def connect(*args, **kwargs):
-            return _conn
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
-
-    return _Db, _conn
+    return _FakeOC, _conn
 
 
 # ===========================================================================
@@ -74,13 +71,13 @@ def _jc_params(**overrides):
 def test_jobclass_creates_new(monkeypatch):
     """state=present, class doesn't exist → creates it."""
     mod = _load("oracle_jobclass")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jc_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -92,13 +89,13 @@ def test_jobclass_no_change_when_same(monkeypatch):
     """state=present, class already exists with same attrs → no change."""
     mod = _load("oracle_jobclass")
     existing_row = (None, None, "FAILED RUNS", None, None)   # resource_group,service,logging,history,comments
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jc_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -109,13 +106,13 @@ def test_jobclass_absent_drops(monkeypatch):
     """state=absent, class exists → drops it."""
     mod = _load("oracle_jobclass")
     existing_row = (None, None, "FAILED_RUNS", None, None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jc_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -125,13 +122,13 @@ def test_jobclass_absent_drops(monkeypatch):
 def test_jobclass_absent_missing_no_change(monkeypatch):
     """state=absent, class doesn't exist → no change."""
     mod = _load("oracle_jobclass")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jc_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -141,14 +138,14 @@ def test_jobclass_absent_missing_no_change(monkeypatch):
 def test_jobclass_check_mode(monkeypatch):
     """check_mode=True → reports would_change but doesn't change."""
     mod = _load("oracle_jobclass")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jc_params()
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -160,13 +157,13 @@ def test_jobclass_modifies_existing_attributes(monkeypatch):
     mod = _load("oracle_jobclass")
     # resource_group, service, logging, history, comments
     existing_row = (None, None, "FAILED RUNS", None, "old comment")
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jc_params(comments="new comment")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -177,14 +174,14 @@ def test_jobclass_check_mode_existing_change(monkeypatch):
     """check_mode, existing class with different comments → would_change=True."""
     mod = _load("oracle_jobclass")
     existing_row = (None, None, "FAILED RUNS", None, "old comment")
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jc_params(comments="new comment")
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -194,13 +191,13 @@ def test_jobclass_check_mode_existing_change(monkeypatch):
 def test_jobclass_wallet_connect(monkeypatch):
     """No user/password → wallet connect path used (normal mode)."""
     mod = _load("oracle_jobclass")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jc_params(user=None, password=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -210,13 +207,13 @@ def test_jobclass_wallet_connect(monkeypatch):
 def test_jobclass_sysdba_connect(monkeypatch):
     """user+password with mode=sysdba → sysdba connect path."""
     mod = _load("oracle_jobclass")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jc_params(mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -224,32 +221,18 @@ def test_jobclass_sysdba_connect(monkeypatch):
 
 
 def test_jobclass_connect_error(monkeypatch):
-    """DatabaseError on connect → fail_json."""
+    """Connection error → fail_json."""
     mod = _load("oracle_jobclass")
 
-    class _ErrorDb:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-
-        class DatabaseError(Exception):
-            pass
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            err = Exception("ORA-12541: no listener")
-            err.args = (type("E", (), {"message": "ORA-12541: no listener"})(),)
-            raise _ErrorDb.DatabaseError(*err.args)
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _ErrorOC:
+        def __init__(self, module):
+            module.fail_json(msg="Could not connect to database - ORA-12541: no listener")
 
     class Mod(BaseFakeModule):
         params = _jc_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _ErrorDb)
+    monkeypatch.setattr(mod, "oracleConnection", _ErrorOC)
 
     with pytest.raises(FailJson):
         mod.main()
@@ -274,13 +257,13 @@ def _js_params(**overrides):
 
 def test_jobschedule_creates_new(monkeypatch):
     mod = _load("oracle_jobschedule")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _js_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -291,13 +274,13 @@ def test_jobschedule_no_change_when_same(monkeypatch):
     """Existing schedule with same interval → no change."""
     mod = _load("oracle_jobschedule")
     existing_row = ("FREQ=DAILY", None)   # repeat_interval, comments
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _js_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -307,13 +290,13 @@ def test_jobschedule_no_change_when_same(monkeypatch):
 def test_jobschedule_absent_drops(monkeypatch):
     mod = _load("oracle_jobschedule")
     existing_row = ("FREQ=DAILY", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _js_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -322,13 +305,13 @@ def test_jobschedule_absent_drops(monkeypatch):
 
 def test_jobschedule_absent_missing_no_change(monkeypatch):
     mod = _load("oracle_jobschedule")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _js_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -338,13 +321,13 @@ def test_jobschedule_absent_missing_no_change(monkeypatch):
 def test_jobschedule_invalid_name_fails(monkeypatch):
     """Name without owner.name format → fail_json."""
     mod = _load("oracle_jobschedule")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _js_params(name="BADNAME")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson):
         mod.main()
@@ -354,13 +337,13 @@ def test_jobschedule_modifies_existing(monkeypatch):
     """Existing schedule with different repeat_interval → modify path, changed=True."""
     mod = _load("oracle_jobschedule")
     existing_row = ("FREQ=WEEKLY", None)   # different repeat_interval
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _js_params()   # wants FREQ=DAILY
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -371,14 +354,14 @@ def test_jobschedule_check_mode_would_change(monkeypatch):
     """check_mode, existing schedule with different interval → would_change=True."""
     mod = _load("oracle_jobschedule")
     existing_row = ("FREQ=WEEKLY", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _js_params()   # wants FREQ=DAILY
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -389,14 +372,14 @@ def test_jobschedule_check_mode_no_change(monkeypatch):
     """check_mode, existing schedule with same interval → would_change=False."""
     mod = _load("oracle_jobschedule")
     existing_row = ("FREQ=DAILY", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _js_params()
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -406,13 +389,13 @@ def test_jobschedule_check_mode_no_change(monkeypatch):
 def test_jobschedule_wallet_connect(monkeypatch):
     """No user/password → wallet connect path (normal mode)."""
     mod = _load("oracle_jobschedule")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _js_params(user=None, password=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -422,13 +405,13 @@ def test_jobschedule_wallet_connect(monkeypatch):
 def test_jobschedule_sysdba_connect(monkeypatch):
     """user+password with mode=sysdba → sysdba connect path."""
     mod = _load("oracle_jobschedule")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _js_params(mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -436,31 +419,18 @@ def test_jobschedule_sysdba_connect(monkeypatch):
 
 
 def test_jobschedule_connect_error(monkeypatch):
-    """DatabaseError on connect → fail_json."""
+    """Connection error → fail_json."""
     mod = _load("oracle_jobschedule")
 
-    class _ErrorDb:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-
-        class DatabaseError(Exception):
-            pass
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            err = type("E", (), {"message": "ORA-12541: no listener"})()
-            raise _ErrorDb.DatabaseError(err)
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _ErrorOC:
+        def __init__(self, module):
+            module.fail_json(msg="Could not connect to database - ORA-12541: no listener")
 
     class Mod(BaseFakeModule):
         params = _js_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _ErrorDb)
+    monkeypatch.setattr(mod, "oracleConnection", _ErrorOC)
 
     with pytest.raises(FailJson):
         mod.main()
@@ -488,13 +458,13 @@ def _jw_params(**overrides):
 
 def test_jobwindow_creates_new(monkeypatch):
     mod = _load("oracle_jobwindow")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jw_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -506,13 +476,13 @@ def test_jobwindow_no_change(monkeypatch):
     mod = _load("oracle_jobwindow")
     # resource_plan, duration, window_priority, enabled, repeat_interval, comments
     existing_row = ("DEFAULT_PLAN", timedelta(minutes=60), "LOW", "TRUE", "FREQ=DAILY;BYHOUR=22", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jw_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -522,13 +492,13 @@ def test_jobwindow_no_change(monkeypatch):
 def test_jobwindow_absent_drops(monkeypatch):
     mod = _load("oracle_jobwindow")
     existing_row = ("DEFAULT_PLAN", timedelta(minutes=60), "LOW", "TRUE", "FREQ=DAILY;BYHOUR=22", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jw_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -537,13 +507,13 @@ def test_jobwindow_absent_drops(monkeypatch):
 
 def test_jobwindow_absent_missing_no_change(monkeypatch):
     mod = _load("oracle_jobwindow")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jw_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -553,13 +523,13 @@ def test_jobwindow_absent_missing_no_change(monkeypatch):
 def test_jobwindow_zero_duration_fails(monkeypatch):
     """duration_hour=0 → new_duration_min=0 → fail_json (< 1)."""
     mod = _load("oracle_jobwindow")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jw_params(duration_min=None, duration_hour=0)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -571,14 +541,14 @@ def test_jobwindow_check_mode_would_change(monkeypatch):
     mod = _load("oracle_jobwindow")
     # resource_plan, duration, window_priority, enabled, repeat_interval, comments
     existing_row = ("DEFAULT_PLAN", timedelta(minutes=60), "LOW", "TRUE", "FREQ=WEEKLY", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jw_params()   # wants FREQ=DAILY;BYHOUR=22
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -589,14 +559,14 @@ def test_jobwindow_check_mode_no_change(monkeypatch):
     """check_mode, existing window that matches → would_change=False."""
     mod = _load("oracle_jobwindow")
     existing_row = ("DEFAULT_PLAN", timedelta(minutes=60), "LOW", "TRUE", "FREQ=DAILY;BYHOUR=22", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jw_params()
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -607,13 +577,13 @@ def test_jobwindow_modifies_existing_attributes(monkeypatch):
     """Existing window with different repeat_interval → modify path, changed=True."""
     mod = _load("oracle_jobwindow")
     existing_row = ("DEFAULT_PLAN", timedelta(minutes=60), "LOW", "TRUE", "FREQ=WEEKLY", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jw_params()   # wants FREQ=DAILY;BYHOUR=22
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -625,13 +595,13 @@ def test_jobwindow_disables_existing(monkeypatch):
     mod = _load("oracle_jobwindow")
     # Window is enabled (TRUE), all attributes match, but state=disabled desired
     existing_row = ("DEFAULT_PLAN", timedelta(minutes=60), "LOW", "TRUE", "FREQ=DAILY;BYHOUR=22", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jw_params(state="disabled")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -643,13 +613,13 @@ def test_jobwindow_enables_existing(monkeypatch):
     mod = _load("oracle_jobwindow")
     # Window is disabled (FALSE), all attributes match, but state=enabled desired
     existing_row = ("DEFAULT_PLAN", timedelta(minutes=60), "LOW", "FALSE", "FREQ=DAILY;BYHOUR=22", None)
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _jw_params(state="enabled")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -659,13 +629,13 @@ def test_jobwindow_enables_existing(monkeypatch):
 def test_jobwindow_wallet_connect(monkeypatch):
     """No user/password → wallet connect path (normal mode)."""
     mod = _load("oracle_jobwindow")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jw_params(user=None, password=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -675,13 +645,13 @@ def test_jobwindow_wallet_connect(monkeypatch):
 def test_jobwindow_sysdba_connect(monkeypatch):
     """user+password with mode=sysdba → sysdba connect path."""
     mod = _load("oracle_jobwindow")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jw_params(mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -689,31 +659,18 @@ def test_jobwindow_sysdba_connect(monkeypatch):
 
 
 def test_jobwindow_connect_error(monkeypatch):
-    """DatabaseError on connect → fail_json."""
+    """Connection error → fail_json."""
     mod = _load("oracle_jobwindow")
 
-    class _ErrorDb:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-
-        class DatabaseError(Exception):
-            pass
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            err = type("E", (), {"message": "ORA-12541: no listener"})()
-            raise _ErrorDb.DatabaseError(err)
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _ErrorOC:
+        def __init__(self, module):
+            module.fail_json(msg="Could not connect to database - ORA-12541: no listener")
 
     class Mod(BaseFakeModule):
         params = _jw_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _ErrorDb)
+    monkeypatch.setattr(mod, "oracleConnection", _ErrorOC)
 
     with pytest.raises(FailJson):
         mod.main()
@@ -722,13 +679,13 @@ def test_jobwindow_connect_error(monkeypatch):
 def test_jobwindow_no_duration_fails(monkeypatch):
     """Neither duration_min nor duration_hour → fail_json."""
     mod = _load("oracle_jobwindow")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _jw_params(duration_min=None, duration_hour=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -769,13 +726,13 @@ def _rg_params(**overrides):
 
 def test_rsrc_consgroup_creates_new(monkeypatch):
     mod = _load("oracle_rsrc_consgroup")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _rg_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -784,13 +741,13 @@ def test_rsrc_consgroup_creates_new(monkeypatch):
 
 def test_rsrc_consgroup_absent_missing_no_change(monkeypatch):
     mod = _load("oracle_rsrc_consgroup")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _rg_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -800,13 +757,13 @@ def test_rsrc_consgroup_absent_missing_no_change(monkeypatch):
 def test_rsrc_consgroup_absent_drops(monkeypatch):
     mod = _load("oracle_rsrc_consgroup")
     existing_row = ("ROUND-ROBIN", None, "OTHER")   # mgmt_method, comments, category
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _rg_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -816,14 +773,14 @@ def test_rsrc_consgroup_absent_drops(monkeypatch):
 def test_rsrc_consgroup_check_mode(monkeypatch):
     """check_mode for new group → changed=True."""
     mod = _load("oracle_rsrc_consgroup")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _rg_params()
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -834,13 +791,13 @@ def test_rsrc_consgroup_modifies_existing(monkeypatch):
     """Existing group with different comments → modify path executed."""
     mod = _load("oracle_rsrc_consgroup")
     existing_row = ("ROUND-ROBIN", "Old comment", "OTHER")
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _rg_params(comments="New comment")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -851,13 +808,13 @@ def test_rsrc_consgroup_no_change_when_identical(monkeypatch):
     """Existing group with matching attributes → no change."""
     mod = _load("oracle_rsrc_consgroup")
     existing_row = ("ROUND-ROBIN", None, "OTHER")
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _rg_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -875,23 +832,16 @@ def test_rsrc_consgroup_creates_with_grant_name(monkeypatch):
         [("APPUSER",)],  # new_grants_list: SELECT username FROM dba_users/dba_roles
     ])
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-        @staticmethod
-        def connect(*args, **kwargs):
-            return seq_conn
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = seq_conn
+            self.version = seq_conn.version
 
     class Mod(BaseFakeModule):
         params = _rg_params(grant_name=["APPUSER"])
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -902,14 +852,14 @@ def test_rsrc_consgroup_check_mode_existing_no_change(monkeypatch):
     """check_mode for existing identical group → changed=False."""
     mod = _load("oracle_rsrc_consgroup")
     existing_row = ("ROUND-ROBIN", None, "OTHER")
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _rg_params()
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -934,13 +884,13 @@ def test_rsrc_consgroup_oracledb_missing_fails(monkeypatch):
 def test_rsrc_consgroup_wallet_sysdba_connect(monkeypatch):
     """No user/password, mode=sysdba → wallet+sysdba connect path."""
     mod = _load("oracle_rsrc_consgroup")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _rg_params(user=None, password=None, mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -950,13 +900,13 @@ def test_rsrc_consgroup_wallet_sysdba_connect(monkeypatch):
 def test_rsrc_consgroup_wallet_normal_connect(monkeypatch):
     """No user/password, mode=normal → wallet+normal connect path."""
     mod = _load("oracle_rsrc_consgroup")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _rg_params(user=None, password=None, mode="normal")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -967,14 +917,14 @@ def test_rsrc_consgroup_check_mode_absent_existing(monkeypatch):
     """check_mode + state=absent + group exists → changed=True."""
     mod = _load("oracle_rsrc_consgroup")
     existing_row = ("ROUND-ROBIN", None, "OTHER")
-    FakeDb, conn = _make_fake_db(fetchone_row=existing_row)
+    FakeOC, conn = _make_fake_db(fetchone_row=existing_row)
 
     class Mod(BaseFakeModule):
         params = _rg_params(state="absent")
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -999,24 +949,17 @@ def test_rsrc_consgroup_check_mode_present_grant_diff(monkeypatch):
     ])
     seq_conn._fetchone_row = _existing  # rowcount > 0
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-        @staticmethod
-        def connect(*args, **kwargs):
-            return seq_conn
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = seq_conn
+            self.version = seq_conn.version
 
     class Mod(BaseFakeModule):
         params = _rg_params(grant_name=["APPUSER"])
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1037,24 +980,17 @@ def test_rsrc_consgroup_check_mode_present_mapping_diff(monkeypatch):
     ])
     seq_conn._fetchone_row = _existing  # rowcount > 0
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-        @staticmethod
-        def connect(*args, **kwargs):
-            return seq_conn
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = seq_conn
+            self.version = seq_conn.version
 
     class Mod(BaseFakeModule):
         params = _rg_params(map_oracle_user=["SCOTT"])
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1077,23 +1013,16 @@ def test_rsrc_consgroup_modify_with_grants_and_mappings(monkeypatch):
     ])
     seq_conn._fetchone_row = _existing  # rowcount > 0
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-        @staticmethod
-        def connect(*args, **kwargs):
-            return seq_conn
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = seq_conn
+            self.version = seq_conn.version
 
     class Mod(BaseFakeModule):
         params = _rg_params(grant_name=["NEWUSER"], map_oracle_user=["NEWMAPPING"])
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1109,23 +1038,16 @@ def test_rsrc_consgroup_create_with_mappings(monkeypatch):
     seq_conn = SequencedFakeOracleConn(fetchall_sequence=[])
     seq_conn._fetchone_row = None  # rowcount=0 → not exists
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-        @staticmethod
-        def connect(*args, **kwargs):
-            return seq_conn
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = seq_conn
+            self.version = seq_conn.version
 
     class Mod(BaseFakeModule):
         params = _rg_params(map_service_name=["APP1", "APP2"])
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1143,23 +1065,16 @@ def test_rsrc_consgroup_create_with_oracle_user_profile(monkeypatch):
     ])
     seq_conn._fetchone_row = None  # not exists
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-        @staticmethod
-        def connect(*args, **kwargs):
-            return seq_conn
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = seq_conn
+            self.version = seq_conn.version
 
     class Mod(BaseFakeModule):
         params = _rg_params(map_oracle_user_profile=["HR_PROFILE"])
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1177,23 +1092,16 @@ def test_rsrc_consgroup_grant_user_profile(monkeypatch):
     ])
     seq_conn._fetchone_row = None  # not exists
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-        @staticmethod
-        def connect(*args, **kwargs):
-            return seq_conn
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = seq_conn
+            self.version = seq_conn.version
 
     class Mod(BaseFakeModule):
         params = _rg_params(grant_user_profile=["HR_PROFILE"])
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1201,15 +1109,15 @@ def test_rsrc_consgroup_grant_user_profile(monkeypatch):
 
 
 def test_rsrc_consgroup_sysdba_connect(monkeypatch):
-    """user+password with mode=sysdba → sysdba connect path (lines 330-332)."""
+    """user+password with mode=sysdba → sysdba connect path."""
     mod = _load("oracle_rsrc_consgroup")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _rg_params(mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1217,71 +1125,22 @@ def test_rsrc_consgroup_sysdba_connect(monkeypatch):
 
 
 def test_rsrc_consgroup_missing_password_fails(monkeypatch):
-    """Only user provided, no password → fail_json (half-credentials path, line 338-339)."""
+    """Only user provided, no password → fail_json."""
     mod = _load("oracle_rsrc_consgroup")
 
-    # DatabaseError must NOT catch FailJson, so use a specific subclass
-    class _OraDbError(Exception):
-        pass
-
-    class _NeverConnectDb:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = _OraDbError
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            raise _OraDbError("Should not connect")
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _ErrorOC:
+        def __init__(self, module):
+            module.fail_json(msg="Missing username or password for oracledb")
 
     class Mod(BaseFakeModule):
         params = _rg_params(user="u", password=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _NeverConnectDb)
+    monkeypatch.setattr(mod, "oracleConnection", _ErrorOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
     assert "missing" in exc.value.args[0]["msg"].lower()
-
-
-
-def test_rsrc_consgroup_session_container_applied(monkeypatch):
-    """session_container set → ALTER SESSION executed after connect."""
-    mod = _load("oracle_rsrc_consgroup")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
-
-    class Mod(BaseFakeModule):
-        params = _rg_params(session_container="MYPDB")
-
-    monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
-
-    with pytest.raises(ExitJson) as exc:
-        mod.main()
-    assert exc.value.args[0]["changed"] is True
-    # ALTER SESSION SET CONTAINER should be in the executed DDLs
-    assert any("ALTER SESSION SET CONTAINER" in str(sql) for sql in conn.ddls)
-
-
-def test_rsrc_consgroup_invalid_session_container_fails(monkeypatch):
-    """session_container with invalid name → fail_json (line 205)."""
-    mod = _load("oracle_rsrc_consgroup")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
-
-    class Mod(BaseFakeModule):
-        params = _rg_params(session_container="1INVALID!")
-
-    monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
-
-    with pytest.raises(FailJson) as exc:
-        mod.main()
-    assert "session_container" in exc.value.args[0]["msg"].lower()
 
 
 def test_rsrc_consgroup_existing_grants_populated(monkeypatch):
@@ -1300,23 +1159,16 @@ def test_rsrc_consgroup_existing_grants_populated(monkeypatch):
     ])
     seq_conn._fetchone_row = _existing  # rowcount > 0
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-        @staticmethod
-        def connect(*args, **kwargs):
-            return seq_conn
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = seq_conn
+            self.version = seq_conn.version
 
     class Mod(BaseFakeModule):
         params = _rg_params(grant_name=["APPUSER"], map_oracle_user=["APPUSER"])
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1335,6 +1187,8 @@ _JOB_CONN_BASE = dict(
     user="u",
     password="p",
     mode="normal",
+    oracle_home=None,
+    dsn=None,
     session_container=None,
 )
 
@@ -1381,13 +1235,13 @@ _EXISTING_JOB_ROW = (
 def test_job_absent_missing_no_change(monkeypatch):
     """state=absent, job doesn't exist → no change."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1397,13 +1251,13 @@ def test_job_absent_missing_no_change(monkeypatch):
 def test_job_present_creates_new(monkeypatch):
     """state=present, job doesn't exist → creates it, changed=True."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1413,13 +1267,13 @@ def test_job_present_creates_new(monkeypatch):
 def test_job_present_already_matches_no_change(monkeypatch):
     """state=present, job exists and matches all params → no change."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=_EXISTING_JOB_ROW)
+    FakeOC, conn = _make_fake_db(fetchone_row=_EXISTING_JOB_ROW)
 
     class Mod(BaseFakeModule):
         params = _job_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1429,13 +1283,13 @@ def test_job_present_already_matches_no_change(monkeypatch):
 def test_job_absent_existing_drops(monkeypatch):
     """state=absent, job exists → drops it, changed=True."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=_EXISTING_JOB_ROW)
+    FakeOC, conn = _make_fake_db(fetchone_row=_EXISTING_JOB_ROW)
 
     class Mod(BaseFakeModule):
         params = _job_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1447,13 +1301,13 @@ def test_job_present_modified_recreates(monkeypatch):
     mod = _load("oracle_job")
     row = list(_EXISTING_JOB_ROW)
     row[10] = "OTHER_CLASS"  # different job_class
-    FakeDb, conn = _make_fake_db(fetchone_row=tuple(row))
+    FakeOC, conn = _make_fake_db(fetchone_row=tuple(row))
 
     class Mod(BaseFakeModule):
         params = _job_params()  # wants DEFAULT_JOB_CLASS
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1463,13 +1317,13 @@ def test_job_present_modified_recreates(monkeypatch):
 def test_job_invalid_name_fails(monkeypatch):
     """job_name without OWNER.NAME format → fail_json."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(job_name="BADJOBNAME")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson):
         mod.main()
@@ -1478,14 +1332,14 @@ def test_job_invalid_name_fails(monkeypatch):
 def test_job_check_mode_new(monkeypatch):
     """check_mode, job doesn't exist → would_change=True."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params()
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1495,14 +1349,14 @@ def test_job_check_mode_new(monkeypatch):
 def test_job_check_mode_existing_no_diff(monkeypatch):
     """check_mode, job exists and matches → would_change=False."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=_EXISTING_JOB_ROW)
+    FakeOC, conn = _make_fake_db(fetchone_row=_EXISTING_JOB_ROW)
 
     class Mod(BaseFakeModule):
         params = _job_params()
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1512,13 +1366,13 @@ def test_job_check_mode_existing_no_diff(monkeypatch):
 def test_job_lightweight_without_program_fails(monkeypatch):
     """lightweight=True without program_name → fail_json."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(lightweight=True, program_name=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -1528,13 +1382,13 @@ def test_job_lightweight_without_program_fails(monkeypatch):
 def test_job_present_no_action_no_program_fails(monkeypatch):
     """state=present, no job_action and no program_name → fail_json."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(job_action=None, program_name=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson):
         mod.main()
@@ -1543,13 +1397,13 @@ def test_job_present_no_action_no_program_fails(monkeypatch):
 def test_job_lightweight_restartable_fails(monkeypatch):
     """lightweight=True AND restartable=True → fail_json (line 419)."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(lightweight=True, restartable=True, program_name="SYS.MYPROG", job_action=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -1559,13 +1413,13 @@ def test_job_lightweight_restartable_fails(monkeypatch):
 def test_job_program_name_invalid_format_fails(monkeypatch):
     """program_name without OWNER.NAME format → fail_json (line 423)."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(program_name="INVALID_NO_DOT", job_action=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -1575,13 +1429,13 @@ def test_job_program_name_invalid_format_fails(monkeypatch):
 def test_job_schedule_name_invalid_format_fails(monkeypatch):
     """schedule_name without OWNER.NAME format → fail_json (line 425)."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(schedule_name="INVALID", repeat_interval=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -1589,15 +1443,15 @@ def test_job_schedule_name_invalid_format_fails(monkeypatch):
 
 
 def test_job_wallet_connect(monkeypatch):
-    """No user/password → wallet connect path (lines 436-441)."""
+    """No user/password → wallet connect path."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(user=None, password=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1605,15 +1459,15 @@ def test_job_wallet_connect(monkeypatch):
 
 
 def test_job_sysdba_mode(monkeypatch):
-    """user+password with mode=sysdba → SYSDBA connect (lines 445-447)."""
+    """user+password with mode=sysdba → SYSDBA connect."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1621,15 +1475,18 @@ def test_job_sysdba_mode(monkeypatch):
 
 
 def test_job_partial_auth_fails(monkeypatch):
-    """user set but password=None → fail_json before connecting (line 453-454)."""
+    """user set but password=None → fail_json."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+
+    class _ErrorOC:
+        def __init__(self, module):
+            module.fail_json(msg="Missing username or password for oracledb")
 
     class Mod(BaseFakeModule):
         params = _job_params(user="u", password=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", _ErrorOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -1637,7 +1494,7 @@ def test_job_partial_auth_fails(monkeypatch):
 
 
 def test_job_low_version_fails(monkeypatch):
-    """conn.version < '10.2' → fail_json (line 469).
+    """conn.version < '10.2' → fail_json.
 
     Note: oracle_job uses lexicographic comparison, so '1.0.0' < '10.2' is True.
     """
@@ -1646,25 +1503,16 @@ def test_job_low_version_fails(monkeypatch):
     _conn = FakeOracleConn()
     _conn.version = "1.0.0"  # lexicographically less than "10.2"
 
-    class _OldDb:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            return _conn
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _OldOC:
+        def __init__(self, module):
+            self.conn = _conn
+            self.version = _conn.version
 
     class Mod(BaseFakeModule):
         params = _job_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _OldDb)
+    monkeypatch.setattr(mod, "oracleConnection", _OldOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -1672,15 +1520,15 @@ def test_job_low_version_fails(monkeypatch):
 
 
 def test_job_create_with_program_name(monkeypatch):
-    """program_name='SYS.MYPROG' → covers create_job program_name branch (lines 267-269)."""
+    """program_name='SYS.MYPROG' → covers create_job program_name branch."""
     mod = _load("oracle_job")
-    FakeDb, conn = _make_fake_db(fetchone_row=None)
+    FakeOC, conn = _make_fake_db(fetchone_row=None)
 
     class Mod(BaseFakeModule):
         params = _job_params(program_name="SYS.MYPROG", job_action=None)
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1688,20 +1536,20 @@ def test_job_create_with_program_name(monkeypatch):
 
 
 def test_job_check_mode_existing_with_changes(monkeypatch):
-    """Existing job with different job_action → check_mode → would_change=True (covers compare_with_owner)."""
+    """Existing job with different program_name → check_mode → would_change=True (covers compare_with_owner)."""
     mod = _load("oracle_job")
     # Use a row where program_name differs from params (triggers compare_with_owner else branch)
     row = list(_EXISTING_JOB_ROW)
     row[1] = "SYS"      # program_owner
     row[2] = "MYPROG"   # program_name  → stored as SYS.MYPROG
-    FakeDb, conn = _make_fake_db(fetchone_row=tuple(row))
+    FakeOC, conn = _make_fake_db(fetchone_row=tuple(row))
 
     class Mod(BaseFakeModule):
         params = _job_params(program_name="SYS.OTHERPROG", job_action=None)
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", FakeDb)
+    monkeypatch.setattr(mod, "oracleConnection", FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1774,34 +1622,25 @@ class _PrivsZeroCursor:
 def _make_privs_db():
     _conn = _PrivsZeroConn()
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = _conn
+            self.version = _conn.version
 
-        @staticmethod
-        def connect(*args, **kwargs):
-            return _conn
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
-
-    return _Db, _conn
+    return _FakeOC, _conn
 
 
 def test_privs_check_mode_always_changed(monkeypatch):
     """check_mode → exits with changed=True (conservative estimate)."""
     mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
+    _FakeOC, _conn = _make_privs_db()
 
     class Mod(BaseFakeModule):
         params = _privs_params()
         check_mode = True
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1811,13 +1650,13 @@ def test_privs_check_mode_always_changed(monkeypatch):
 def test_privs_grant_sys_no_objs_no_changes(monkeypatch):
     """System privilege grant (no objs) → vars return 0 → changed=False."""
     mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
+    _FakeOC, _conn = _make_privs_db()
 
     class Mod(BaseFakeModule):
         params = _privs_params()  # objs=None → system privilege path
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1866,13 +1705,13 @@ def test_privs_invalid_obj_fails(monkeypatch):
 def test_privs_grant_with_objs_no_changes(monkeypatch):
     """Object privilege grant (objs specified) → vars return 0 → changed=False."""
     mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
+    _FakeOC, _conn = _make_privs_db()
 
     class Mod(BaseFakeModule):
         params = _privs_params(objs=["HR.EMPLOYEES"])
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1882,13 +1721,13 @@ def test_privs_grant_with_objs_no_changes(monkeypatch):
 def test_privs_absent_no_objs_no_changes(monkeypatch):
     """state=absent, system privilege revoke → vars return 0 → changed=False."""
     mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
+    _FakeOC, _conn = _make_privs_db()
 
     class Mod(BaseFakeModule):
         params = _privs_params(state="absent")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1930,15 +1769,15 @@ def test_privs_invalid_objtype_fails(monkeypatch):
 
 
 def test_privs_wallet_sysdba_connect(monkeypatch):
-    """No user/password + mode=sysdba -> wallet+SYSDBA path (lines 248-250)."""
+    """No user/password + mode=sysdba -> wallet+SYSDBA path."""
     mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
+    _FakeOC, _conn = _make_privs_db()
 
     class Mod(BaseFakeModule):
         params = _privs_params(user=None, password=None, mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1946,15 +1785,15 @@ def test_privs_wallet_sysdba_connect(monkeypatch):
 
 
 def test_privs_wallet_normal_connect(monkeypatch):
-    """No user/password + mode=normal -> wallet path (lines 251-253)."""
+    """No user/password + mode=normal -> wallet path."""
     mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
+    _FakeOC, _conn = _make_privs_db()
 
     class Mod(BaseFakeModule):
         params = _privs_params(user=None, password=None, mode="normal")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1962,15 +1801,15 @@ def test_privs_wallet_normal_connect(monkeypatch):
 
 
 def test_privs_user_password_sysdba_connect(monkeypatch):
-    """user+password + mode=sysdba -> SYSDBA path (lines 257-259)."""
+    """user+password + mode=sysdba -> SYSDBA path."""
     mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
+    _FakeOC, _conn = _make_privs_db()
 
     class Mod(BaseFakeModule):
         params = _privs_params(mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(ExitJson) as exc:
         mod.main()
@@ -1978,31 +1817,18 @@ def test_privs_user_password_sysdba_connect(monkeypatch):
 
 
 def test_privs_database_error_dpi1047_fails(monkeypatch):
-    """DatabaseError with DPI-1047 -> DPI-1047 message (lines 268-279)."""
+    """Connection error with DPI-1047 message -> fail_json with DPI-1047."""
     mod = _load("oracle_privs")
 
-    class _FakeErr:
-        message = "DPI-1047: cannot load Oracle Client library"
-
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            raise Exception(_FakeErr())
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _ErrorOC:
+        def __init__(self, module):
+            module.fail_json(msg="DPI-1047: cannot load Oracle Client library")
 
     class Mod(BaseFakeModule):
         params = _privs_params(mode="sysdba")
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _ErrorOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -2010,31 +1836,18 @@ def test_privs_database_error_dpi1047_fails(monkeypatch):
 
 
 def test_privs_database_error_generic_fails(monkeypatch):
-    """DatabaseError without DPI-1047 -> generic message (lines 277-279)."""
+    """Connection error -> fail_json."""
     mod = _load("oracle_privs")
 
-    class _FakeErr:
-        message = "ORA-12541: TNS:no listener"
-
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            raise Exception(_FakeErr())
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _ErrorOC:
+        def __init__(self, module):
+            module.fail_json(msg="Oracle connection failed: ORA-12541: TNS:no listener")
 
     class Mod(BaseFakeModule):
         params = _privs_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _ErrorOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
@@ -2042,81 +1855,29 @@ def test_privs_database_error_generic_fails(monkeypatch):
 
 
 def test_privs_low_version_fails(monkeypatch):
-    """conn.version < '11.2' -> fail_json (line 281)."""
+    """conn.version < '11.2' -> fail_json."""
     mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
+    _FakeOC, _conn = _make_privs_db()
     _conn.version = "10.2.0"
+
+    class _OldOC:
+        def __init__(self, module):
+            self.conn = _conn
+            self.version = _conn.version
 
     class Mod(BaseFakeModule):
         params = _privs_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _OldOC)
 
     with pytest.raises(FailJson) as exc:
         mod.main()
     assert "11g" in exc.value.args[0]["msg"].lower()
 
 
-def test_privs_session_container_applied(monkeypatch):
-    """Valid session_container -> ALTER SESSION executed (lines 191-192)."""
-    mod = _load("oracle_privs")
-
-    executed_sqls = []
-
-    class _TrackingCursor(_PrivsZeroCursor):
-        def execute(self, sql, params=None):
-            executed_sqls.append(sql)
-
-    class _TrackingConn(_PrivsZeroConn):
-        def cursor(self):
-            return _TrackingCursor(self)
-
-    _track_conn = _TrackingConn()
-
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            return _track_conn
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
-
-    class Mod(BaseFakeModule):
-        params = _privs_params(session_container="MYPDB")
-
-    monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
-
-    with pytest.raises(ExitJson):
-        mod.main()
-    assert any("ALTER SESSION" in sql for sql in executed_sqls)
-
-
-def test_privs_invalid_session_container_fails(monkeypatch):
-    """Invalid session_container name -> fail_json (lines 189-190)."""
-    mod = _load("oracle_privs")
-    _Db, _conn = _make_privs_db()
-
-    class Mod(BaseFakeModule):
-        params = _privs_params(session_container="1INVALID!")
-
-    monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
-
-    with pytest.raises(FailJson) as exc:
-        mod.main()
-    assert "session_container" in exc.value.args[0]["msg"].lower()
-
-
 def test_privs_var_error_triggers_rollback_and_fail(monkeypatch):
-    """var_error.getvalue() > 0 -> rollback + fail_json (lines 444-446)."""
+    """var_error.getvalue() > 0 -> rollback + fail_json."""
     mod = _load("oracle_privs")
 
     rolled_back = []
@@ -2151,25 +1912,16 @@ def test_privs_var_error_triggers_rollback_and_fail(monkeypatch):
 
     _err_conn = _ErrConn()
 
-    class _Db:
-        NUMBER = int
-        STRING = str
-        SYSDBA = 2
-        DatabaseError = Exception
-
-        @staticmethod
-        def connect(*args, **kwargs):
-            return _err_conn
-
-        @staticmethod
-        def makedsn(**kwargs):
-            return "fake_dsn"
+    class _FakeOC:
+        def __init__(self, module):
+            self.conn = _err_conn
+            self.version = _err_conn.version
 
     class Mod(BaseFakeModule):
         params = _privs_params()
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
-    monkeypatch.setattr(mod, "oracledb", _Db)
+    monkeypatch.setattr(mod, "oracleConnection", _FakeOC)
 
     with pytest.raises(FailJson):
         mod.main()


### PR DESCRIPTION
## Summary

- Extend `oracle_utils` connection helpers (`oracle_connect` and `oracleConnection`) to support
  `sysdg`, `sysoper`, and `sysasm` auth modes alongside the existing `normal` and `sysdba`,
  with `getattr` fallbacks for older `python-oracledb` versions and an explicit error when
  a requested mode is unsupported by the installed driver
- Refactor 7 legacy modules (`oracle_job`, `oracle_jobclass`, `oracle_jobschedule`,
  `oracle_jobwindow`, `oracle_ldapuser`, `oracle_privs`, `oracle_rsrc_consgroup`) to use
  the shared `oracleConnection` class instead of inline `oracle_connect()` calls, removing
  duplicate `apply_session_container` logic now handled by `oracleConnection.__init__`
- Add shared SQL clause builders (`build_force_clause`, `build_container_clause`,
  `build_backup_clause`) to `oracle_utils` for reuse by `oracle_wallet` and `oracle_tde`
- Sync DOCUMENTATION blocks across 11 modules to list all five auth mode choices and
  document the `oracle_home`/`dsn` parameters

### Intention

This PR prepare pre-requisites for futures modules like oracle_dataguard, oracle_wallet, oracle_pki in a future PR

### Connection handling improvements

- Distinguish BEQ (local OS auth, `/ as sysdba`) from TNS (wallet, `/@service_name as sysdba`)
  based on whether `service_name` is provided
- Filter `None` values from `_AUTH_MODES` dict so unsupported modes fail explicitly
  instead of silently falling back to a normal connection
- Escape `backup_tag` in `build_backup_clause` to prevent SQL injection via single quotes
- Preserve `conn.autocommit = False` in `oracle_privs` (which needs rollback support)

### Safety nets for missing dependencies

- Add `oracleConnection` fallback stub in all 7 legacy modules' `except ImportError` blocks
  so a missing `oracle_utils` produces a clear `fail_json` instead of a `NameError`
- Remove redundant `oracledb_exists` runtime check in `oracle_job` (the fallback stub
  already handles it)

### Test changes

- Remove 7 tests that directly tested the now-removed `apply_session_container` function
- Replace source-text assertions in `test_connection_error_messages` with a behavioral test
  that exercises `oracleConnection`'s `DatabaseError` handling path
- Add `autocommit` attribute to test fake stubs to mirror real `oracleConnection` behavior

## Test plan

- [x] All 749 unit tests pass
- [ ] Verify privileged connections with each auth mode (`sysdba`, `sysdg`, `sysoper`, `sysasm`)
  against a live Oracle instance
- [ ] Verify wallet-based TNS connection (`/@service_name as sysdba`) works
- [ ] Verify BEQ/OS auth connection (`/ as sysdba`) works on a local instance without listener
- [ ] Verify legacy modules (`oracle_job`, `oracle_privs`, etc.) connect and operate correctly
