### PR TITLE
Fix/set container check mode

### DIFF
--- a/plugins/module_utils/oracle_utils.py
+++ b/plugins/module_utils/oracle_utils.py
@@ -404,7 +404,16 @@ class oracleConnection:
             return
         if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', pdb_name):
             self.module.fail_json(msg='Invalid pdb_name for alter session', changed=self.changed, ddls=self.ddls)
-        self.execute_ddl('ALTER SESSION SET CONTAINER = %s' % pdb_name, no_change=True)
+        # Execute directly instead of via execute_ddl so that the session
+        # container is switched even in check_mode — subsequent SELECT queries
+        # need to run against the correct PDB.
+        sql = 'ALTER SESSION SET CONTAINER = %s' % pdb_name
+        try:
+            with self.conn.cursor() as cursor:
+                cursor.execute(sql)
+        except oracledb.DatabaseError as e:
+            error = e.args[0]
+            self.module.fail_json(msg=error.message, code=error.code, ddls=self.ddls, changed=self.changed)
 
     def resolve_object_name(self, object_name):
         statement = """

--- a/tests/unit/test_oracle_utils.py
+++ b/tests/unit/test_oracle_utils.py
@@ -49,14 +49,29 @@ def test_set_container_rejects_invalid_name():
         raise AssertionError("set_container should fail on invalid pdb name")
 
 
+class _DummyCursor:
+    def execute(self, _sql, _params=None):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        pass
+
+
+class _DummyConn:
+    def cursor(self):
+        return _DummyCursor()
+
+
 def test_set_container_valid_does_not_mark_changed_in_check_mode():
     utils = load_module_from_path(module_path("plugins", "module_utils", "oracle_utils.py"), "oracle_utils_test_3")
     conn = _new_conn_instance(utils, check_mode=True)
+    conn.conn = _DummyConn()
 
     conn.set_container("PDB1")
 
     assert conn.changed is False
-    assert conn.ddls == ["--ALTER SESSION SET CONTAINER = PDB1"]
+    assert conn.ddls == []
 
 
 def test_execute_statement_check_mode_records_statement():


### PR DESCRIPTION
fix(oracle_utils): execute set_container directly to fix check_mode                                                                           
                                                                                                                                                
  set_container used execute_ddl which skips execution in check_mode,                                                                           
  causing ALTER SESSION SET CONTAINER to never run. This meant all                                                                              
  subsequent SELECT queries would execute against the CDB root instead                                                                          
  of the target PDB during dry runs, returning incorrect results.                                                                               
                                                                                                                                                
  Use direct cursor execution so the session container is always                                                                                
  switched, even in check_mode.                             