### PR TITLE
Add oracle_tde module for Transparent Data Encryption management 

### DIFF
--- a/plugins/module_utils/oracle_utils.py
+++ b/plugins/module_utils/oracle_utils.py
@@ -89,6 +89,11 @@ def _ensure_oracle_client(module, oracle_home=None, required=False):
 # ---------------------------------------------------------------------------
 
 def sql_single_quoted_literal(value):
+    """Escape *value* for use inside a single-quoted Oracle SQL string literal.
+
+    ``None`` yields ``''``. Other values are coerced with ``str()`` so callers
+    (e.g. unified audit condition text) stay compatible; single quotes are doubled.
+    """
     if value is None:
         return ''
     s = str(value)
@@ -119,15 +124,6 @@ def build_backup_clause(backup=True, backup_tag=None):
     if backup_tag:
         clause += " USING '%s'" % sql_single_quoted_literal(backup_tag)
     return clause
-
-
-def sql_single_quoted_literal(value):
-    """Double embedded single quotes for safe use inside Oracle '...' string literals."""
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise TypeError('sql_single_quoted_literal expects str or None')
-    return value.replace("'", "''")
 
 
 def sanitize_string_params(module_params):

--- a/plugins/module_utils/oracle_utils.py
+++ b/plugins/module_utils/oracle_utils.py
@@ -121,6 +121,15 @@ def build_backup_clause(backup=True, backup_tag=None):
     return clause
 
 
+def sql_single_quoted_literal(value):
+    """Double embedded single quotes for safe use inside Oracle '...' string literals."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError('sql_single_quoted_literal expects str or None')
+    return value.replace("'", "''")
+
+
 def sanitize_string_params(module_params):
     """Strip leading/trailing whitespace from every string value in module.params.
 

--- a/plugins/module_utils/oracle_utils.py
+++ b/plugins/module_utils/oracle_utils.py
@@ -126,14 +126,21 @@ def build_backup_clause(backup=True, backup_tag=None):
     return clause
 
 
-def sanitize_string_params(module_params):
+def sanitize_string_params(module_params, no_trim=None):
     """Strip leading/trailing whitespace from every string value in module.params.
 
     Mutates the dict in place so all downstream reads of module.params are
     automatically cleaned without changing any call site. Non-string values
     (None, int, bool, list, dict) are left untouched.
+
+    Keys listed in *no_trim* (a set or sequence) are skipped so that
+    passwords and secrets whose leading/trailing whitespace is significant
+    are not silently altered.
     """
+    skip = set(no_trim) if no_trim else set()
     for key, value in module_params.items():
+        if key in skip:
+            continue
         if isinstance(value, str):
             module_params[key] = value.strip()
 

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -490,10 +490,10 @@ def _validate_dgmgrl_identifier(module, value, param_name):
         module.fail_json(msg='Invalid %s: must be an Oracle identifier' % param_name, changed=False)
 
 
-def _quote_dgmgrl_literal(value):
+def _quote_dgmgrl_literal(module, value):
     """Escape single quotes and reject injection characters in a DGMGRL string literal."""
     if ';' in value or '\n' in value or '\r' in value:
-        raise ValueError("DGMGRL literal must not contain semicolons or newlines: %r" % value)
+        module.fail_json(msg="DGMGRL literal must not contain semicolons or newlines: %r" % value, changed=False)
     return value.replace("'", "''")
 
 
@@ -513,7 +513,7 @@ def dgmgrl_create_configuration(module):
     _validate_dgmgrl_identifier(module, primary_db, 'primary_database')
 
     cmd = "CREATE CONFIGURATION %s AS PRIMARY DATABASE IS %s CONNECT IDENTIFIER IS '%s'" % (
-        config_name, primary_db, _quote_dgmgrl_literal(connect_id)
+        config_name, primary_db, _quote_dgmgrl_literal(module, connect_id)
     )
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already exists' not in stdout.lower():
@@ -534,7 +534,7 @@ def dgmgrl_add_database(module):
 
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
 
-    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, _quote_dgmgrl_literal(connect_id))
+    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, _quote_dgmgrl_literal(module, connect_id))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already' not in stdout.lower():
         module.fail_json(msg='Failed to add database: %s %s' % (stdout, stderr), changed=False)
@@ -633,7 +633,7 @@ def dgmgrl_set_properties(module, db_name, properties):
     commands = []
     for prop, value in properties.items():
         _validate_dgmgrl_identifier(module, prop, 'property name')
-        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(str(value))))
+        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(module, str(value))))
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
         module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
@@ -661,7 +661,7 @@ def dgmgrl_set_protection_mode(module, protection_mode):
 def dgmgrl_set_state(module, db_name, db_state):
     """Set database transport/apply state."""
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
-    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(db_state.upper()))
+    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(module, db_state.upper()))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         module.fail_json(msg='Failed to set state: %s %s' % (stdout, stderr), changed=False)
@@ -709,7 +709,7 @@ def dgmgrl_add_far_sync(module):
 
     _validate_dgmgrl_identifier(module, fs_name, 'far_sync_name')
 
-    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, _quote_dgmgrl_literal(fs_connect))
+    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, _quote_dgmgrl_literal(module, fs_connect))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         if 'already' in stdout.lower():
@@ -732,7 +732,7 @@ def dgmgrl_validate(module, db_name):
 
 def _validate_dgmgrl_connect_string(module, value, param_name):
     """Validate a connect identifier is safe for DGMGRL (no injection)."""
-    if not value or ';' in value or '\n' in value:
+    if not value or ';' in value or '\n' in value or '\r' in value:
         module.fail_json(msg='Invalid %s: must not be empty or contain ; or newlines' % param_name, changed=False)
 
 
@@ -749,7 +749,7 @@ def dgmgrl_set_primary_database_candidates(module, candidates):
     for c in candidates:
         _validate_dgmgrl_identifier(module, c, 'primary_database_candidates member')
     value = ','.join(candidates)
-    cmd = "EDIT CONFIGURATION SET PROPERTY PrimaryDatabaseCandidates='%s'" % _quote_dgmgrl_literal(value)
+    cmd = "EDIT CONFIGURATION SET PROPERTY PrimaryDatabaseCandidates='%s'" % _quote_dgmgrl_literal(module, value)
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         if 'not supported' in stdout.lower() or 'invalid property' in stdout.lower():
@@ -789,10 +789,10 @@ def dgmgrl_set_tags(module, tags):
         _validate_dgmgrl_tag_name(module, tag_name)
         if target_name:
             cmd = "EDIT %s %s SET TAG %s='%s'" % (
-                target_type, target_name, tag_name, _quote_dgmgrl_literal(str(tag_value)))
+                target_type, target_name, tag_name, _quote_dgmgrl_literal(module, str(tag_value)))
         else:
             cmd = "EDIT %s SET TAG %s='%s'" % (
-                target_type, tag_name, _quote_dgmgrl_literal(str(tag_value)))
+                target_type, tag_name, _quote_dgmgrl_literal(module, str(tag_value)))
         commands.append(cmd)
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
@@ -830,7 +830,7 @@ def dgmgrl_show_tags(module, output_format):
         cmd = 'SHOW %s %s TAG' % (target_type, target_name)
     else:
         cmd = 'SHOW %s TAG' % target_type
-    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    rc, stdout, stderr = run_dgmgrl(module, [cmd], output_format)
     if rc != 0:
         return None
     return stdout

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -430,8 +430,7 @@ def parse_show_configuration(stdout):
             result['name'] = line.split('-', 1)[1].strip()
         elif line.startswith('Protection Mode:'):
             result['protection_mode'] = line.split(':', 1)[1].strip()
-        elif any(role in line for role in (
-                'Primary database', 'Physical standby', 'Snapshot standby', 'Logical standby')):
+        elif re.search(r'(?i)\b(primary|physical\s+standby|snapshot\s+standby|logical\s+standby)\b', line):
             parts = line.split('-')
             if len(parts) >= 2:
                 db_info = {
@@ -440,14 +439,12 @@ def parse_show_configuration(stdout):
                     'status': '',
                 }
                 desc = parts[1].strip()
-                if 'Primary' in desc:
-                    db_info['role'] = 'PRIMARY'
-                elif 'Physical standby' in desc:
-                    db_info['role'] = 'PHYSICAL STANDBY'
-                elif 'Snapshot standby' in desc:
-                    db_info['role'] = 'SNAPSHOT STANDBY'
-                elif 'Logical standby' in desc:
-                    db_info['role'] = 'LOGICAL STANDBY'
+                role_match = re.search(
+                    r'(?i)\b(physical\s+standby|snapshot\s+standby|logical\s+standby|primary)\b',
+                    desc,
+                )
+                if role_match:
+                    db_info['role'] = re.sub(r'\s+', ' ', role_match.group(1)).upper()
                 result['databases'].append(db_info)
         elif line.startswith('Fast-Start Failover:'):
             result['fast_start_failover'] = line.split(':', 1)[1].strip()
@@ -623,17 +620,24 @@ def dgmgrl_convert_database(module, db_name, target_type):
 
 
 def dgmgrl_set_properties(module, db_name, properties):
-    """Set properties on a database.
-
-    Returns True because DGMGRL does not report whether a value actually changed.
-    """
+    """Set properties on a database. Returns True only when a value changed."""
     if not db_name or not properties:
         return False
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
     commands = []
     for prop, value in properties.items():
         _validate_dgmgrl_identifier(module, prop, 'property name')
-        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(module, str(value))))
+        desired = str(value)
+        # Query current value to avoid unnecessary EDIT commands.
+        rc, stdout, _ = run_dgmgrl(module, ['SHOW DATABASE %s %s' % (db_name, prop)])
+        if rc == 0:
+            # DGMGRL output is typically "  <prop> = '<value>'" or similar.
+            m = re.search(r"=\s*'?([^'\n]*)'?", stdout)
+            if m and m.group(1).strip().upper() == desired.upper():
+                continue
+        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(module, desired)))
+    if not commands:
+        return False
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
         module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
@@ -641,7 +645,7 @@ def dgmgrl_set_properties(module, db_name, properties):
 
 
 def dgmgrl_set_protection_mode(module, protection_mode):
-    """Set the protection mode."""
+    """Set the protection mode. Returns True only when the mode changed."""
     mode_map = {
         'maximum_protection': 'MAXPROTECTION',
         'maximum_availability': 'MAXAVAILABILITY',
@@ -651,6 +655,13 @@ def dgmgrl_set_protection_mode(module, protection_mode):
     if not mode:
         module.fail_json(msg='Invalid protection mode: %s' % protection_mode, changed=False)
 
+    # Check current protection mode to avoid unnecessary changes.
+    rc, stdout, _ = run_dgmgrl(module, ['SHOW CONFIGURATION'])
+    if rc == 0:
+        m = re.search(r'(?i)protection\s+mode:\s*(\S+)', stdout)
+        if m and m.group(1).upper() == mode.upper():
+            return False
+
     cmd = 'EDIT CONFIGURATION SET PROTECTION MODE AS %s' % mode
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
@@ -659,9 +670,18 @@ def dgmgrl_set_protection_mode(module, protection_mode):
 
 
 def dgmgrl_set_state(module, db_name, db_state):
-    """Set database transport/apply state."""
+    """Set database transport/apply state. Returns True only when the state changed."""
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
-    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(module, db_state.upper()))
+    desired = db_state.upper()
+
+    # Check current state to avoid unnecessary changes.
+    rc, stdout, _ = run_dgmgrl(module, ['SHOW DATABASE %s StateName' % db_name])
+    if rc == 0:
+        m = re.search(r"=\s*'?([^'\n]*)'?", stdout)
+        if m and m.group(1).strip().upper() == desired:
+            return False
+
+    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(module, desired))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         module.fail_json(msg='Failed to set state: %s %s' % (stdout, stderr), changed=False)
@@ -830,7 +850,7 @@ def dgmgrl_show_tags(module, output_format):
         cmd = 'SHOW %s %s TAG' % (target_type, target_name)
     else:
         cmd = 'SHOW %s TAG' % target_type
-    rc, stdout, stderr = run_dgmgrl(module, [cmd], output_format)
+    rc, stdout, _ = run_dgmgrl(module, [cmd], output_format)
     if rc != 0:
         return None
     return stdout

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -1018,12 +1018,14 @@ def _run_broker_mode(module):
     database_name = module.params["database_name"]
     output_format = module.params["output_format"]
 
+    if state == 'status':
+        # Status is read-only, allow it even in check mode.
+        _broker_status(module, database_name, output_format)
+
     if module.check_mode:
         module.exit_json(changed=False, msg='Check mode: no broker operations executed')
 
-    if state == 'status':
-        _broker_status(module, database_name, output_format)
-    elif state == 'present':
+    if state == 'present':
         _broker_present(module, database_name, output_format)
     elif state == 'absent':
         _broker_absent(module, database_name)

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -1,0 +1,930 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: oracle_dataguard
+short_description: Manage Oracle Data Guard configurations
+description:
+  - Manage Oracle Data Guard via the Broker (DGMGRL) or via SQL direct
+  - Create, enable, disable, and remove Data Guard configurations
+  - Add, remove, enable, and disable standby databases
+  - Perform switchover and failover operations
+  - Convert databases between physical/snapshot standby
+  - Manage Data Guard properties
+  - Set protection modes (Maximum Protection, Maximum Availability, Maximum Performance)
+  - Manage Fast-Start Failover (FSFO) and observers
+  - Manage Far Sync instances
+  - Query Data Guard status, lag, and health
+  - SQL mode for environments without broker
+  - Compatible with Oracle 19c, 23ai, and 26ai
+  - "Oracle 26ai features: JSON output, PrimaryDatabaseCandidates, VALIDATE DGConnectIdentifier, tagging"
+version_added: "3.4.0"
+options:
+  mode_dg:
+    description:
+      - Data Guard management mode
+      - broker uses DGMGRL commands (recommended by Oracle)
+      - sql uses direct SQL and V$ views (for environments without broker)
+    default: broker
+    choices: ['broker', 'sql']
+  state:
+    description: The intended state
+    default: status
+    choices:
+      - present
+      - absent
+      - enabled
+      - disabled
+      - status
+      - switchover
+      - failover
+      - snapshot_standby
+      - physical_standby
+  oracle_home:
+    description: ORACLE_HOME path (required for DGMGRL in broker mode)
+    required: false
+    aliases: ['oh']
+  dgmgrl_user:
+    description:
+      - Username for DGMGRL connection
+      - If omitted (along with dgmgrl_password), OS authentication is used (/ AS SYSDG or / AS SYSDBA)
+    required: false
+  dgmgrl_password:
+    description:
+      - Password for DGMGRL connection
+      - If omitted (along with dgmgrl_user), OS authentication is used
+    required: false
+  dgmgrl_connect_identifier:
+    description: Connect identifier for DGMGRL (e.g. host:port/service)
+    required: false
+  dgmgrl_as:
+    description:
+      - DGMGRL connection privilege
+      - Used for both password and OS authentication
+    default: sysdg
+    choices: ['sysdba', 'sysdg']
+  configuration_name:
+    description: Name of the Data Guard broker configuration
+    required: false
+  primary_database:
+    description: DB_UNIQUE_NAME of the primary database
+    required: false
+  connect_identifier:
+    description: Oracle Net connect identifier for the database being managed
+    required: false
+  database_name:
+    description: DB_UNIQUE_NAME of the database to manage
+    required: false
+  properties:
+    description:
+      - Dictionary of broker properties to set on a database
+      - "Example: {'LogXptMode': 'SYNC', 'NetTimeout': '60'}"
+    type: dict
+    required: false
+  protection_mode:
+    description: Data Guard protection mode
+    choices: ['maximum_protection', 'maximum_availability', 'maximum_performance']
+    required: false
+  database_state:
+    description: Desired state of redo transport/apply for a database
+    choices: ['transport-on', 'transport-off', 'apply-on', 'apply-off']
+    required: false
+  fsfo:
+    description: Fast-Start Failover state
+    choices: ['enabled', 'disabled']
+    required: false
+  fsfo_target:
+    description: Target database for Fast-Start Failover
+    required: false
+  far_sync_name:
+    description: Name of the Far Sync instance
+    required: false
+  far_sync_connect_identifier:
+    description: Connect identifier for Far Sync instance
+    required: false
+  observer_state:
+    description: Observer state
+    choices: ['started', 'stopped']
+    required: false
+  output_format:
+    description:
+      - Output format for DGMGRL (26ai supports JSON)
+      - json provides structured output (Oracle 26ai+)
+    default: text
+    choices: ['text', 'json']
+  force_logging:
+    description: Enable or disable FORCE LOGGING (SQL mode)
+    choices: ['enable', 'disable']
+    required: false
+  apply_state:
+    description: Managed recovery state (SQL mode)
+    choices: ['started', 'stopped']
+    required: false
+notes:
+  - Broker mode requires DGMGRL binary in ORACLE_HOME/bin
+  - "Broker mode supports OS authentication (/ AS SYSDG or / AS SYSDBA) when dgmgrl_user and dgmgrl_password are omitted"
+  - "SQL mode supports OS authentication (mode: sysdba without user/password) when running as the oracle OS user"
+  - SQL mode uses standard oracledb connection
+  - Switchover and failover are non-idempotent operations - use with care
+  - oracledb Python module is required for SQL mode
+requirements: [ "oracledb" ]
+author:
+  - Cyrille Modiano
+'''
+
+EXAMPLES = '''
+# --- Broker Mode (default) ---
+
+# OS authentication (runs as oracle OS user, no username/password needed)
+- name: Get Data Guard status with OS authentication as SYSDG
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: status
+
+- name: Get Data Guard status with OS authentication as SYSDBA
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    dgmgrl_as: sysdba
+    state: status
+
+# Password authentication
+- name: Get Data Guard status with password authentication
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    dgmgrl_user: sys
+    dgmgrl_password: "SysPass123"
+    dgmgrl_as: sysdg
+    state: status
+
+- name: Create a Data Guard broker configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: present
+    configuration_name: my_dg_config
+    primary_database: PROD
+    connect_identifier: "prod-host:1521/PROD"
+
+- name: Add a standby database to the configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: present
+    database_name: STDBY
+    connect_identifier: "stdby-host:1521/STDBY"
+
+- name: Enable the configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: enabled
+
+- name: Set database properties
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    database_name: STDBY
+    properties:
+      LogXptMode: SYNC
+      NetTimeout: "60"
+      RedoCompression: ENABLE
+
+- name: Set protection mode to Maximum Availability
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    protection_mode: maximum_availability
+
+- name: Switchover to standby
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: switchover
+    database_name: STDBY
+
+- name: Failover to standby
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: failover
+    database_name: STDBY
+
+- name: Convert to snapshot standby
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: snapshot_standby
+    database_name: STDBY
+
+- name: Enable Fast-Start Failover
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    fsfo: enabled
+
+- name: Disable the configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: disabled
+
+- name: Remove a standby database
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: absent
+    database_name: STDBY
+
+- name: Remove entire configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: absent
+
+# --- SQL Mode ---
+
+# OS authentication (mode: sysdba, no user/password)
+- name: Get Data Guard status via SQL with OS authentication
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    state: status
+
+# Password authentication
+- name: Get Data Guard status via SQL with password
+  oracle_dataguard:
+    mode_dg: sql
+    user: sys
+    password: "SysPass123"
+    mode: sysdba
+    service_name: PROD
+    state: status
+
+- name: Start managed recovery (SQL mode)
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    apply_state: started
+
+- name: Stop managed recovery (SQL mode)
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    apply_state: stopped
+
+- name: Enable force logging (SQL mode)
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    force_logging: enable
+
+- name: Set protection mode via SQL
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    protection_mode: maximum_availability
+'''
+
+import json
+import os
+
+
+# ============================================================================
+# DGMGRL (Broker) Functions
+# ============================================================================
+
+def run_dgmgrl(module, commands, output_format='text'):
+    """Execute DGMGRL commands and return output.
+
+    Commands are passed via stdin to avoid shell injection.
+    """
+    oracle_home = module.params.get("oracle_home")
+    if not oracle_home:
+        if 'ORACLE_HOME' in os.environ:
+            oracle_home = os.environ['ORACLE_HOME']
+        else:
+            module.fail_json(msg='oracle_home is required for broker mode', changed=False)
+
+    dgmgrl_bin = os.path.join(oracle_home, 'bin', 'dgmgrl')
+    if not os.path.exists(dgmgrl_bin):
+        module.fail_json(msg='DGMGRL not found at %s' % dgmgrl_bin, changed=False)
+
+    # Build connect string
+    dgmgrl_user = module.params.get("dgmgrl_user")
+    dgmgrl_password = module.params.get("dgmgrl_password")
+    dgmgrl_connect_id = module.params.get("dgmgrl_connect_identifier")
+    dgmgrl_as = module.params.get("dgmgrl_as")
+
+    if dgmgrl_user and dgmgrl_password:
+        if dgmgrl_connect_id:
+            connect_string = '%s/%s@%s' % (dgmgrl_user, dgmgrl_password, dgmgrl_connect_id)
+        else:
+            connect_string = '%s/%s' % (dgmgrl_user, dgmgrl_password)
+        if dgmgrl_as:
+            connect_string += ' AS %s' % dgmgrl_as.upper()
+    else:
+        connect_string = '/ AS %s' % dgmgrl_as.upper()
+
+    # Build command
+    cmd = [dgmgrl_bin, '-silent']
+    if output_format == 'json':
+        cmd.extend(['-outputformat', 'json'])
+    cmd.append(connect_string)
+
+    # Build script from commands
+    script = ';\n'.join(commands) + ';\n'
+
+    rc, stdout, stderr = module.run_command(cmd, data=script)
+
+    return rc, stdout, stderr
+
+
+def parse_show_configuration(stdout):
+    """Parse SHOW CONFIGURATION output into a dict."""
+    result = {
+        'name': '',
+        'protection_mode': '',
+        'status': '',
+        'databases': [],
+        'fast_start_failover': '',
+    }
+    for line in stdout.split('\n'):
+        line = line.strip()
+        if line.startswith('Configuration -'):
+            result['name'] = line.split('-', 1)[1].strip()
+        elif line.startswith('Protection Mode:'):
+            result['protection_mode'] = line.split(':', 1)[1].strip()
+        elif any(role in line for role in (
+                'Primary database', 'Physical standby', 'Snapshot standby', 'Logical standby')):
+            parts = line.split('-')
+            if len(parts) >= 2:
+                db_info = {
+                    'name': parts[0].strip(),
+                    'role': '',
+                    'status': '',
+                }
+                desc = parts[1].strip()
+                if 'Primary' in desc:
+                    db_info['role'] = 'PRIMARY'
+                elif 'Physical standby' in desc:
+                    db_info['role'] = 'PHYSICAL STANDBY'
+                elif 'Snapshot standby' in desc:
+                    db_info['role'] = 'SNAPSHOT STANDBY'
+                elif 'Logical standby' in desc:
+                    db_info['role'] = 'LOGICAL STANDBY'
+                result['databases'].append(db_info)
+        elif line.startswith('Fast-Start Failover:'):
+            result['fast_start_failover'] = line.split(':', 1)[1].strip()
+        elif line.startswith('Configuration Status:'):
+            result['status'] = line.split(':', 1)[1].strip()
+    return result
+
+
+def dgmgrl_show_configuration(module, output_format):
+    """Run SHOW CONFIGURATION and return parsed result."""
+    rc, stdout, stderr = run_dgmgrl(module, ['SHOW CONFIGURATION VERBOSE'], output_format)
+    if rc != 0:
+        if 'ORA-16532' in stdout or 'not yet created' in stdout.lower():
+            return {'status': 'NOT_CONFIGURED', 'name': '', 'databases': []}
+        module.fail_json(msg='DGMGRL SHOW CONFIGURATION failed: %s %s' % (stdout, stderr), changed=False)
+
+    if output_format == 'json':
+        try:
+            return json.loads(stdout)
+        except (ValueError, TypeError):
+            return parse_show_configuration(stdout)
+    return parse_show_configuration(stdout)
+
+
+def dgmgrl_show_database(module, db_name, output_format):
+    """Run SHOW DATABASE and return output."""
+    rc, stdout, _stderr = run_dgmgrl(module, ['SHOW DATABASE %s VERBOSE' % db_name], output_format)
+    if rc != 0:
+        return None
+    return stdout
+
+
+def dgmgrl_create_configuration(module):
+    """Create a Data Guard broker configuration."""
+    config_name = module.params["configuration_name"]
+    primary_db = module.params["primary_database"]
+    connect_id = module.params["connect_identifier"]
+
+    if not config_name or not primary_db or not connect_id:
+        module.fail_json(
+            msg='configuration_name, primary_database, and connect_identifier are required to create a configuration',
+            changed=False
+        )
+
+    cmd = "CREATE CONFIGURATION %s AS PRIMARY DATABASE IS %s CONNECT IDENTIFIER IS '%s'" % (
+        config_name, primary_db, connect_id
+    )
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already exists' not in stdout.lower():
+        module.fail_json(msg='Failed to create configuration: %s %s' % (stdout, stderr), changed=False)
+    return rc == 0 or 'already exists' in stdout.lower()
+
+
+def dgmgrl_add_database(module):
+    """Add a database to the Data Guard configuration."""
+    db_name = module.params["database_name"]
+    connect_id = module.params["connect_identifier"]
+
+    if not db_name or not connect_id:
+        module.fail_json(
+            msg='database_name and connect_identifier are required to add a database',
+            changed=False
+        )
+
+    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, connect_id)
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already' not in stdout.lower():
+        module.fail_json(msg='Failed to add database: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_remove_database(module, db_name):
+    """Remove a database from the configuration."""
+    rc, stdout, stderr = run_dgmgrl(module, ['REMOVE DATABASE %s' % db_name])
+    if rc != 0 and 'not found' not in stdout.lower():
+        module.fail_json(msg='Failed to remove database: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_remove_configuration(module):
+    """Remove the entire Data Guard configuration."""
+    rc, stdout, stderr = run_dgmgrl(module, ['REMOVE CONFIGURATION'])
+    if rc != 0 and 'not yet created' not in stdout.lower():
+        module.fail_json(msg='Failed to remove configuration: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_enable(module, target_type, target_name=None):
+    """Enable configuration or database."""
+    if target_type == 'configuration':
+        cmd = 'ENABLE CONFIGURATION'
+    else:
+        cmd = 'ENABLE DATABASE %s' % target_name
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already enabled' not in stdout.lower():
+        module.fail_json(msg='Failed to enable %s: %s %s' % (target_type, stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_disable(module, target_type, target_name=None):
+    """Disable configuration or database."""
+    if target_type == 'configuration':
+        cmd = 'DISABLE CONFIGURATION'
+    else:
+        cmd = 'DISABLE DATABASE %s' % target_name
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already disabled' not in stdout.lower():
+        module.fail_json(msg='Failed to disable %s: %s %s' % (target_type, stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_switchover(module, db_name):
+    """Perform a switchover to the specified database."""
+    if not db_name:
+        module.fail_json(msg='database_name is required for switchover', changed=False)
+    rc, stdout, stderr = run_dgmgrl(module, ['SWITCHOVER TO %s' % db_name])
+    if rc != 0:
+        module.fail_json(msg='Switchover failed: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_failover(module, db_name):
+    """Perform a failover to the specified database."""
+    if not db_name:
+        module.fail_json(msg='database_name is required for failover', changed=False)
+    rc, stdout, stderr = run_dgmgrl(module, ['FAILOVER TO %s' % db_name])
+    if rc != 0:
+        module.fail_json(msg='Failover failed: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_convert_database(module, db_name, target_type):
+    """Convert database to snapshot or physical standby."""
+    if not db_name:
+        module.fail_json(msg='database_name is required for convert', changed=False)
+    cmd = 'CONVERT DATABASE %s TO %s' % (db_name, target_type)
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Convert failed: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_set_properties(module, db_name, properties):
+    """Set properties on a database."""
+    if not db_name or not properties:
+        return
+    commands = []
+    for prop, value in properties.items():
+        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, value))
+    rc, stdout, stderr = run_dgmgrl(module, commands)
+    if rc != 0:
+        module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
+
+
+def dgmgrl_set_protection_mode(module, protection_mode):
+    """Set the protection mode."""
+    mode_map = {
+        'maximum_protection': 'MAXPROTECTION',
+        'maximum_availability': 'MAXAVAILABILITY',
+        'maximum_performance': 'MAXPERFORMANCE',
+    }
+    mode = mode_map.get(protection_mode)
+    if not mode:
+        module.fail_json(msg='Invalid protection mode: %s' % protection_mode, changed=False)
+
+    cmd = 'EDIT CONFIGURATION SET PROTECTION MODE AS %s' % mode
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Failed to set protection mode: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_set_state(module, db_name, db_state):
+    """Set database transport/apply state."""
+    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, db_state.upper())
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Failed to set state: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_manage_fsfo(module, fsfo_state):
+    """Enable or disable Fast-Start Failover."""
+    if fsfo_state == 'enabled':
+        cmd = 'ENABLE FAST_START FAILOVER'
+    else:
+        cmd = 'DISABLE FAST_START FAILOVER'
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Failed to manage FSFO: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_manage_observer(module, observer_state):
+    """Start or stop the FSFO observer."""
+    if observer_state == 'started':
+        cmd = 'START OBSERVER IN BACKGROUND'
+    else:
+        cmd = 'STOP OBSERVER'
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Failed to manage observer: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_add_far_sync(module):
+    """Add a Far Sync instance."""
+    fs_name = module.params["far_sync_name"]
+    fs_connect = module.params["far_sync_connect_identifier"]
+
+    if not fs_name or not fs_connect:
+        module.fail_json(
+            msg='far_sync_name and far_sync_connect_identifier are required',
+            changed=False
+        )
+
+    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, fs_connect)
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already' not in stdout.lower():
+        module.fail_json(msg='Failed to add Far Sync: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_validate(module, db_name):
+    """Validate a database configuration."""
+    cmd = 'VALIDATE DATABASE %s' % db_name
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    return {'rc': rc, 'output': stdout, 'errors': stderr}
+
+
+# ============================================================================
+# SQL Mode Functions
+# ============================================================================
+
+def sql_get_database_info(conn):
+    """Get Data Guard related information from V$DATABASE."""
+    sql = """SELECT DATABASE_ROLE, PROTECTION_MODE, PROTECTION_LEVEL,
+                    SWITCHOVER_STATUS, DATAGUARD_BROKER, FORCE_LOGGING,
+                    FLASHBACK_ON, DB_UNIQUE_NAME
+             FROM V$DATABASE"""
+    return conn.execute_select_to_dict(sql, fetchone=True)
+
+
+def sql_get_dataguard_stats(conn):
+    """Get transport and apply lag from V$DATAGUARD_STATS."""
+    sql = "SELECT NAME, VALUE, UNIT, TIME_COMPUTED, DATUM_TIME FROM V$DATAGUARD_STATS"
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def sql_get_archive_dest_status(conn):
+    """Get archive destination status."""
+    sql = """SELECT DEST_ID, STATUS, TYPE, DATABASE_MODE, RECOVERY_MODE,
+                    GAP_STATUS, SYNCHRONIZED, ERROR, DB_UNIQUE_NAME
+             FROM V$ARCHIVE_DEST_STATUS
+             WHERE STATUS != 'INACTIVE'"""
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def sql_get_dataguard_processes(conn):
+    """Get active Data Guard processes."""
+    sql = """SELECT ROLE, ACTION, CLIENT_ROLE, THREAD#, SEQUENCE#, BLOCK#
+             FROM V$DATAGUARD_PROCESS"""
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def sql_start_apply(conn, _module):
+    """Start managed recovery (redo apply)."""
+    # Check if MRP is already running
+    processes = sql_get_dataguard_processes(conn)
+    for p in processes:
+        if p.get('action', '').upper() in ('APPLYING_LOG', 'APPLYING'):
+            return  # Already running, idempotent
+
+    conn.execute_ddl('ALTER DATABASE RECOVER MANAGED STANDBY DATABASE USING CURRENT LOGFILE DISCONNECT')
+
+
+def sql_stop_apply(conn, _module):
+    """Stop managed recovery."""
+    processes = sql_get_dataguard_processes(conn)
+    mrp_running = False
+    for p in processes:
+        if p.get('action', '').upper() in ('APPLYING_LOG', 'APPLYING'):
+            mrp_running = True
+            break
+    if not mrp_running:
+        return  # Already stopped, idempotent
+
+    conn.execute_ddl('ALTER DATABASE RECOVER MANAGED STANDBY DATABASE CANCEL')
+
+
+def sql_set_force_logging(conn, _module, enable):
+    """Enable or disable force logging."""
+    db_info = sql_get_database_info(conn)
+    current = db_info.get('force_logging', 'NO')
+
+    if enable == 'enable' and current == 'YES':
+        return  # Already enabled
+    if enable == 'disable' and current == 'NO':
+        return  # Already disabled
+
+    if enable == 'enable':
+        conn.execute_ddl('ALTER DATABASE FORCE LOGGING')
+    else:
+        conn.execute_ddl('ALTER DATABASE NO FORCE LOGGING')
+
+
+def sql_set_protection_mode(conn, module, protection_mode):
+    """Set protection mode via SQL."""
+    mode_map = {
+        'maximum_protection': 'MAXIMIZE PROTECTION',
+        'maximum_availability': 'MAXIMIZE AVAILABILITY',
+        'maximum_performance': 'MAXIMIZE PERFORMANCE',
+    }
+    target = mode_map.get(protection_mode)
+    if not target:
+        module.fail_json(msg='Invalid protection mode: %s' % protection_mode, changed=False)
+
+    db_info = sql_get_database_info(conn)
+    current = db_info.get('protection_mode', '')
+
+    if target.replace('MAXIMIZE ', 'MAXIMUM ') == current:
+        return  # Already set
+
+    conn.execute_ddl('ALTER DATABASE SET STANDBY DATABASE TO %s' % target)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            # Standard connection params (for SQL mode)
+            user=dict(required=False, aliases=['un', 'username']),
+            password=dict(required=False, no_log=True, aliases=['pw']),
+            mode=dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            hostname=dict(required=False, default='localhost', aliases=['host']),
+            port=dict(required=False, default=1521, type='int'),
+            service_name=dict(required=False, aliases=['sn']),
+            dsn=dict(required=False, aliases=['datasource_name']),
+            oracle_home=dict(required=False, aliases=['oh']),
+            session_container=dict(required=False),
+
+            # Data Guard mode
+            mode_dg=dict(default='broker', choices=['broker', 'sql']),
+            state=dict(default='status',
+                       choices=['present', 'absent', 'enabled', 'disabled', 'status',
+                                'switchover', 'failover', 'snapshot_standby', 'physical_standby']),
+
+            # DGMGRL connection
+            dgmgrl_user=dict(required=False),
+            dgmgrl_password=dict(required=False, no_log=True),
+            dgmgrl_connect_identifier=dict(required=False),
+            dgmgrl_as=dict(default='sysdg', choices=['sysdba', 'sysdg']),
+
+            # Configuration
+            configuration_name=dict(required=False),
+            primary_database=dict(required=False),
+            connect_identifier=dict(required=False),
+
+            # Database member
+            database_name=dict(required=False),
+
+            # Properties
+            properties=dict(required=False, type='dict'),
+
+            # Protection mode
+            protection_mode=dict(required=False,
+                                choices=['maximum_protection', 'maximum_availability',
+                                         'maximum_performance']),
+
+            # Database state
+            database_state=dict(required=False,
+                               choices=['transport-on', 'transport-off',
+                                        'apply-on', 'apply-off']),
+
+            # Fast-Start Failover
+            fsfo=dict(required=False, choices=['enabled', 'disabled']),
+            fsfo_target=dict(required=False),
+
+            # Far Sync
+            far_sync_name=dict(required=False),
+            far_sync_connect_identifier=dict(required=False),
+
+            # Observer
+            observer_state=dict(required=False, choices=['started', 'stopped']),
+
+            # Output format (26ai JSON)
+            output_format=dict(default='text', choices=['text', 'json']),
+
+            # SQL mode specific
+            force_logging=dict(required=False, choices=['enable', 'disable']),
+            apply_state=dict(required=False, choices=['started', 'stopped']),
+        ),
+        supports_check_mode=True,
+    )
+
+    sanitize_string_params(module.params)
+
+    if module.params["mode_dg"] == 'broker':
+        _run_broker_mode(module)
+    else:
+        _run_sql_mode(module)
+
+
+def _run_broker_mode(module):
+    """Handle all broker (DGMGRL) operations."""
+    state = module.params["state"]
+    database_name = module.params["database_name"]
+    output_format = module.params["output_format"]
+
+    if module.check_mode:
+        module.exit_json(changed=False, msg='Check mode: no broker operations executed')
+
+    if state == 'status':
+        _broker_status(module, database_name, output_format)
+    elif state == 'present':
+        _broker_present(module, database_name, output_format)
+    elif state == 'absent':
+        _broker_absent(module, database_name)
+    elif state == 'enabled':
+        _broker_enable_disable(module, database_name, enable=True)
+    elif state == 'disabled':
+        _broker_enable_disable(module, database_name, enable=False)
+    elif state == 'switchover':
+        dgmgrl_switchover(module, database_name)
+        module.exit_json(changed=True, msg='Switchover to %s completed' % database_name)
+    elif state == 'failover':
+        dgmgrl_failover(module, database_name)
+        module.exit_json(changed=True, msg='Failover to %s completed' % database_name)
+    elif state == 'snapshot_standby':
+        dgmgrl_convert_database(module, database_name, 'SNAPSHOT STANDBY')
+        module.exit_json(changed=True, msg='Converted %s to snapshot standby' % database_name)
+    elif state == 'physical_standby':
+        dgmgrl_convert_database(module, database_name, 'PHYSICAL STANDBY')
+        module.exit_json(changed=True, msg='Converted %s to physical standby' % database_name)
+
+
+def _broker_status(module, database_name, output_format):
+    """Handle broker status query."""
+    config = dgmgrl_show_configuration(module, output_format)
+    db_detail = None
+    validate_result = None
+    if database_name:
+        db_detail = dgmgrl_show_database(module, database_name, output_format)
+        validate_result = dgmgrl_validate(module, database_name)
+    module.exit_json(
+        changed=False,
+        configuration=config,
+        database_detail=db_detail,
+        validate=validate_result,
+    )
+
+
+def _broker_present(module, database_name, output_format):
+    """Handle broker present state (create/add/configure)."""
+    changed = False
+    config = dgmgrl_show_configuration(module, 'text')
+
+    if module.params["configuration_name"] and config.get('status') == 'NOT_CONFIGURED':
+        dgmgrl_create_configuration(module)
+        changed = True
+
+    if database_name and config.get('status') != 'NOT_CONFIGURED':
+        existing_dbs = [d['name'] for d in config.get('databases', [])]
+        if database_name.upper() not in [d.upper() for d in existing_dbs]:
+            dgmgrl_add_database(module)
+            changed = True
+
+    if module.params["far_sync_name"]:
+        dgmgrl_add_far_sync(module)
+        changed = True
+    if module.params["properties"] and database_name:
+        dgmgrl_set_properties(module, database_name, module.params["properties"])
+        changed = True
+    if module.params["protection_mode"]:
+        dgmgrl_set_protection_mode(module, module.params["protection_mode"])
+        changed = True
+    if module.params["database_state"] and database_name:
+        dgmgrl_set_state(module, database_name, module.params["database_state"])
+        changed = True
+    if module.params["fsfo"]:
+        dgmgrl_manage_fsfo(module, module.params["fsfo"])
+        changed = True
+    if module.params["observer_state"]:
+        dgmgrl_manage_observer(module, module.params["observer_state"])
+        changed = True
+
+    config = dgmgrl_show_configuration(module, output_format)
+    module.exit_json(changed=changed, configuration=config, msg='Data Guard configuration updated')
+
+
+def _broker_absent(module, database_name):
+    """Handle broker absent state (remove)."""
+    config = dgmgrl_show_configuration(module, 'text')
+    if config.get('status') == 'NOT_CONFIGURED':
+        module.exit_json(changed=False, msg='No configuration exists')
+
+    changed = False
+    if database_name:
+        existing_dbs = [d['name'] for d in config.get('databases', [])]
+        if database_name.upper() in [d.upper() for d in existing_dbs]:
+            dgmgrl_remove_database(module, database_name)
+            changed = True
+    else:
+        dgmgrl_remove_configuration(module)
+        changed = True
+
+    module.exit_json(changed=changed, msg='Data Guard resources removed')
+
+
+def _broker_enable_disable(module, database_name, enable):
+    """Handle broker enable/disable operations."""
+    func = dgmgrl_enable if enable else dgmgrl_disable
+    if database_name:
+        func(module, 'database', database_name)
+    else:
+        func(module, 'configuration')
+    action = 'Enabled' if enable else 'Disabled'
+    module.exit_json(changed=True, msg='%s successfully' % action)
+
+
+def _run_sql_mode(module):
+    """Handle all SQL mode operations."""
+    state = module.params["state"]
+    protection_mode = module.params["protection_mode"]
+    conn = oracleConnection(module)
+
+    if state == 'status':
+        module.exit_json(
+            changed=False,
+            database=sql_get_database_info(conn),
+            dataguard_stats=sql_get_dataguard_stats(conn),
+            archive_dest_status=sql_get_archive_dest_status(conn),
+            dataguard_processes=sql_get_dataguard_processes(conn),
+        )
+
+    apply_state = module.params["apply_state"]
+    if apply_state == 'started':
+        sql_start_apply(conn, module)
+    elif apply_state == 'stopped':
+        sql_stop_apply(conn, module)
+
+    force_logging = module.params["force_logging"]
+    if force_logging:
+        sql_set_force_logging(conn, module, force_logging)
+
+    if protection_mode:
+        sql_set_protection_mode(conn, module, protection_mode)
+
+    module.exit_json(
+        changed=conn.changed,
+        ddls=conn.ddls,
+        database=sql_get_database_info(conn),
+        msg='Data Guard SQL operations completed',
+    )
+
+
+from ansible.module_utils.basic import *  # noqa: F403
+
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(_params):
+        pass
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -276,6 +276,7 @@ EXAMPLES = '''
 
 import json
 import os
+import re
 
 
 # ============================================================================
@@ -387,10 +388,22 @@ def dgmgrl_show_configuration(module, output_format):
 
 def dgmgrl_show_database(module, db_name, output_format):
     """Run SHOW DATABASE and return output."""
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     rc, stdout, _stderr = run_dgmgrl(module, ['SHOW DATABASE %s VERBOSE' % db_name], output_format)
     if rc != 0:
         return None
     return stdout
+
+
+def _validate_dgmgrl_identifier(module, value, param_name):
+    """Validate that a value is a safe DGMGRL identifier (letters, digits, _, $, #)."""
+    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', value):
+        module.fail_json(msg='Invalid %s: must be an Oracle identifier' % param_name, changed=False)
+
+
+def _quote_dgmgrl_literal(value):
+    """Escape single quotes in a DGMGRL string literal."""
+    return value.replace("'", "''")
 
 
 def dgmgrl_create_configuration(module):
@@ -405,8 +418,11 @@ def dgmgrl_create_configuration(module):
             changed=False
         )
 
+    _validate_dgmgrl_identifier(module, config_name, 'configuration_name')
+    _validate_dgmgrl_identifier(module, primary_db, 'primary_database')
+
     cmd = "CREATE CONFIGURATION %s AS PRIMARY DATABASE IS %s CONNECT IDENTIFIER IS '%s'" % (
-        config_name, primary_db, connect_id
+        config_name, primary_db, _quote_dgmgrl_literal(connect_id)
     )
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already exists' not in stdout.lower():
@@ -425,7 +441,9 @@ def dgmgrl_add_database(module):
             changed=False
         )
 
-    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, connect_id)
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
+
+    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, _quote_dgmgrl_literal(connect_id))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already' not in stdout.lower():
         module.fail_json(msg='Failed to add database: %s %s' % (stdout, stderr), changed=False)
@@ -434,6 +452,7 @@ def dgmgrl_add_database(module):
 
 def dgmgrl_remove_database(module, db_name):
     """Remove a database from the configuration."""
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     rc, stdout, stderr = run_dgmgrl(module, ['REMOVE DATABASE %s' % db_name])
     if rc != 0 and 'not found' not in stdout.lower():
         module.fail_json(msg='Failed to remove database: %s %s' % (stdout, stderr), changed=False)
@@ -449,26 +468,32 @@ def dgmgrl_remove_configuration(module):
 
 
 def dgmgrl_enable(module, target_type, target_name=None):
-    """Enable configuration or database."""
+    """Enable configuration or database. Returns True if changed."""
     if target_type == 'configuration':
         cmd = 'ENABLE CONFIGURATION'
     else:
+        _validate_dgmgrl_identifier(module, target_name, 'database_name')
         cmd = 'ENABLE DATABASE %s' % target_name
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already enabled' not in stdout.lower():
         module.fail_json(msg='Failed to enable %s: %s %s' % (target_type, stdout, stderr), changed=False)
+    if 'already enabled' in stdout.lower():
+        return False
     return True
 
 
 def dgmgrl_disable(module, target_type, target_name=None):
-    """Disable configuration or database."""
+    """Disable configuration or database. Returns True if changed."""
     if target_type == 'configuration':
         cmd = 'DISABLE CONFIGURATION'
     else:
+        _validate_dgmgrl_identifier(module, target_name, 'database_name')
         cmd = 'DISABLE DATABASE %s' % target_name
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already disabled' not in stdout.lower():
         module.fail_json(msg='Failed to disable %s: %s %s' % (target_type, stdout, stderr), changed=False)
+    if 'already disabled' in stdout.lower():
+        return False
     return True
 
 
@@ -476,6 +501,7 @@ def dgmgrl_switchover(module, db_name):
     """Perform a switchover to the specified database."""
     if not db_name:
         module.fail_json(msg='database_name is required for switchover', changed=False)
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     rc, stdout, stderr = run_dgmgrl(module, ['SWITCHOVER TO %s' % db_name])
     if rc != 0:
         module.fail_json(msg='Switchover failed: %s %s' % (stdout, stderr), changed=False)
@@ -486,6 +512,7 @@ def dgmgrl_failover(module, db_name):
     """Perform a failover to the specified database."""
     if not db_name:
         module.fail_json(msg='database_name is required for failover', changed=False)
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     rc, stdout, stderr = run_dgmgrl(module, ['FAILOVER TO %s' % db_name])
     if rc != 0:
         module.fail_json(msg='Failover failed: %s %s' % (stdout, stderr), changed=False)
@@ -507,9 +534,11 @@ def dgmgrl_set_properties(module, db_name, properties):
     """Set properties on a database."""
     if not db_name or not properties:
         return
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     commands = []
     for prop, value in properties.items():
-        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, value))
+        _validate_dgmgrl_identifier(module, prop, 'property name')
+        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(str(value))))
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
         module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
@@ -535,7 +564,8 @@ def dgmgrl_set_protection_mode(module, protection_mode):
 
 def dgmgrl_set_state(module, db_name, db_state):
     """Set database transport/apply state."""
-    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, db_state.upper())
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
+    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(db_state.upper()))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         module.fail_json(msg='Failed to set state: %s %s' % (stdout, stderr), changed=False)
@@ -577,7 +607,9 @@ def dgmgrl_add_far_sync(module):
             changed=False
         )
 
-    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, fs_connect)
+    _validate_dgmgrl_identifier(module, fs_name, 'far_sync_name')
+
+    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, _quote_dgmgrl_literal(fs_connect))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already' not in stdout.lower():
         module.fail_json(msg='Failed to add Far Sync: %s %s' % (stdout, stderr), changed=False)
@@ -586,6 +618,7 @@ def dgmgrl_add_far_sync(module):
 
 def dgmgrl_validate(module, db_name):
     """Validate a database configuration."""
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     cmd = 'VALIDATE DATABASE %s' % db_name
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     return {'rc': rc, 'output': stdout, 'errors': stderr}
@@ -873,11 +906,11 @@ def _broker_enable_disable(module, database_name, enable):
     """Handle broker enable/disable operations."""
     func = dgmgrl_enable if enable else dgmgrl_disable
     if database_name:
-        func(module, 'database', database_name)
+        changed = func(module, 'database', database_name)
     else:
-        func(module, 'configuration')
+        changed = func(module, 'configuration')
     action = 'Enabled' if enable else 'Disabled'
-    module.exit_json(changed=True, msg='%s successfully' % action)
+    module.exit_json(changed=changed, msg='%s successfully' % action)
 
 
 def _run_sql_mode(module):

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -378,6 +378,12 @@ def run_dgmgrl(module, commands, output_format='text'):
     dgmgrl_connect_id = module.params.get("dgmgrl_connect_identifier")
     dgmgrl_as = module.params.get("dgmgrl_as")
 
+    # Reject command separators in credentials to prevent DGMGRL injection.
+    if dgmgrl_password:
+        _validate_dgmgrl_connect_string(module, dgmgrl_password, 'dgmgrl_password')
+    if dgmgrl_connect_id:
+        _validate_dgmgrl_connect_string(module, dgmgrl_connect_id, 'dgmgrl_connect_identifier')
+
     if dgmgrl_user and dgmgrl_password:
         if dgmgrl_connect_id:
             connect_string = '%s/%s@%s' % (dgmgrl_user, dgmgrl_password, dgmgrl_connect_id)

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -1203,6 +1203,15 @@ def _run_sql_mode(module):
 
 from ansible.module_utils.basic import *  # noqa: F403
 
+# In these we do import from local project sub-directory <project-dir>/module_utils
+# While this file is placed in <project-dir>/library
+# No collections are used
+#try:
+#    from ansible.module_utils.oracle_utils import oracleConnection, sanitize_string_params
+#except:
+#    pass
+
+# In this case we do import from collections
 try:
     from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
         oracleConnection, sanitize_string_params,

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -379,6 +379,8 @@ def run_dgmgrl(module, commands, output_format='text'):
     dgmgrl_as = module.params.get("dgmgrl_as")
 
     # Reject command separators in credentials to prevent DGMGRL injection.
+    if dgmgrl_user:
+        _validate_dgmgrl_connect_string(module, dgmgrl_user, 'dgmgrl_user')
     if dgmgrl_password:
         _validate_dgmgrl_connect_string(module, dgmgrl_password, 'dgmgrl_password')
     if dgmgrl_connect_id:

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -54,6 +54,7 @@ options:
     description:
       - Password for DGMGRL connection
       - If omitted (along with dgmgrl_user), OS authentication is used
+      - Credentials are passed via stdin (CONNECT command), never on the command line
     required: false
   dgmgrl_connect_identifier:
     description: Connect identifier for DGMGRL (e.g. host:port/service)
@@ -153,6 +154,7 @@ options:
     required: false
 notes:
   - Broker mode requires DGMGRL binary in ORACLE_HOME/bin
+  - "Broker mode uses dgmgrl /nolog and passes credentials via stdin (CONNECT command) to avoid exposing passwords in process listings"
   - "Broker mode supports OS authentication (/ AS SYSDG or / AS SYSDBA) when dgmgrl_user and dgmgrl_password are omitted"
   - "SQL mode supports OS authentication (mode: sysdba without user/password) when running as the oracle OS user"
   - SQL mode uses standard oracledb connection
@@ -178,7 +180,7 @@ EXAMPLES = '''
     dgmgrl_as: sysdba
     state: status
 
-# Password authentication
+# Password authentication (credentials are passed via stdin, not on the command line)
 - name: Get Data Guard status with password authentication
   oracle_dataguard:
     oracle_home: /u01/app/oracle/product/19c
@@ -368,7 +370,9 @@ def run_dgmgrl(module, commands, output_format='text'):
     if not os.path.exists(dgmgrl_bin):
         module.fail_json(msg='DGMGRL not found at %s' % dgmgrl_bin, changed=False)
 
-    # Build connect string
+    # Build connect string and pass it via stdin (CONNECT command) so that
+    # credentials never appear on the command line or in process listings.
+    # This mirrors how oracle_sqldba passes passwords to sqlplus via stdin.
     dgmgrl_user = module.params.get("dgmgrl_user")
     dgmgrl_password = module.params.get("dgmgrl_password")
     dgmgrl_connect_id = module.params.get("dgmgrl_connect_identifier")
@@ -381,17 +385,29 @@ def run_dgmgrl(module, commands, output_format='text'):
             connect_string = '%s/%s' % (dgmgrl_user, dgmgrl_password)
         if dgmgrl_as:
             connect_string += ' AS %s' % dgmgrl_as.upper()
+    elif dgmgrl_user:
+        # Wallet-based authentication (no password)
+        if dgmgrl_connect_id:
+            connect_string = '%s/@%s' % (dgmgrl_user, dgmgrl_connect_id)
+        else:
+            connect_string = '%s/' % dgmgrl_user
+        if dgmgrl_as:
+            connect_string += ' AS %s' % dgmgrl_as.upper()
     else:
+        # OS authentication
         connect_string = '/ AS %s' % dgmgrl_as.upper()
 
-    # Build command
+    # Use /nolog mode and issue CONNECT via stdin to keep credentials
+    # out of the process argument list visible in ps/proc.
     cmd = [dgmgrl_bin, '-silent']
     if output_format == 'json':
         cmd.extend(['-outputformat', 'json'])
-    cmd.append(connect_string)
+    cmd.append('/nolog')
 
-    # Build script from commands
-    script = ';\n'.join(commands) + ';\n'
+    # Build script: CONNECT first, then the actual commands
+    script_lines = ['CONNECT %s' % connect_string]
+    script_lines.extend(commands)
+    script = ';\n'.join(script_lines) + ';\n'
 
     rc, stdout, stderr = module.run_command(cmd, data=script)
 
@@ -605,9 +621,12 @@ def dgmgrl_convert_database(module, db_name, target_type):
 
 
 def dgmgrl_set_properties(module, db_name, properties):
-    """Set properties on a database."""
+    """Set properties on a database.
+
+    Returns True because DGMGRL does not report whether a value actually changed.
+    """
     if not db_name or not properties:
-        return
+        return False
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
     commands = []
     for prop, value in properties.items():
@@ -616,6 +635,7 @@ def dgmgrl_set_properties(module, db_name, properties):
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
         module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
+    return True
 
 
 def dgmgrl_set_protection_mode(module, protection_mode):
@@ -689,7 +709,9 @@ def dgmgrl_add_far_sync(module):
 
     cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, _quote_dgmgrl_literal(fs_connect))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
-    if rc != 0 and 'already' not in stdout.lower():
+    if rc != 0:
+        if 'already' in stdout.lower():
+            return False
         module.fail_json(msg='Failed to add Far Sync: %s %s' % (stdout, stderr), changed=False)
     return True
 
@@ -1065,26 +1087,26 @@ def _broker_present(module, database_name, output_format):
             changed = True
 
     if module.params["far_sync_name"]:
-        dgmgrl_add_far_sync(module)
-        changed = True
+        if dgmgrl_add_far_sync(module):
+            changed = True
     if module.params["properties"] and database_name:
-        dgmgrl_set_properties(module, database_name, module.params["properties"])
-        changed = True
+        if dgmgrl_set_properties(module, database_name, module.params["properties"]):
+            changed = True
     if module.params["protection_mode"]:
-        dgmgrl_set_protection_mode(module, module.params["protection_mode"])
-        changed = True
+        if dgmgrl_set_protection_mode(module, module.params["protection_mode"]):
+            changed = True
     if module.params["database_state"] and database_name:
-        dgmgrl_set_state(module, database_name, module.params["database_state"])
-        changed = True
+        if dgmgrl_set_state(module, database_name, module.params["database_state"]):
+            changed = True
     if module.params["primary_database_candidates"]:
         if dgmgrl_set_primary_database_candidates(module, module.params["primary_database_candidates"]):
             changed = True
     if module.params["fsfo"]:
-        dgmgrl_manage_fsfo(module, module.params["fsfo"], module.params.get("fsfo_target"))
-        changed = True
+        if dgmgrl_manage_fsfo(module, module.params["fsfo"], module.params.get("fsfo_target")):
+            changed = True
     if module.params["observer_state"]:
-        dgmgrl_manage_observer(module, module.params["observer_state"])
-        changed = True
+        if dgmgrl_manage_observer(module, module.params["observer_state"]):
+            changed = True
     if module.params["tags"]:
         if dgmgrl_set_tags(module, module.params["tags"]):
             changed = True
@@ -1126,12 +1148,24 @@ def _broker_enable_disable(module, database_name, enable):
     module.exit_json(changed=changed, msg='%s successfully' % action)
 
 
+_SQL_SUPPORTED_STATES = frozenset(['status', 'present'])
+
+
 def _run_sql_mode(module):
     """Handle all SQL mode operations."""
     if oracleConnection is None:
         module.fail_json(msg='SQL mode requires oracledb module. Install via: pip install oracledb', changed=False)
     state = module.params["state"]
     protection_mode = module.params["protection_mode"]
+
+    if state not in _SQL_SUPPORTED_STATES:
+        module.fail_json(
+            msg="state '%s' is not supported in SQL mode. "
+                "Supported states: %s. Use mode_dg=broker for this operation."
+                % (state, ', '.join(sorted(_SQL_SUPPORTED_STATES))),
+            changed=False,
+        )
+
     conn = oracleConnection(module)
 
     if state == 'status':

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -895,6 +895,9 @@ def _run_sql_mode(module):
             dataguard_processes=sql_get_dataguard_processes(conn),
         )
 
+    if module.check_mode:
+        module.exit_json(changed=False, msg='Check mode: no SQL operations executed')
+
     apply_state = module.params["apply_state"]
     if apply_state == 'started':
         sql_start_apply(conn, module)
@@ -923,8 +926,10 @@ try:
         oracleConnection, sanitize_string_params,
     )
 except ImportError:
-    def sanitize_string_params(_params):
-        pass
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -767,7 +767,7 @@ def _validate_dgmgrl_connect_string(module, value, param_name):
 def dgmgrl_validate_connect_identifier(module, connect_identifier):
     """Validate a DG connect identifier (26ai+)."""
     _validate_dgmgrl_connect_string(module, connect_identifier, 'validate_connect_identifier')
-    cmd = 'VALIDATE DGConnectIdentifier %s' % connect_identifier
+    cmd = "VALIDATE DGConnectIdentifier '%s'" % _quote_dgmgrl_literal(module, connect_identifier)
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     return {'rc': rc, 'output': stdout, 'errors': stderr}
 

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -407,7 +407,8 @@ def parse_show_configuration(stdout):
         'databases': [],
         'fast_start_failover': '',
     }
-    for line in stdout.split('\n'):
+    lines = stdout.split('\n')
+    for i, line in enumerate(lines):
         line = line.strip()
         if line.startswith('Configuration -'):
             result['name'] = line.split('-', 1)[1].strip()
@@ -435,7 +436,10 @@ def parse_show_configuration(stdout):
         elif line.startswith('Fast-Start Failover:'):
             result['fast_start_failover'] = line.split(':', 1)[1].strip()
         elif line.startswith('Configuration Status:'):
-            result['status'] = line.split(':', 1)[1].strip()
+            # Status value appears on the next line in DGMGRL output
+            if i + 1 < len(lines):
+                status_line = lines[i + 1].strip()
+                result['status'] = status_line.split('(')[0].strip() if '(' in status_line else status_line
     return result
 
 
@@ -592,6 +596,7 @@ def dgmgrl_convert_database(module, db_name, target_type):
     """Convert database to snapshot or physical standby."""
     if not db_name:
         module.fail_json(msg='database_name is required for convert', changed=False)
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     cmd = 'CONVERT DATABASE %s TO %s' % (db_name, target_type)
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
@@ -1051,6 +1056,7 @@ def _broker_present(module, database_name, output_format):
     if module.params["configuration_name"] and config.get('status') == 'NOT_CONFIGURED':
         dgmgrl_create_configuration(module)
         changed = True
+        config = dgmgrl_show_configuration(module, 'text')
 
     if database_name and config.get('status') != 'NOT_CONFIGURED':
         existing_dbs = [d['name'] for d in config.get('databases', [])]
@@ -1122,6 +1128,8 @@ def _broker_enable_disable(module, database_name, enable):
 
 def _run_sql_mode(module):
     """Handle all SQL mode operations."""
+    if oracleConnection is None:
+        module.fail_json(msg='SQL mode requires oracledb module. Install via: pip install oracledb', changed=False)
     state = module.params["state"]
     protection_mode = module.params["protection_mode"]
     conn = oracleConnection(module)
@@ -1166,6 +1174,8 @@ try:
         oracleConnection, sanitize_string_params,
     )
 except ImportError:
+    oracleConnection = None
+
     def sanitize_string_params(module_params):
         for key, value in module_params.items():
             if isinstance(value, str):

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -18,7 +18,7 @@ description:
   - Query Data Guard status, lag, and health
   - SQL mode for environments without broker
   - Compatible with Oracle 19c, 23ai, and 26ai
-  - "Oracle 26ai features: JSON output, PrimaryDatabaseCandidates, VALIDATE DGConnectIdentifier, tagging"
+  - "Oracle 26ai features: JSON output, VALIDATE DGConnectIdentifier, PrimaryDatabaseCandidates, tagging, FSFO target"
 version_added: "3.4.0"
 options:
   mode_dg:
@@ -95,7 +95,9 @@ options:
     choices: ['enabled', 'disabled']
     required: false
   fsfo_target:
-    description: Target database for Fast-Start Failover
+    description:
+      - Target database for Fast-Start Failover
+      - "When enabling FSFO, issues ENABLE FAST_START FAILOVER TARGET TO <target>"
     required: false
   far_sync_name:
     description: Name of the Far Sync instance
@@ -106,6 +108,34 @@ options:
   observer_state:
     description: Observer state
     choices: ['started', 'stopped']
+    required: false
+  validate_connect_identifier:
+    description:
+      - Connect identifier to validate via DGMGRL VALIDATE DGConnectIdentifier
+      - "Tests network resolution, connectivity, and service name validation"
+      - "Oracle 26ai+ feature"
+    required: false
+  primary_database_candidates:
+    description:
+      - List of database unique names eligible to become primary
+      - Sets the PrimaryDatabaseCandidates configuration property
+      - "Oracle 26ai+ feature, will warn and skip on older versions"
+    type: list
+    elements: str
+    required: false
+  tags:
+    description:
+      - Dictionary of tags to set on the target object
+      - "Target is determined by database_name (DATABASE), far_sync_name (FAR_SYNC), or CONFIGURATION if neither is set"
+      - "Uses EDIT <object> SET TAG syntax (Oracle 26ai+)"
+    type: dict
+    required: false
+  reset_tags:
+    description:
+      - List of tag names to remove from the target object
+      - "Uses EDIT <object> RESET TAG syntax (Oracle 26ai+)"
+    type: list
+    elements: str
     required: false
   output_format:
     description:
@@ -229,6 +259,45 @@ EXAMPLES = '''
   oracle_dataguard:
     oracle_home: /u01/app/oracle/product/19c
     state: absent
+
+# --- Oracle 26ai Features ---
+
+- name: Enable Fast-Start Failover with specific target
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: present
+    fsfo: enabled
+    fsfo_target: STDBY
+
+- name: Validate a DG connect identifier (26ai+)
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: status
+    validate_connect_identifier: "stdby-host:1521/STDBY"
+
+- name: Set PrimaryDatabaseCandidates (26ai+)
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: present
+    primary_database_candidates:
+      - PROD
+      - STDBY
+
+- name: Set tags on a database (26ai+)
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: present
+    database_name: STDBY
+    tags:
+      environment: production
+      tier: dr
+
+- name: Remove tags from configuration (26ai+)
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: present
+    reset_tags:
+      - environment
 
 # --- SQL Mode ---
 
@@ -572,10 +641,14 @@ def dgmgrl_set_state(module, db_name, db_state):
     return True
 
 
-def dgmgrl_manage_fsfo(module, fsfo_state):
+def dgmgrl_manage_fsfo(module, fsfo_state, fsfo_target=None):
     """Enable or disable Fast-Start Failover."""
     if fsfo_state == 'enabled':
-        cmd = 'ENABLE FAST_START FAILOVER'
+        if fsfo_target:
+            _validate_dgmgrl_identifier(module, fsfo_target, 'fsfo_target')
+            cmd = 'ENABLE FAST_START FAILOVER TARGET TO %s' % fsfo_target
+        else:
+            cmd = 'ENABLE FAST_START FAILOVER'
     else:
         cmd = 'DISABLE FAST_START FAILOVER'
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
@@ -622,6 +695,116 @@ def dgmgrl_validate(module, db_name):
     cmd = 'VALIDATE DATABASE %s' % db_name
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     return {'rc': rc, 'output': stdout, 'errors': stderr}
+
+
+# ============================================================================
+# Oracle 26ai Features
+# ============================================================================
+
+def _validate_dgmgrl_connect_string(module, value, param_name):
+    """Validate a connect identifier is safe for DGMGRL (no injection)."""
+    if not value or ';' in value or '\n' in value:
+        module.fail_json(msg='Invalid %s: must not be empty or contain ; or newlines' % param_name, changed=False)
+
+
+def dgmgrl_validate_connect_identifier(module, connect_identifier):
+    """Validate a DG connect identifier (26ai+)."""
+    _validate_dgmgrl_connect_string(module, connect_identifier, 'validate_connect_identifier')
+    cmd = 'VALIDATE DGConnectIdentifier %s' % connect_identifier
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    return {'rc': rc, 'output': stdout, 'errors': stderr}
+
+
+def dgmgrl_set_primary_database_candidates(module, candidates):
+    """Set PrimaryDatabaseCandidates configuration property (26ai+)."""
+    for c in candidates:
+        _validate_dgmgrl_identifier(module, c, 'primary_database_candidates member')
+    value = ','.join(candidates)
+    cmd = "EDIT CONFIGURATION SET PROPERTY PrimaryDatabaseCandidates='%s'" % _quote_dgmgrl_literal(value)
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        if 'not supported' in stdout.lower() or 'invalid property' in stdout.lower():
+            module.warn('PrimaryDatabaseCandidates not supported on this Oracle version')
+            return False
+        module.fail_json(msg='Failed to set PrimaryDatabaseCandidates: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def _validate_dgmgrl_tag_name(module, tag_name):
+    """Validate a tag name — alphanumeric, underscores, hyphens."""
+    if not re.match(r'^[A-Za-z][A-Za-z0-9_-]*$', tag_name):
+        module.fail_json(msg='Invalid tag name: %s' % tag_name, changed=False)
+
+
+def _resolve_tag_target(module):
+    """Determine the DGMGRL object type and name for tag operations.
+
+    Returns (target_keyword, target_name) e.g. ('DATABASE', 'STDBY') or ('CONFIGURATION', '').
+    """
+    db_name = module.params.get("database_name")
+    fs_name = module.params.get("far_sync_name")
+    if db_name:
+        _validate_dgmgrl_identifier(module, db_name, 'database_name')
+        return ('DATABASE', db_name)
+    if fs_name:
+        _validate_dgmgrl_identifier(module, fs_name, 'far_sync_name')
+        return ('FAR_SYNC', fs_name)
+    return ('CONFIGURATION', '')
+
+
+def dgmgrl_set_tags(module, tags):
+    """Set tags on a DGMGRL object (26ai+)."""
+    target_type, target_name = _resolve_tag_target(module)
+    commands = []
+    for tag_name, tag_value in tags.items():
+        _validate_dgmgrl_tag_name(module, tag_name)
+        if target_name:
+            cmd = "EDIT %s %s SET TAG %s='%s'" % (
+                target_type, target_name, tag_name, _quote_dgmgrl_literal(str(tag_value)))
+        else:
+            cmd = "EDIT %s SET TAG %s='%s'" % (
+                target_type, tag_name, _quote_dgmgrl_literal(str(tag_value)))
+        commands.append(cmd)
+    rc, stdout, stderr = run_dgmgrl(module, commands)
+    if rc != 0:
+        if 'not supported' in stdout.lower():
+            module.warn('Tagging not supported on this Oracle version')
+            return False
+        module.fail_json(msg='Failed to set tags: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_reset_tags(module, tag_names):
+    """Reset (remove) tags from a DGMGRL object (26ai+)."""
+    target_type, target_name = _resolve_tag_target(module)
+    commands = []
+    for tag_name in tag_names:
+        _validate_dgmgrl_tag_name(module, tag_name)
+        if target_name:
+            cmd = 'EDIT %s %s RESET TAG %s' % (target_type, target_name, tag_name)
+        else:
+            cmd = 'EDIT %s RESET TAG %s' % (target_type, tag_name)
+        commands.append(cmd)
+    rc, stdout, stderr = run_dgmgrl(module, commands)
+    if rc != 0:
+        if 'not supported' in stdout.lower():
+            module.warn('Tagging not supported on this Oracle version')
+            return False
+        module.fail_json(msg='Failed to reset tags: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_show_tags(module, output_format):
+    """Show tags on a DGMGRL object (26ai+). Returns tag output string or None."""
+    target_type, target_name = _resolve_tag_target(module)
+    if target_name:
+        cmd = 'SHOW %s %s TAG' % (target_type, target_name)
+    else:
+        cmd = 'SHOW %s TAG' % target_type
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        return None
+    return stdout
 
 
 # ============================================================================
@@ -778,6 +961,12 @@ def main():
             # Observer
             observer_state=dict(required=False, choices=['started', 'stopped']),
 
+            # 26ai features
+            validate_connect_identifier=dict(required=False),
+            primary_database_candidates=dict(required=False, type='list', elements='str'),
+            tags=dict(required=False, type='dict'),
+            reset_tags=dict(required=False, type='list', elements='str'),
+
             # Output format (26ai JSON)
             output_format=dict(default='text', choices=['text', 'json']),
 
@@ -834,14 +1023,23 @@ def _broker_status(module, database_name, output_format):
     config = dgmgrl_show_configuration(module, output_format)
     db_detail = None
     validate_result = None
+    validate_connect = None
+    tags_output = None
     if database_name:
         db_detail = dgmgrl_show_database(module, database_name, output_format)
         validate_result = dgmgrl_validate(module, database_name)
+    if module.params.get("validate_connect_identifier"):
+        validate_connect = dgmgrl_validate_connect_identifier(
+            module, module.params["validate_connect_identifier"])
+    if config.get('status') != 'NOT_CONFIGURED':
+        tags_output = dgmgrl_show_tags(module, output_format)
     module.exit_json(
         changed=False,
         configuration=config,
         database_detail=db_detail,
         validate=validate_result,
+        validate_connect_identifier=validate_connect,
+        tags=tags_output,
     )
 
 
@@ -872,12 +1070,21 @@ def _broker_present(module, database_name, output_format):
     if module.params["database_state"] and database_name:
         dgmgrl_set_state(module, database_name, module.params["database_state"])
         changed = True
+    if module.params["primary_database_candidates"]:
+        if dgmgrl_set_primary_database_candidates(module, module.params["primary_database_candidates"]):
+            changed = True
     if module.params["fsfo"]:
-        dgmgrl_manage_fsfo(module, module.params["fsfo"])
+        dgmgrl_manage_fsfo(module, module.params["fsfo"], module.params.get("fsfo_target"))
         changed = True
     if module.params["observer_state"]:
         dgmgrl_manage_observer(module, module.params["observer_state"])
         changed = True
+    if module.params["tags"]:
+        if dgmgrl_set_tags(module, module.params["tags"]):
+            changed = True
+    if module.params["reset_tags"]:
+        if dgmgrl_reset_tags(module, module.params["reset_tags"]):
+            changed = True
 
     config = dgmgrl_show_configuration(module, output_format)
     module.exit_json(changed=changed, configuration=config, msg='Data Guard configuration updated')

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -491,7 +491,9 @@ def _validate_dgmgrl_identifier(module, value, param_name):
 
 
 def _quote_dgmgrl_literal(value):
-    """Escape single quotes in a DGMGRL string literal."""
+    """Escape single quotes and reject injection characters in a DGMGRL string literal."""
+    if ';' in value or '\n' in value or '\r' in value:
+        raise ValueError("DGMGRL literal must not contain semicolons or newlines: %r" % value)
     return value.replace("'", "''")
 
 

--- a/plugins/modules/oracle_dblink.py
+++ b/plugins/modules/oracle_dblink.py
@@ -284,6 +284,14 @@ except ImportError:
     def sanitize_string_params(_params):
         pass
 
+    def sql_single_quoted_literal(value):
+        if value is None:
+            return ''
+        s = str(value)
+        if s.startswith("'") and s.endswith("'"):
+            s = s[1:-1]
+        return s.replace("'", "''")
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_gi_facts.py
+++ b/plugins/modules/oracle_gi_facts.py
@@ -254,7 +254,7 @@ def main():
     else:
         for i in ['releaseversion', 'releasepatch', 'softwareversion', 'softwarepatch']:
             version = exec_program([ohomes.crsctl, 'query', 'has', i])
-            m = re.search('\[([0-9\.]+)\]$', version)
+            m = re.search(r'\[([0-9.]+)\]$', version)
             if m:
                 facts.update({i: m.group(1)})
                 facts.update({"version": m.group(1)})  # for backward compatibility

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -216,14 +216,16 @@ def is_tablespace_encrypted(conn, tablespace_name):
     return bool(r)
 
 
-def check_prerequisites(conn, module):
+def check_prerequisites(conn, module, honor_force_keystore=False):
     """Verify that keystore is open before TDE operations.
 
-    When force_keystore is True, skip the check — the FORCE KEYSTORE clause
-    tells Oracle to use the password-based keystore even when an auto-login
-    keystore is active, so the password keystore may appear CLOSED.
+    When honor_force_keystore is True **and** force_keystore is set, skip the
+    check — the FORCE KEYSTORE clause tells Oracle to use the password-based
+    keystore even when an auto-login keystore is active, so the password
+    keystore may appear CLOSED.  Tablespace operations never emit FORCE
+    KEYSTORE, so they must always validate the keystore state.
     """
-    if module.params.get("force_keystore"):
+    if honor_force_keystore and module.params.get("force_keystore"):
         return get_wallet_status(conn)
     status = get_wallet_status(conn)
     if not status or status.get('status') not in ('OPEN', 'OPEN_NO_MASTER_KEY'):
@@ -238,7 +240,7 @@ def check_prerequisites(conn, module):
 
 def set_master_key(conn, module):
     """Create and activate a new master encryption key."""
-    check_prerequisites(conn, module)
+    check_prerequisites(conn, module, honor_force_keystore=True)
     keystore_password = module.params["keystore_password"]
     algorithm = module.params["algorithm"]
     key_tag = module.params["key_tag"]
@@ -265,7 +267,7 @@ def set_master_key(conn, module):
 
 def create_master_key(conn, module):
     """Create a master key without activating it."""
-    check_prerequisites(conn, module)
+    check_prerequisites(conn, module, honor_force_keystore=True)
     keystore_password = module.params["keystore_password"]
     algorithm = module.params["algorithm"]
     key_tag = module.params["key_tag"]
@@ -292,7 +294,7 @@ def create_master_key(conn, module):
 
 def export_keys(conn, module):
     """Export encryption keys to a file."""
-    check_prerequisites(conn, module)
+    check_prerequisites(conn, module, honor_force_keystore=True)
     keystore_password = module.params["keystore_password"]
     export_file = module.params["export_file"]
     export_secret = module.params["export_secret"]
@@ -317,7 +319,7 @@ def export_keys(conn, module):
 
 def import_keys(conn, module):
     """Import encryption keys from a file."""
-    check_prerequisites(conn, module)
+    check_prerequisites(conn, module, honor_force_keystore=True)
     keystore_password = module.params["keystore_password"]
     export_file = module.params["export_file"]
     export_secret = module.params["export_secret"]
@@ -365,7 +367,7 @@ def encrypt_tablespace(conn, module):
 
     mode = 'ONLINE' if online else 'OFFLINE'
 
-    safe_ts = '"%s"' % tablespace.replace('"', '""')
+    safe_ts = '"%s"' % tablespace.upper().replace('"', '""')
     sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (safe_ts, mode)
     if algorithm:
         sql += " USING '%s'" % algorithm
@@ -394,7 +396,7 @@ def decrypt_tablespace(conn, module):
 
     mode = 'ONLINE' if online else 'OFFLINE'
 
-    safe_ts = '"%s"' % tablespace.replace('"', '""')
+    safe_ts = '"%s"' % tablespace.upper().replace('"', '""')
     sql = "ALTER TABLESPACE %s ENCRYPTION %s DECRYPT" % (safe_ts, mode)
 
     if file_name_convert and online:
@@ -417,7 +419,7 @@ def rekey_tablespace(conn, module):
 
     mode = 'ONLINE' if online else 'OFFLINE'
 
-    safe_ts = '"%s"' % tablespace.replace('"', '""')
+    safe_ts = '"%s"' % tablespace.upper().replace('"', '""')
     sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (safe_ts, mode)
     if algorithm:
         sql += " USING '%s'" % algorithm
@@ -512,9 +514,6 @@ def main():
             encrypted_tablespaces=encrypted_ts,
         )
 
-    if module.check_mode:
-        module.exit_json(changed=False, msg='Check mode: no TDE operations executed')
-
     if state == 'present':
         # Handle encryption policy parameter
         if tablespace_encryption_policy:
@@ -573,11 +572,26 @@ try:
         oracleConnection, sanitize_string_params,
         build_backup_clause, build_container_clause, build_force_clause,
     )
-except ImportError:
+except ImportError as e:
+    HAS_ORACLE_UTILS = False
+    _oracle_utils_err = e
+
     def sanitize_string_params(module_params):
         for key, value in module_params.items():
             if isinstance(value, str):
                 module_params[key] = value.strip()
+
+    def oracleConnection(*args, **kwargs):
+        raise ImportError("oracle_utils is required: %s" % _oracle_utils_err)
+
+    def build_backup_clause(*args, **kwargs):
+        raise ImportError("oracle_utils is required: %s" % _oracle_utils_err)
+
+    def build_container_clause(*args, **kwargs):
+        raise ImportError("oracle_utils is required: %s" % _oracle_utils_err)
+
+    def build_force_clause(*args, **kwargs):
+        raise ImportError("oracle_utils is required: %s" % _oracle_utils_err)
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -447,7 +447,7 @@ def set_encryption_parameter(conn, module):
     if current and current.upper() == policy.upper():
         return  # Already set, idempotent
 
-    conn.execute_ddl("ALTER SYSTEM SET TABLESPACE_ENCRYPTION = '%s' SCOPE=BOTH" % policy)
+    conn.execute_ddl("ALTER SYSTEM SET TABLESPACE_ENCRYPTION = '%s' SCOPE=SPFILE" % policy)
 
 
 def main():

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -365,7 +365,8 @@ def encrypt_tablespace(conn, module):
 
     mode = 'ONLINE' if online else 'OFFLINE'
 
-    sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (tablespace, mode)
+    safe_ts = '"%s"' % tablespace.replace('"', '""')
+    sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (safe_ts, mode)
     if algorithm:
         sql += " USING '%s'" % algorithm
     sql += " ENCRYPT"
@@ -393,7 +394,8 @@ def decrypt_tablespace(conn, module):
 
     mode = 'ONLINE' if online else 'OFFLINE'
 
-    sql = "ALTER TABLESPACE %s ENCRYPTION %s DECRYPT" % (tablespace, mode)
+    safe_ts = '"%s"' % tablespace.replace('"', '""')
+    sql = "ALTER TABLESPACE %s ENCRYPTION %s DECRYPT" % (safe_ts, mode)
 
     if file_name_convert and online:
         pairs = ', '.join("'%s', '%s'" % (k.replace("'", "''"), v.replace("'", "''")) for k, v in file_name_convert.items())
@@ -415,7 +417,8 @@ def rekey_tablespace(conn, module):
 
     mode = 'ONLINE' if online else 'OFFLINE'
 
-    sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (tablespace, mode)
+    safe_ts = '"%s"' % tablespace.replace('"', '""')
+    sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (safe_ts, mode)
     if algorithm:
         sql += " USING '%s'" % algorithm
     sql += " REKEY"

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -168,6 +168,20 @@ EXAMPLES = '''
 '''
 
 
+import re as _re
+
+
+def _redact_ddls(ddls):
+    """Redact passwords and secrets from DDL statements before returning to user."""
+    redacted = []
+    for ddl in ddls:
+        s = _re.sub(r'(IDENTIFIED\s+BY\s+)"[^"]*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
+        s = _re.sub(r"(SECRET\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r"(USING\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        redacted.append(s)
+    return redacted
+
+
 def get_wallet_status(conn):
     """Check keystore status - prerequisite for TDE operations."""
     sql = "SELECT STATUS, WALLET_TYPE, KEYSTORE_MODE FROM V$ENCRYPTION_WALLET WHERE ROWNUM = 1"
@@ -204,7 +218,14 @@ def is_tablespace_encrypted(conn, tablespace_name):
 
 
 def check_prerequisites(conn, module):
-    """Verify that keystore is open before TDE operations."""
+    """Verify that keystore is open before TDE operations.
+
+    When force_keystore is True, skip the check — the FORCE KEYSTORE clause
+    tells Oracle to use the password-based keystore even when an auto-login
+    keystore is active, so the password keystore may appear CLOSED.
+    """
+    if module.params.get("force_keystore"):
+        return get_wallet_status(conn)
     status = get_wallet_status(conn)
     if not status or status.get('status') not in ('OPEN', 'OPEN_NO_MASTER_KEY'):
         module.fail_json(
@@ -520,26 +541,26 @@ def main():
         encrypted_ts = get_encrypted_tablespaces(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='TDE operations completed successfully',
             master_key=master_key,
             encrypted_tablespaces=encrypted_ts,
         )
 
     elif state == 'absent':
-        # Decrypt tablespace if specified
-        if tablespace_state == 'decrypted' or module.params["tablespace"]:
-            decrypt_tablespace(conn, module)
-            encrypted_ts = get_encrypted_tablespaces(conn)
-            module.exit_json(
-                changed=conn.changed,
-                ddls=conn.ddls,
-                msg='Tablespace decryption completed',
-                encrypted_tablespaces=encrypted_ts,
+        # Decrypt tablespace — requires tablespace parameter
+        if not module.params["tablespace"]:
+            module.fail_json(
+                msg='state=absent requires a tablespace to decrypt',
+                changed=False,
             )
-        module.fail_json(
-            msg='state=absent requires a tablespace to decrypt',
-            changed=False,
+        decrypt_tablespace(conn, module)
+        encrypted_ts = get_encrypted_tablespaces(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=_redact_ddls(conn.ddls),
+            msg='Tablespace decryption completed',
+            encrypted_tablespaces=encrypted_ts,
         )
 
 

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -287,8 +287,10 @@ def export_keys(conn, module):
 
     force = build_force_clause(force_keystore)
 
+    safe_secret = export_secret.replace("'", "''")
+    safe_file = export_file.replace("'", "''")
     sql = "ADMINISTER KEY MANAGEMENT %sEXPORT KEYS WITH SECRET '%s' TO '%s' IDENTIFIED BY \"%s\"" % (
-        force, export_secret, export_file, keystore_password
+        force, safe_secret, safe_file, keystore_password
     )
     conn.execute_ddl(sql)
 
@@ -310,8 +312,10 @@ def import_keys(conn, module):
 
     force = build_force_clause(force_keystore)
 
+    safe_secret = export_secret.replace("'", "''")
+    safe_file = export_file.replace("'", "''")
     sql = "ADMINISTER KEY MANAGEMENT %sIMPORT KEYS WITH SECRET '%s' FROM '%s' IDENTIFIED BY \"%s\"%s" % (
-        force, export_secret, export_file, keystore_password, build_backup_clause()
+        force, safe_secret, safe_file, keystore_password, build_backup_clause()
     )
     conn.execute_ddl(sql)
 
@@ -485,7 +489,10 @@ def main():
             encrypted_tablespaces=encrypted_ts,
         )
 
-    elif state == 'present':
+    if module.check_mode:
+        module.exit_json(changed=False, msg='Check mode: no TDE operations executed')
+
+    if state == 'present':
         # Handle encryption policy parameter
         if tablespace_encryption_policy:
             set_encryption_parameter(conn, module)
@@ -544,8 +551,10 @@ try:
         build_backup_clause, build_container_clause, build_force_clause,
     )
 except ImportError:
-    def sanitize_string_params(_params):
-        pass
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -441,8 +441,10 @@ def set_encryption_parameter(conn, module):
 
     container = module.params["container"]
 
-    # Check current value
-    sql = "SELECT VALUE FROM V$PARAMETER WHERE NAME = 'tablespace_encryption'"
+    # Check the SPFILE value, not the in-memory value.  TABLESPACE_ENCRYPTION
+    # is a static parameter so V$PARAMETER keeps the old value until restart.
+    sql = ("SELECT VALUE FROM V$SPPARAMETER"
+           " WHERE NAME = 'tablespace_encryption' AND ISSPECIFIED = 'TRUE'")
     r = conn.execute_select_to_dict(sql, fetchone=True)
     current = r.get('value', '') if r else ''
 

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -573,7 +573,6 @@ try:
         build_backup_clause, build_container_clause, build_force_clause,
     )
 except ImportError as e:
-    HAS_ORACLE_UTILS = False
     _oracle_utils_err = e
 
     def sanitize_string_params(module_params):

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -216,21 +216,6 @@ def check_prerequisites(conn, module):
     return status
 
 
-def build_force_clause(force_keystore):
-    """Build FORCE KEYSTORE clause."""
-    return 'FORCE KEYSTORE ' if force_keystore else ''
-
-
-def build_container_clause(container):
-    """Build CONTAINER clause."""
-    return ' CONTAINER = ALL' if container == 'all' else ''
-
-
-def build_backup_clause():
-    """Build WITH BACKUP clause."""
-    return ' WITH BACKUP'
-
-
 def set_master_key(conn, module):
     """Create and activate a new master encryption key."""
     check_prerequisites(conn, module)
@@ -556,6 +541,7 @@ from ansible.module_utils.basic import *  # noqa: F403
 try:
     from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
         oracleConnection, sanitize_string_params,
+        build_backup_clause, build_container_clause, build_force_clause,
     )
 except ImportError:
     def sanitize_string_params(_params):

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -177,7 +177,7 @@ def _redact_ddls(ddls):
     for ddl in ddls:
         s = _re.sub(r'(IDENTIFIED\s+BY\s+)"[^"]*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
         s = _re.sub(r"(SECRET\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
-        s = _re.sub(r"(USING\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r"(USING\s+TAG\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
         redacted.append(s)
     return redacted
 
@@ -256,7 +256,7 @@ def set_master_key(conn, module):
     if algorithm:
         sql += " USING ALGORITHM '%s'" % algorithm
     if key_tag:
-        sql += " USING TAG '%s'" % key_tag
+        sql += " USING TAG '%s'" % key_tag.replace("'", "''")
     sql += " IDENTIFIED BY \"%s\"" % keystore_password
     sql += build_backup_clause()
     sql += container_clause
@@ -283,7 +283,7 @@ def create_master_key(conn, module):
     if algorithm:
         sql += " USING ALGORITHM '%s'" % algorithm
     if key_tag:
-        sql += " USING TAG '%s'" % key_tag
+        sql += " USING TAG '%s'" % key_tag.replace("'", "''")
     sql += " IDENTIFIED BY \"%s\"" % keystore_password
     sql += build_backup_clause()
     sql += container_clause

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -568,6 +568,15 @@ def main():
 
 from ansible.module_utils.basic import *  # noqa: F403
 
+# In these we do import from local project sub-directory <project-dir>/module_utils
+# While this file is placed in <project-dir>/library
+# No collections are used
+#try:
+#    from ansible.module_utils.oracle_utils import oracleConnection
+#except:
+#    pass
+
+# In these we do import from collections
 try:
     from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
         oracleConnection, sanitize_string_params,

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -177,7 +177,6 @@ def _redact_ddls(ddls):
     for ddl in ddls:
         s = _re.sub(r'(IDENTIFIED\s+BY\s+)"[^"]*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
         s = _re.sub(r"(SECRET\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
-        s = _re.sub(r"(USING\s+TAG\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
         redacted.append(s)
     return redacted
 

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -370,7 +370,7 @@ def encrypt_tablespace(conn, module):
 
     safe_ts = '"%s"' % tablespace.upper().replace('"', '""')
     sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (safe_ts, mode)
-    if algorithm:
+    if algorithm and online:
         sql += " USING '%s'" % algorithm
     sql += " ENCRYPT"
 
@@ -422,7 +422,7 @@ def rekey_tablespace(conn, module):
 
     safe_ts = '"%s"' % tablespace.upper().replace('"', '""')
     sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (safe_ts, mode)
-    if algorithm:
+    if algorithm and online:
         sql += " USING '%s'" % algorithm
     sql += " REKEY"
 

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -370,7 +370,7 @@ def encrypt_tablespace(conn, module):
 
     safe_ts = '"%s"' % tablespace.upper().replace('"', '""')
     sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (safe_ts, mode)
-    if algorithm and online:
+    if algorithm:
         sql += " USING '%s'" % algorithm
     sql += " ENCRYPT"
 
@@ -422,7 +422,7 @@ def rekey_tablespace(conn, module):
 
     safe_ts = '"%s"' % tablespace.upper().replace('"', '""')
     sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (safe_ts, mode)
-    if algorithm and online:
+    if algorithm:
         sql += " USING '%s'" % algorithm
     sql += " REKEY"
 

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -260,7 +260,7 @@ def set_master_key(conn, module):
     sql += build_backup_clause()
     sql += container_clause
 
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddls([sql])[0])
 
 
 def create_master_key(conn, module):
@@ -287,7 +287,7 @@ def create_master_key(conn, module):
     sql += build_backup_clause()
     sql += container_clause
 
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddls([sql])[0])
 
 
 def export_keys(conn, module):
@@ -312,7 +312,7 @@ def export_keys(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT %sEXPORT KEYS WITH SECRET '%s' TO '%s' IDENTIFIED BY \"%s\"" % (
         force, safe_secret, safe_file, keystore_password.replace('"', '""')
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddls([sql])[0])
 
 
 def import_keys(conn, module):
@@ -337,7 +337,7 @@ def import_keys(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT %sIMPORT KEYS WITH SECRET '%s' FROM '%s' IDENTIFIED BY \"%s\"%s" % (
         force, safe_secret, safe_file, keystore_password.replace('"', '""'), build_backup_clause()
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddls([sql])[0])
 
 
 def encrypt_tablespace(conn, module):

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -66,9 +66,10 @@ options:
   tablespace_encryption_policy:
     description:
       - Database-level tablespace encryption policy parameter
-      - AUTO_ENABLE encrypts all new tablespaces automatically (26ai)
-      - DDL requires explicit ENCRYPTION clause in CREATE TABLESPACE
-    choices: ['AUTO_ENABLE', 'MANUAL_ENABLE', 'DECRYPT_ONLY', 'DDL']
+      - AUTO_ENABLE encrypts all new tablespaces automatically
+      - MANUAL_ENABLE requires explicit ENCRYPTION clause in CREATE TABLESPACE
+      - DECRYPT_ONLY allows decryption but prevents new encryption
+    choices: ['AUTO_ENABLE', 'MANUAL_ENABLE', 'DECRYPT_ONLY']
     required: false
   force_keystore:
     description: Use FORCE KEYSTORE clause (temporarily opens auto-login keystore)
@@ -483,7 +484,7 @@ def main():
 
             tablespace_encryption_policy=dict(required=False,
                                               choices=['AUTO_ENABLE', 'MANUAL_ENABLE',
-                                                       'DECRYPT_ONLY', 'DDL']),
+                                                       'DECRYPT_ONLY']),
 
             force_keystore=dict(default=False, type='bool'),
             container=dict(default='current', choices=['current', 'all']),

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -439,6 +439,8 @@ def set_encryption_parameter(conn, module):
     if not policy:
         return
 
+    container = module.params["container"]
+
     # Check current value
     sql = "SELECT VALUE FROM V$PARAMETER WHERE NAME = 'tablespace_encryption'"
     r = conn.execute_select_to_dict(sql, fetchone=True)
@@ -447,7 +449,8 @@ def set_encryption_parameter(conn, module):
     if current and current.upper() == policy.upper():
         return  # Already set, idempotent
 
-    conn.execute_ddl("ALTER SYSTEM SET TABLESPACE_ENCRYPTION = '%s' SCOPE=SPFILE" % policy)
+    container_clause = build_container_clause(container)
+    conn.execute_ddl("ALTER SYSTEM SET TABLESPACE_ENCRYPTION = '%s' SCOPE=SPFILE%s" % (policy, container_clause))
 
 
 def main():

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -1,0 +1,565 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: oracle_tde
+short_description: Manage Oracle Transparent Data Encryption (TDE)
+description:
+  - Manage TDE master encryption keys (create, activate, rotate)
+  - Encrypt/decrypt tablespaces (online and offline)
+  - Query encryption status of tablespaces and keys
+  - Export and import encryption keys
+  - Configure TDE-related database parameters
+  - Supports multitenant (CDB/PDB) environments
+  - Compatible with Oracle 19c, 23ai, and 26ai
+  - In Oracle 26ai, AES256 is the default algorithm, AES-XTS for tablespace, GCM for column
+  - 3DES168, GOST256, and SEED128 are desupported in Oracle 26ai
+  - Does NOT manage the keystore itself (use oracle_wallet for that)
+  - See connection parameters for oracle_ping
+version_added: "3.4.0"
+options:
+  state:
+    description: The intended state
+    default: present
+    choices: ['present', 'absent', 'status']
+  master_key_action:
+    description: Action to perform on master encryption key
+    choices: ['set_key', 'rotate_key', 'create_key', 'export_keys', 'import_keys']
+    required: false
+  algorithm:
+    description:
+      - Encryption algorithm for master key or tablespace encryption
+      - AES256 is the default and recommended algorithm
+      - 3DES168, GOST256, SEED128 are desupported in Oracle 26ai
+    default: AES256
+    choices: ['AES128', 'AES192', 'AES256', 'ARIA128', 'ARIA192', 'ARIA256']
+  key_tag:
+    description: User-defined tag for the master encryption key
+    required: false
+  keystore_password:
+    description: Password for the keystore (required for most operations)
+    required: false
+  tablespace:
+    description: Name of the tablespace to encrypt, decrypt, or rekey
+    required: false
+  tablespace_state:
+    description: Desired encryption state of the tablespace
+    choices: ['encrypted', 'decrypted', 'rekeyed']
+    required: false
+  file_name_convert:
+    description:
+      - Dictionary mapping old datafile names to new names for online conversion
+      - "Example: {'old_file.dbf': 'new_file.dbf'}"
+    type: dict
+    required: false
+  online:
+    description: Whether to perform online (true) or offline (false) tablespace conversion
+    default: true
+    type: bool
+  export_file:
+    description: File path for key export/import operations
+    required: false
+  export_secret:
+    description: Secret passphrase for key export/import file encryption
+    required: false
+  tablespace_encryption_policy:
+    description:
+      - Database-level tablespace encryption policy parameter
+      - AUTO_ENABLE encrypts all new tablespaces automatically (26ai)
+      - DDL requires explicit ENCRYPTION clause in CREATE TABLESPACE
+    choices: ['AUTO_ENABLE', 'MANUAL_ENABLE', 'DECRYPT_ONLY', 'DDL']
+    required: false
+  force_keystore:
+    description: Use FORCE KEYSTORE clause (temporarily opens auto-login keystore)
+    default: false
+    type: bool
+  container:
+    description: Container clause for multitenant environments
+    default: current
+    choices: ['current', 'all']
+notes:
+  - The keystore must be open before most TDE operations (use oracle_wallet state=open)
+  - A master encryption key must exist before encrypting tablespaces
+  - oracledb Python module is required
+  - Requires ADMINISTER KEY MANAGEMENT or SYSKM privilege
+requirements: [ "oracledb" ]
+author:
+  - Cyrille Modiano
+'''
+
+EXAMPLES = '''
+- name: Create and activate a master encryption key
+  oracle_tde:
+    mode: sysdba
+    master_key_action: set_key
+    keystore_password: "MyKeystorePass123"
+
+- name: Create a master key with specific algorithm and tag
+  oracle_tde:
+    mode: sysdba
+    master_key_action: set_key
+    algorithm: AES256
+    key_tag: "production_key_2024"
+    keystore_password: "MyKeystorePass123"
+
+- name: Rotate the master encryption key
+  oracle_tde:
+    mode: sysdba
+    master_key_action: rotate_key
+    keystore_password: "MyKeystorePass123"
+
+- name: Encrypt a tablespace online
+  oracle_tde:
+    mode: sysdba
+    tablespace: USERS
+    tablespace_state: encrypted
+    algorithm: AES256
+    keystore_password: "MyKeystorePass123"
+
+- name: Decrypt a tablespace online
+  oracle_tde:
+    mode: sysdba
+    tablespace: USERS
+    tablespace_state: decrypted
+    keystore_password: "MyKeystorePass123"
+
+- name: Rekey a tablespace with a new algorithm
+  oracle_tde:
+    mode: sysdba
+    tablespace: USERS
+    tablespace_state: rekeyed
+    algorithm: AES256
+    keystore_password: "MyKeystorePass123"
+
+- name: Export encryption keys
+  oracle_tde:
+    mode: sysdba
+    master_key_action: export_keys
+    export_file: /tmp/keys_export.exp
+    export_secret: "ExportSecret123"
+    keystore_password: "MyKeystorePass123"
+
+- name: Import encryption keys
+  oracle_tde:
+    mode: sysdba
+    master_key_action: import_keys
+    export_file: /tmp/keys_export.exp
+    export_secret: "ExportSecret123"
+    keystore_password: "MyKeystorePass123"
+
+- name: Set tablespace encryption policy to AUTO_ENABLE (26ai)
+  oracle_tde:
+    mode: sysdba
+    tablespace_encryption_policy: AUTO_ENABLE
+
+- name: Get TDE status
+  oracle_tde:
+    mode: sysdba
+    state: status
+  register: tde_info
+
+- name: Create and activate key for all PDBs
+  oracle_tde:
+    mode: sysdba
+    master_key_action: set_key
+    keystore_password: "MyKeystorePass123"
+    container: all
+'''
+
+
+def get_wallet_status(conn):
+    """Check keystore status - prerequisite for TDE operations."""
+    sql = "SELECT STATUS, WALLET_TYPE, KEYSTORE_MODE FROM V$ENCRYPTION_WALLET WHERE ROWNUM = 1"
+    return conn.execute_select_to_dict(sql, fetchone=True)
+
+
+def get_active_master_key(conn):
+    """Get the currently active master encryption key."""
+    sql = """SELECT KEY_ID, TAG, CREATION_TIME, ACTIVATION_TIME, KEY_USE, KEYSTORE_TYPE, ORIGIN
+             FROM V$ENCRYPTION_KEYS
+             WHERE ACTIVATION_TIME IS NOT NULL
+             ORDER BY ACTIVATION_TIME DESC"""
+    rows = conn.execute_select_to_dict(sql)
+    return rows[0] if rows else {}
+
+
+def get_encrypted_tablespaces(conn):
+    """Get list of encrypted tablespaces with their encryption details."""
+    sql = """SELECT t.NAME AS TABLESPACE_NAME, e.ENCRYPTIONALG, e.ENCRYPTEDTS, e.STATUS, e.KEY_VERSION
+             FROM V$ENCRYPTED_TABLESPACES e
+             JOIN V$TABLESPACE t ON e.TS# = t.TS#"""
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def is_tablespace_encrypted(conn, tablespace_name):
+    """Check if a specific tablespace is encrypted."""
+    sql = """SELECT e.ENCRYPTIONALG, e.ENCRYPTEDTS, e.STATUS
+             FROM V$ENCRYPTED_TABLESPACES e
+             JOIN V$TABLESPACE t ON e.TS# = t.TS#
+             WHERE UPPER(t.NAME) = UPPER(:tablespace)
+             AND e.ENCRYPTEDTS = 'YES'"""
+    r = conn.execute_select_to_dict(sql, {'tablespace': tablespace_name}, fetchone=True)
+    return bool(r)
+
+
+def check_prerequisites(conn, module):
+    """Verify that keystore is open before TDE operations."""
+    status = get_wallet_status(conn)
+    if not status or status.get('status') not in ('OPEN', 'OPEN_NO_MASTER_KEY'):
+        module.fail_json(
+            msg='Keystore is not open (status: %s). Use oracle_wallet state=open first.' % (
+                status.get('status', 'UNKNOWN') if status else 'NOT_AVAILABLE'
+            ),
+            changed=False
+        )
+    return status
+
+
+def build_force_clause(force_keystore):
+    """Build FORCE KEYSTORE clause."""
+    return 'FORCE KEYSTORE ' if force_keystore else ''
+
+
+def build_container_clause(container):
+    """Build CONTAINER clause."""
+    return ' CONTAINER = ALL' if container == 'all' else ''
+
+
+def build_backup_clause():
+    """Build WITH BACKUP clause."""
+    return ' WITH BACKUP'
+
+
+def set_master_key(conn, module):
+    """Create and activate a new master encryption key."""
+    check_prerequisites(conn, module)
+    keystore_password = module.params["keystore_password"]
+    algorithm = module.params["algorithm"]
+    key_tag = module.params["key_tag"]
+    force_keystore = module.params["force_keystore"]
+    container = module.params["container"]
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required for set_key', changed=False)
+
+    force = build_force_clause(force_keystore)
+    container_clause = build_container_clause(container)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sSET KEY" % force
+    if algorithm:
+        sql += " USING ALGORITHM '%s'" % algorithm
+    if key_tag:
+        sql += " USING TAG '%s'" % key_tag
+    sql += " IDENTIFIED BY \"%s\"" % keystore_password
+    sql += build_backup_clause()
+    sql += container_clause
+
+    conn.execute_ddl(sql)
+
+
+def create_master_key(conn, module):
+    """Create a master key without activating it."""
+    check_prerequisites(conn, module)
+    keystore_password = module.params["keystore_password"]
+    algorithm = module.params["algorithm"]
+    key_tag = module.params["key_tag"]
+    force_keystore = module.params["force_keystore"]
+    container = module.params["container"]
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required for create_key', changed=False)
+
+    force = build_force_clause(force_keystore)
+    container_clause = build_container_clause(container)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sCREATE KEY" % force
+    if algorithm:
+        sql += " USING ALGORITHM '%s'" % algorithm
+    if key_tag:
+        sql += " USING TAG '%s'" % key_tag
+    sql += " IDENTIFIED BY \"%s\"" % keystore_password
+    sql += build_backup_clause()
+    sql += container_clause
+
+    conn.execute_ddl(sql)
+
+
+def export_keys(conn, module):
+    """Export encryption keys to a file."""
+    check_prerequisites(conn, module)
+    keystore_password = module.params["keystore_password"]
+    export_file = module.params["export_file"]
+    export_secret = module.params["export_secret"]
+    force_keystore = module.params["force_keystore"]
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required for export_keys', changed=False)
+    if not export_file:
+        module.fail_json(msg='export_file is required for export_keys', changed=False)
+    if not export_secret:
+        module.fail_json(msg='export_secret is required for export_keys', changed=False)
+
+    force = build_force_clause(force_keystore)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sEXPORT KEYS WITH SECRET '%s' TO '%s' IDENTIFIED BY \"%s\"" % (
+        force, export_secret, export_file, keystore_password
+    )
+    conn.execute_ddl(sql)
+
+
+def import_keys(conn, module):
+    """Import encryption keys from a file."""
+    check_prerequisites(conn, module)
+    keystore_password = module.params["keystore_password"]
+    export_file = module.params["export_file"]
+    export_secret = module.params["export_secret"]
+    force_keystore = module.params["force_keystore"]
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required for import_keys', changed=False)
+    if not export_file:
+        module.fail_json(msg='export_file is required for import_keys', changed=False)
+    if not export_secret:
+        module.fail_json(msg='export_secret is required for import_keys', changed=False)
+
+    force = build_force_clause(force_keystore)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sIMPORT KEYS WITH SECRET '%s' FROM '%s' IDENTIFIED BY \"%s\"%s" % (
+        force, export_secret, export_file, keystore_password, build_backup_clause()
+    )
+    conn.execute_ddl(sql)
+
+
+def encrypt_tablespace(conn, module):
+    """Encrypt a tablespace."""
+    check_prerequisites(conn, module)
+    tablespace = module.params["tablespace"]
+    algorithm = module.params["algorithm"]
+    online = module.params["online"]
+    file_name_convert = module.params["file_name_convert"]
+
+    if not tablespace:
+        module.fail_json(msg='tablespace is required for encryption', changed=False)
+
+    # Check if already encrypted
+    if is_tablespace_encrypted(conn, tablespace):
+        return  # Already encrypted, idempotent
+
+    # Verify master key exists
+    key = get_active_master_key(conn)
+    if not key:
+        module.fail_json(
+            msg='No active master key found. Use master_key_action=set_key first.',
+            changed=False
+        )
+
+    mode = 'ONLINE' if online else 'OFFLINE'
+
+    sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (tablespace, mode)
+    if algorithm:
+        sql += " USING '%s'" % algorithm
+    sql += " ENCRYPT"
+
+    if file_name_convert and online:
+        pairs = ', '.join("'%s', '%s'" % (k, v) for k, v in file_name_convert.items())
+        sql += " FILE_NAME_CONVERT = (%s)" % pairs
+
+    conn.execute_ddl(sql)
+
+
+def decrypt_tablespace(conn, module):
+    """Decrypt a tablespace."""
+    check_prerequisites(conn, module)
+    tablespace = module.params["tablespace"]
+    online = module.params["online"]
+    file_name_convert = module.params["file_name_convert"]
+
+    if not tablespace:
+        module.fail_json(msg='tablespace is required for decryption', changed=False)
+
+    # Check if already decrypted
+    if not is_tablespace_encrypted(conn, tablespace):
+        return  # Already decrypted, idempotent
+
+    mode = 'ONLINE' if online else 'OFFLINE'
+
+    sql = "ALTER TABLESPACE %s ENCRYPTION %s DECRYPT" % (tablespace, mode)
+
+    if file_name_convert and online:
+        pairs = ', '.join("'%s', '%s'" % (k, v) for k, v in file_name_convert.items())
+        sql += " FILE_NAME_CONVERT = (%s)" % pairs
+
+    conn.execute_ddl(sql)
+
+
+def rekey_tablespace(conn, module):
+    """Rekey a tablespace (change encryption key/algorithm)."""
+    check_prerequisites(conn, module)
+    tablespace = module.params["tablespace"]
+    algorithm = module.params["algorithm"]
+    online = module.params["online"]
+    file_name_convert = module.params["file_name_convert"]
+
+    if not tablespace:
+        module.fail_json(msg='tablespace is required for rekeying', changed=False)
+
+    mode = 'ONLINE' if online else 'OFFLINE'
+
+    sql = "ALTER TABLESPACE %s ENCRYPTION %s" % (tablespace, mode)
+    if algorithm:
+        sql += " USING '%s'" % algorithm
+    sql += " REKEY"
+
+    if file_name_convert and online:
+        pairs = ', '.join("'%s', '%s'" % (k, v) for k, v in file_name_convert.items())
+        sql += " FILE_NAME_CONVERT = (%s)" % pairs
+
+    conn.execute_ddl(sql)
+
+
+def set_encryption_parameter(conn, module):
+    """Set tablespace encryption policy parameter."""
+    policy = module.params["tablespace_encryption_policy"]
+    if not policy:
+        return
+
+    # Check current value
+    sql = "SELECT VALUE FROM V$PARAMETER WHERE NAME = 'tablespace_encryption'"
+    r = conn.execute_select_to_dict(sql, fetchone=True)
+    current = r.get('value', '') if r else ''
+
+    if current and current.upper() == policy.upper():
+        return  # Already set, idempotent
+
+    conn.execute_ddl("ALTER SYSTEM SET TABLESPACE_ENCRYPTION = '%s' SCOPE=BOTH" % policy)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            user=dict(required=False, aliases=['un', 'username']),
+            password=dict(required=False, no_log=True, aliases=['pw']),
+            mode=dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            hostname=dict(required=False, default='localhost', aliases=['host']),
+            port=dict(required=False, default=1521, type='int'),
+            service_name=dict(required=False, aliases=['sn']),
+            dsn=dict(required=False, aliases=['datasource_name']),
+            oracle_home=dict(required=False, aliases=['oh']),
+            session_container=dict(required=False),
+
+            state=dict(default="present", choices=["present", "absent", "status"]),
+            master_key_action=dict(required=False,
+                                   choices=['set_key', 'rotate_key', 'create_key',
+                                            'export_keys', 'import_keys']),
+            algorithm=dict(default='AES256',
+                          choices=['AES128', 'AES192', 'AES256',
+                                   'ARIA128', 'ARIA192', 'ARIA256']),
+            key_tag=dict(required=False),
+            keystore_password=dict(required=False, no_log=True),
+
+            tablespace=dict(required=False),
+            tablespace_state=dict(required=False,
+                                  choices=['encrypted', 'decrypted', 'rekeyed']),
+            file_name_convert=dict(required=False, type='dict'),
+            online=dict(default=True, type='bool'),
+
+            export_file=dict(required=False),
+            export_secret=dict(required=False, no_log=True),
+
+            tablespace_encryption_policy=dict(required=False,
+                                              choices=['AUTO_ENABLE', 'MANUAL_ENABLE',
+                                                       'DECRYPT_ONLY', 'DDL']),
+
+            force_keystore=dict(default=False, type='bool'),
+            container=dict(default='current', choices=['current', 'all']),
+        ),
+        required_if=[
+            ('master_key_action', 'export_keys', ('export_file', 'export_secret')),
+            ('master_key_action', 'import_keys', ('export_file', 'export_secret')),
+        ],
+        supports_check_mode=True,
+    )
+    sanitize_string_params(module.params)
+
+    state = module.params["state"]
+    master_key_action = module.params["master_key_action"]
+    tablespace_state = module.params["tablespace_state"]
+    tablespace_encryption_policy = module.params["tablespace_encryption_policy"]
+
+    conn = oracleConnection(module)
+
+    if state == 'status':
+        wallet = get_wallet_status(conn)
+        master_key = get_active_master_key(conn)
+        encrypted_ts = get_encrypted_tablespaces(conn)
+        module.exit_json(
+            changed=False,
+            wallet_status=wallet.get('status', '') if wallet else '',
+            master_key=master_key,
+            encrypted_tablespaces=encrypted_ts,
+        )
+
+    elif state == 'present':
+        # Handle encryption policy parameter
+        if tablespace_encryption_policy:
+            set_encryption_parameter(conn, module)
+
+        # Handle master key operations
+        if master_key_action in ('set_key', 'rotate_key'):
+            set_master_key(conn, module)
+        elif master_key_action == 'create_key':
+            create_master_key(conn, module)
+        elif master_key_action == 'export_keys':
+            export_keys(conn, module)
+        elif master_key_action == 'import_keys':
+            import_keys(conn, module)
+
+        # Handle tablespace encryption
+        if tablespace_state == 'encrypted':
+            encrypt_tablespace(conn, module)
+        elif tablespace_state == 'decrypted':
+            decrypt_tablespace(conn, module)
+        elif tablespace_state == 'rekeyed':
+            rekey_tablespace(conn, module)
+
+        # Gather final status
+        master_key = get_active_master_key(conn)
+        encrypted_ts = get_encrypted_tablespaces(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='TDE operations completed successfully',
+            master_key=master_key,
+            encrypted_tablespaces=encrypted_ts,
+        )
+
+    elif state == 'absent':
+        # Decrypt tablespace if specified
+        if tablespace_state == 'decrypted' or module.params["tablespace"]:
+            decrypt_tablespace(conn, module)
+            encrypted_ts = get_encrypted_tablespaces(conn)
+            module.exit_json(
+                changed=conn.changed,
+                ddls=conn.ddls,
+                msg='Tablespace decryption completed',
+                encrypted_tablespaces=encrypted_ts,
+            )
+        module.fail_json(
+            msg='state=absent requires a tablespace to decrypt',
+            changed=False,
+        )
+
+
+from ansible.module_utils.basic import *  # noqa: F403
+
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(_params):
+        pass
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -254,12 +254,12 @@ def set_master_key(conn, module):
     force = build_force_clause(force_keystore)
     container_clause = build_container_clause(container)
 
-    sql = "ADMINISTER KEY MANAGEMENT %sSET KEY" % force
+    sql = "ADMINISTER KEY MANAGEMENT SET KEY"
     if algorithm:
         sql += " USING ALGORITHM '%s'" % algorithm
     if key_tag:
         sql += " USING TAG '%s'" % key_tag.replace("'", "''")
-    sql += " IDENTIFIED BY \"%s\"" % keystore_password.replace('"', '""')
+    sql += " %sIDENTIFIED BY \"%s\"" % (force, keystore_password.replace('"', '""'))
     sql += build_backup_clause()
     sql += container_clause
 
@@ -281,12 +281,12 @@ def create_master_key(conn, module):
     force = build_force_clause(force_keystore)
     container_clause = build_container_clause(container)
 
-    sql = "ADMINISTER KEY MANAGEMENT %sCREATE KEY" % force
+    sql = "ADMINISTER KEY MANAGEMENT CREATE KEY"
     if algorithm:
         sql += " USING ALGORITHM '%s'" % algorithm
     if key_tag:
         sql += " USING TAG '%s'" % key_tag.replace("'", "''")
-    sql += " IDENTIFIED BY \"%s\"" % keystore_password.replace('"', '""')
+    sql += " %sIDENTIFIED BY \"%s\"" % (force, keystore_password.replace('"', '""'))
     sql += build_backup_clause()
     sql += container_clause
 
@@ -312,8 +312,8 @@ def export_keys(conn, module):
 
     safe_secret = export_secret.replace("'", "''")
     safe_file = export_file.replace("'", "''")
-    sql = "ADMINISTER KEY MANAGEMENT %sEXPORT KEYS WITH SECRET '%s' TO '%s' IDENTIFIED BY \"%s\"" % (
-        force, safe_secret, safe_file, keystore_password.replace('"', '""')
+    sql = "ADMINISTER KEY MANAGEMENT EXPORT KEYS WITH SECRET '%s' TO '%s' %sIDENTIFIED BY \"%s\"" % (
+        safe_secret, safe_file, force, keystore_password.replace('"', '""')
     )
     conn.execute_ddl(sql, ddls_entry=_redact_ddls([sql])[0])
 
@@ -337,8 +337,8 @@ def import_keys(conn, module):
 
     safe_secret = export_secret.replace("'", "''")
     safe_file = export_file.replace("'", "''")
-    sql = "ADMINISTER KEY MANAGEMENT %sIMPORT KEYS WITH SECRET '%s' FROM '%s' IDENTIFIED BY \"%s\"%s" % (
-        force, safe_secret, safe_file, keystore_password.replace('"', '""'), build_backup_clause()
+    sql = "ADMINISTER KEY MANAGEMENT IMPORT KEYS WITH SECRET '%s' FROM '%s' %sIDENTIFIED BY \"%s\"%s" % (
+        safe_secret, safe_file, force, keystore_password.replace('"', '""'), build_backup_clause()
     )
     conn.execute_ddl(sql, ddls_entry=_redact_ddls([sql])[0])
 

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -256,7 +256,7 @@ def set_master_key(conn, module):
         sql += " USING ALGORITHM '%s'" % algorithm
     if key_tag:
         sql += " USING TAG '%s'" % key_tag.replace("'", "''")
-    sql += " IDENTIFIED BY \"%s\"" % keystore_password
+    sql += " IDENTIFIED BY \"%s\"" % keystore_password.replace('"', '""')
     sql += build_backup_clause()
     sql += container_clause
 
@@ -283,7 +283,7 @@ def create_master_key(conn, module):
         sql += " USING ALGORITHM '%s'" % algorithm
     if key_tag:
         sql += " USING TAG '%s'" % key_tag.replace("'", "''")
-    sql += " IDENTIFIED BY \"%s\"" % keystore_password
+    sql += " IDENTIFIED BY \"%s\"" % keystore_password.replace('"', '""')
     sql += build_backup_clause()
     sql += container_clause
 
@@ -310,7 +310,7 @@ def export_keys(conn, module):
     safe_secret = export_secret.replace("'", "''")
     safe_file = export_file.replace("'", "''")
     sql = "ADMINISTER KEY MANAGEMENT %sEXPORT KEYS WITH SECRET '%s' TO '%s' IDENTIFIED BY \"%s\"" % (
-        force, safe_secret, safe_file, keystore_password
+        force, safe_secret, safe_file, keystore_password.replace('"', '""')
     )
     conn.execute_ddl(sql)
 
@@ -335,7 +335,7 @@ def import_keys(conn, module):
     safe_secret = export_secret.replace("'", "''")
     safe_file = export_file.replace("'", "''")
     sql = "ADMINISTER KEY MANAGEMENT %sIMPORT KEYS WITH SECRET '%s' FROM '%s' IDENTIFIED BY \"%s\"%s" % (
-        force, safe_secret, safe_file, keystore_password, build_backup_clause()
+        force, safe_secret, safe_file, keystore_password.replace('"', '""'), build_backup_clause()
     )
     conn.execute_ddl(sql)
 
@@ -371,7 +371,7 @@ def encrypt_tablespace(conn, module):
     sql += " ENCRYPT"
 
     if file_name_convert and online:
-        pairs = ', '.join("'%s', '%s'" % (k, v) for k, v in file_name_convert.items())
+        pairs = ', '.join("'%s', '%s'" % (k.replace("'", "''"), v.replace("'", "''")) for k, v in file_name_convert.items())
         sql += " FILE_NAME_CONVERT = (%s)" % pairs
 
     conn.execute_ddl(sql)
@@ -396,7 +396,7 @@ def decrypt_tablespace(conn, module):
     sql = "ALTER TABLESPACE %s ENCRYPTION %s DECRYPT" % (tablespace, mode)
 
     if file_name_convert and online:
-        pairs = ', '.join("'%s', '%s'" % (k, v) for k, v in file_name_convert.items())
+        pairs = ', '.join("'%s', '%s'" % (k.replace("'", "''"), v.replace("'", "''")) for k, v in file_name_convert.items())
         sql += " FILE_NAME_CONVERT = (%s)" % pairs
 
     conn.execute_ddl(sql)
@@ -421,7 +421,7 @@ def rekey_tablespace(conn, module):
     sql += " REKEY"
 
     if file_name_convert and online:
-        pairs = ', '.join("'%s', '%s'" % (k, v) for k, v in file_name_convert.items())
+        pairs = ', '.join("'%s', '%s'" % (k.replace("'", "''"), v.replace("'", "''")) for k, v in file_name_convert.items())
         sql += " FILE_NAME_CONVERT = (%s)" % pairs
 
     conn.execute_ddl(sql)

--- a/plugins/modules/oracle_tde.py
+++ b/plugins/modules/oracle_tde.py
@@ -175,8 +175,8 @@ def _redact_ddls(ddls):
     """Redact passwords and secrets from DDL statements before returning to user."""
     redacted = []
     for ddl in ddls:
-        s = _re.sub(r'(IDENTIFIED\s+BY\s+)"[^"]*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
-        s = _re.sub(r"(SECRET\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r'(IDENTIFIED\s+BY\s+)"([^"]|"")*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
+        s = _re.sub(r"(SECRET\s+)'([^']|'')*'", r"\1'***'", s, flags=_re.IGNORECASE)
         redacted.append(s)
     return redacted
 

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -192,30 +192,6 @@ def secret_exists(conn, client_name):
     return False
 
 
-def build_backup_clause(backup, backup_tag):
-    """Build the WITH BACKUP clause for key management commands."""
-    if not backup:
-        return ''
-    clause = ' WITH BACKUP'
-    if backup_tag:
-        clause += " USING '%s'" % backup_tag
-    return clause
-
-
-def build_container_clause(container):
-    """Build CONTAINER clause."""
-    if container == 'all':
-        return ' CONTAINER = ALL'
-    return ''
-
-
-def build_force_clause(force_keystore):
-    """Build FORCE KEYSTORE clause."""
-    if force_keystore:
-        return 'FORCE KEYSTORE '
-    return ''
-
-
 def ensure_keystore_present(conn, module):
     """Create a software keystore if it doesn't exist."""
     status = get_wallet_status(conn)
@@ -560,6 +536,7 @@ from ansible.module_utils.basic import *  # noqa: F403
 try:
     from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
         oracleConnection, sanitize_string_params,
+        build_backup_clause, build_container_clause, build_force_clause,
     )
 except ImportError:
     def sanitize_string_params(_params):

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -217,6 +217,11 @@ def ensure_keystore_present(conn, module):
                 changed=False
             )
 
+    if "'" in keystore_location:
+        module.fail_json(
+            msg='keystore_location must not contain single quotes',
+            changed=False,
+        )
     sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
         keystore_location, keystore_password
     )
@@ -369,21 +374,25 @@ def manage_secret(conn, module):
     backup_clause = build_backup_clause(backup, backup_tag)
     exists = secret_exists(conn, secret_client)
 
+    safe_client = secret_client.replace("'", "''")
+
     if secret_state == 'present':
         if not secret:
             module.fail_json(msg='secret is required when secret_state=present', changed=False)
 
+        safe_secret = secret.replace("'", "''")
         tag_clause = ""
         if secret_tag:
-            tag_clause = " USING TAG '%s'" % secret_tag
+            safe_tag = secret_tag.replace("'", "''")
+            tag_clause = " USING TAG '%s'" % safe_tag
 
         if exists:
             sql = "ADMINISTER KEY MANAGEMENT %sUPDATE SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
-                force, secret, secret_client, tag_clause, keystore_password, backup_clause
+                force, safe_secret, safe_client, tag_clause, keystore_password, backup_clause
             )
         else:
             sql = "ADMINISTER KEY MANAGEMENT %sADD SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
-                force, secret, secret_client, tag_clause, keystore_password, backup_clause
+                force, safe_secret, safe_client, tag_clause, keystore_password, backup_clause
             )
         conn.execute_ddl(sql)
 
@@ -391,7 +400,7 @@ def manage_secret(conn, module):
         if not exists:
             return  # Already absent, idempotent
         sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s' IDENTIFIED BY \"%s\"%s" % (
-            force, secret_client, keystore_password, backup_clause
+            force, safe_client, keystore_password, backup_clause
         )
         conn.execute_ddl(sql)
 
@@ -447,6 +456,8 @@ def main():
 
     # Secret management takes priority if secret_state is set
     if secret_state:
+        if module.check_mode:
+            module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
         manage_secret(conn, module)
         status = get_wallet_status(conn)
         module.exit_json(
@@ -471,7 +482,10 @@ def main():
             secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
         )
 
-    elif state == 'present':
+    if module.check_mode:
+        module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
+
+    if state == 'present':
         status = ensure_keystore_present(conn, module)
 
         # Handle auto-login creation
@@ -539,8 +553,10 @@ try:
         build_backup_clause, build_container_clause, build_force_clause,
     )
 except ImportError:
-    def sanitize_string_params(_params):
-        pass
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -258,7 +258,12 @@ def validate_wallet_inputs_before_connect(module):
 
 
 def _redact_ddls(ddls):
-    """Redact passwords and secrets from DDL statements before returning to user."""
+    """Redact passwords and secrets from DDL statements before returning to user.
+
+    Backup identifiers in ``... USING 'tag'`` (BACKUP KEYSTORE / WITH BACKUP) are
+    left visible; they are not credentials. ``USING TAG`` for secrets uses a
+    different token sequence and is unaffected.
+    """
     # Oracle doubles embedded quotes inside literals; match full quoted spans.
     _sq_lit = r"'(?:[^']|'')*'"
     _dq_lit = r'"(?:[^"]|"")*"'
@@ -266,7 +271,6 @@ def _redact_ddls(ddls):
     for ddl in ddls:
         s = _re.sub(r'(IDENTIFIED\s+BY\s+)' + _dq_lit, r'\1"***"', ddl, flags=_re.IGNORECASE)
         s = _re.sub(r'(SECRET\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
-        s = _re.sub(r'(USING\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
         s = _re.sub(
             r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _dq_lit,
             r"\1'***'",

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -678,6 +678,9 @@ def main():
         ],
         supports_check_mode=True,
     )
+    if not HAS_ORACLE_UTILS:
+        module.fail_json(msg='oracle_utils is required for oracle_wallet: %s' % _ORACLE_UTILS_ERR)
+
     sanitize_string_params(module.params)
 
     state = module.params["state"]
@@ -791,11 +794,26 @@ try:
         oracleConnection, sanitize_string_params,
         build_backup_clause, build_container_clause, build_force_clause,
     )
-except ImportError:
+except ImportError as e:
+    HAS_ORACLE_UTILS = False
+    _ORACLE_UTILS_ERR = str(e)
+
     def sanitize_string_params(module_params):
         for key, value in module_params.items():
             if isinstance(value, str):
                 module_params[key] = value.strip()
+
+    def _missing_oracle_utils(*_a, **_kw):
+        raise ImportError(
+            'oracle_utils is required for oracle_wallet: %s' % _ORACLE_UTILS_ERR
+        )
+
+    oracleConnection = _missing_oracle_utils  # noqa: F811
+    build_backup_clause = _missing_oracle_utils
+    build_container_clause = _missing_oracle_utils
+    build_force_clause = _missing_oracle_utils
+else:
+    HAS_ORACLE_UTILS = True
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -206,13 +206,6 @@ def validate_wallet_inputs_before_connect(module):
     backup_tag = module.params['backup_tag']
     backup_location = module.params['backup_location']
 
-    if state == 'absent':
-        module.fail_json(
-            msg='Oracle does not support dropping a keystore via SQL. '
-                'Remove the keystore files manually from the filesystem.',
-            changed=False,
-        )
-
     if secret_state:
         if not module.params.get('secret_client'):
             module.fail_json(msg='secret_client is required for secret management', changed=False)
@@ -227,6 +220,13 @@ def validate_wallet_inputs_before_connect(module):
         _assert_sql_embeddable_str(module, module.params.get('secret_tag'), "'")
         _assert_sql_embeddable_str(module, backup_tag, "'")
         return
+
+    if state == 'absent':
+        module.fail_json(
+            msg='Oracle does not support dropping a keystore via SQL. '
+                'Remove the keystore files manually from the filesystem.',
+            changed=False,
+        )
 
     if state == 'present':
         loc = module.params.get('keystore_location')
@@ -287,11 +287,84 @@ def _redact_ddls(ddls):
     return redacted
 
 
-def get_wallet_status(conn):
-    """Query V$ENCRYPTION_WALLET for current keystore status."""
-    sql = """SELECT WRL_TYPE, WRL_PARAMETER, STATUS, WALLET_TYPE, WALLET_ORDER, KEYSTORE_MODE
-             FROM V$ENCRYPTION_WALLET
-             WHERE ROWNUM = 1"""
+def _vwallet_field(row, col):
+    """Read a V$ view column from a row dict (oracledb lower/upper keys)."""
+    if not row:
+        return ''
+    lc, uc = col.lower(), col.upper()
+    if lc in row:
+        return row[lc]
+    if uc in row:
+        return row[uc]
+    return ''
+
+
+def _aggregate_wallet_rows(rows):
+    """Merge multiple V$ENCRYPTION_WALLET rows when ``container`` is ``all``."""
+    if not rows:
+        return {}
+    if len(rows) == 1:
+        return rows[0]
+
+    statuses = []
+    for r in rows:
+        st = (_vwallet_field(r, 'STATUS') or '').upper()
+        statuses.append(st)
+
+    def _is_open(s):
+        return s in ('OPEN', 'OPEN_NO_MASTER_KEY')
+
+    def _is_closed(s):
+        return s in ('CLOSED', 'NOT_AVAILABLE') or not s
+
+    all_open = bool(statuses) and all(_is_open(s) for s in statuses)
+    all_closed = bool(statuses) and all(_is_closed(s) for s in statuses)
+    if all_open:
+        agg_status = 'OPEN'
+    elif all_closed:
+        agg_status = 'CLOSED'
+    else:
+        agg_status = 'MIXED'
+
+    first = rows[0]
+    open_rows = [rows[i] for i, s in enumerate(statuses) if _is_open(s)]
+    auto_types = ('AUTOLOGIN', 'LOCAL_AUTOLOGIN')
+
+    def _wtype(r):
+        return (_vwallet_field(r, 'WALLET_TYPE') or '').upper()
+
+    if open_rows and not all(_wtype(r) in auto_types for r in open_rows):
+        rep_wallet_type = 'PASSWORD'
+    else:
+        rep_wallet_type = _vwallet_field(first, 'WALLET_TYPE')
+
+    modes = {_vwallet_field(r, 'KEYSTORE_MODE') for r in rows if _vwallet_field(r, 'KEYSTORE_MODE')}
+    keystore_mode = 'MIXED' if len(modes) > 1 else _vwallet_field(first, 'KEYSTORE_MODE')
+
+    return {
+        'wrl_type': _vwallet_field(first, 'WRL_TYPE'),
+        'wrl_parameter': _vwallet_field(first, 'WRL_PARAMETER'),
+        'status': agg_status,
+        'wallet_type': rep_wallet_type,
+        'wallet_order': _vwallet_field(first, 'WALLET_ORDER'),
+        'keystore_mode': keystore_mode,
+    }
+
+
+def get_wallet_status(conn, container=None):
+    """Query V$ENCRYPTION_WALLET for keystore status.
+
+    With ``container='all'``, aggregates every row so open/close idempotency
+    reflects all PDBs/containers, not an arbitrary single row.
+    """
+    base_sql = """SELECT WRL_TYPE, WRL_PARAMETER, STATUS, WALLET_TYPE, WALLET_ORDER, KEYSTORE_MODE
+             FROM V$ENCRYPTION_WALLET"""
+    if container == 'all':
+        rows = conn.execute_select_to_dict(base_sql, fetchone=False)
+        if not rows:
+            return {}
+        return _aggregate_wallet_rows(rows)
+    sql = base_sql + "\n             WHERE ROWNUM = 1"
     return conn.execute_select_to_dict(sql, fetchone=True)
 
 
@@ -308,20 +381,29 @@ def get_secrets(conn):
     return conn.execute_select_to_dict(sql, fail_on_error=False) or []
 
 
-def secret_exists(conn, client_name):
-    """Check if a specific secret client entry exists."""
+def secret_exists(conn, client_name, secret_tag=None):
+    """Check if a secret exists for *client_name*, optionally scoped to *secret_tag*."""
     secrets = get_secrets(conn)
     if not secrets:
         return False
+    c_upper = client_name.upper()
+    want_tag = (secret_tag or '').strip()
+    want_tag_u = want_tag.upper() if want_tag else None
     for s in secrets:
-        if s.get('client', '').upper() == client_name.upper():
+        cli = (_vwallet_field(s, 'CLIENT') or '').upper()
+        if cli != c_upper:
+            continue
+        if want_tag_u is None:
+            return True
+        tag = (_vwallet_field(s, 'SECRET_TAG') or '').upper()
+        if tag == want_tag_u:
             return True
     return False
 
 
 def ensure_keystore_present(conn, module):
     """Create a software keystore if it doesn't exist."""
-    status = get_wallet_status(conn)
+    status = get_wallet_status(conn, module.params["container"])
     keystore_location = module.params["keystore_location"]
     keystore_password = module.params["keystore_password"]
 
@@ -350,12 +432,12 @@ def ensure_keystore_present(conn, module):
         loc_esc, pwd_esc
     )
     conn.execute_ddl(sql)
-    return get_wallet_status(conn)
+    return get_wallet_status(conn, module.params["container"])
 
 
 def ensure_keystore_open(conn, module):
     """Open the keystore if it is closed."""
-    status = get_wallet_status(conn)
+    status = get_wallet_status(conn, module.params["container"])
     current_status = status.get('status', '') if status else ''
     keystore_password = module.params["keystore_password"]
     container = module.params["container"]
@@ -375,12 +457,12 @@ def ensure_keystore_open(conn, module):
         force, pwd_esc, container_clause
     )
     conn.execute_ddl(sql)
-    return get_wallet_status(conn)
+    return get_wallet_status(conn, module.params["container"])
 
 
 def ensure_keystore_closed(conn, module):
     """Close the keystore if it is open."""
-    status = get_wallet_status(conn)
+    status = get_wallet_status(conn, module.params["container"])
     current_status = status.get('status', '') if status else ''
     keystore_password = module.params["keystore_password"]
     container = module.params["container"]
@@ -402,7 +484,7 @@ def ensure_keystore_closed(conn, module):
             pwd_esc, container_clause
         )
     conn.execute_ddl(sql)
-    return get_wallet_status(conn)
+    return get_wallet_status(conn, module.params["container"])
 
 
 def create_auto_login(conn, module):
@@ -415,7 +497,7 @@ def create_auto_login(conn, module):
         return
 
     # Check if the desired auto-login type already exists
-    status = get_wallet_status(conn)
+    status = get_wallet_status(conn, module.params["container"])
     current_type = status.get('wallet_type', '') if status else ''
     if auto_login == 'auto_login' and current_type == 'AUTOLOGIN':
         return
@@ -427,7 +509,7 @@ def create_auto_login(conn, module):
 
     # Determine location
     if not keystore_location:
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         keystore_location = status.get('wrl_parameter', '')
         if not keystore_location:
             wallet_root = get_wallet_root(conn)
@@ -516,7 +598,7 @@ def manage_secret(conn, module):
 
     force = build_force_clause(force_keystore)
     backup_clause = build_backup_clause(backup, backup_tag)
-    exists = secret_exists(conn, secret_client)
+    exists = secret_exists(conn, secret_client, secret_tag)
 
     safe_client = escape_sql_literal_or_fail(secret_client, "'", module)
     pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
@@ -541,8 +623,12 @@ def manage_secret(conn, module):
     elif secret_state == 'absent':
         if not exists:
             return  # Already absent, idempotent
-        sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s' IDENTIFIED BY \"%s\"%s" % (
-            force, safe_client, pwd_esc, backup_clause
+        tag_clause = ""
+        if secret_tag:
+            safe_tag_del = escape_sql_literal_or_fail(secret_tag, "'", module)
+            tag_clause = " USING TAG '%s'" % safe_tag_del
+        sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
+            force, safe_client, tag_clause, pwd_esc, backup_clause
         )
         conn.execute_ddl(sql)
 
@@ -597,7 +683,7 @@ def main():
     validate_wallet_inputs_before_connect(module)
 
     def _exit_status_query(conn_):
-        status = get_wallet_status(conn_)
+        status = get_wallet_status(conn_, module.params["container"])
         secrets = get_secrets(conn_)
         module.exit_json(
             changed=False,
@@ -620,7 +706,7 @@ def main():
     # Secret management takes priority if secret_state is set
     if secret_state:
         manage_secret(conn, module)
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         module.exit_json(
             changed=conn.changed,
             ddls=_redact_ddls(conn.ddls),
@@ -656,7 +742,7 @@ def main():
             else:
                 backup_keystore(conn, module)
 
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         module.exit_json(
             changed=conn.changed,
             ddls=_redact_ddls(conn.ddls),
@@ -668,7 +754,7 @@ def main():
 
     elif state == 'open':
         ensure_keystore_open(conn, module)
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         module.exit_json(
             changed=conn.changed,
             ddls=_redact_ddls(conn.ddls),
@@ -680,7 +766,7 @@ def main():
 
     elif state == 'closed':
         ensure_keystore_closed(conn, module)
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         module.exit_json(
             changed=conn.changed,
             ddls=_redact_ddls(conn.ddls),

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -1,0 +1,569 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: oracle_wallet
+short_description: Manage Oracle TDE keystores (wallets)
+description:
+  - Manage Oracle TDE keystores (wallets) using ADMINISTER KEY MANAGEMENT SQL
+  - Create, open, close, backup keystores
+  - Create auto-login keystores (local or network)
+  - Change keystore password
+  - Manage secrets (credentials) stored in the keystore
+  - Supports multitenant CONTAINER clause
+  - Compatible with Oracle 19c, 23ai, and 26ai
+  - In Oracle 26ai, WALLET_ROOT is mandatory (ENCRYPTION_WALLET_LOCATION is desupported)
+  - See connection parameters for oracle_ping
+version_added: "3.4.0"
+options:
+  state:
+    description: The intended state of the keystore
+    default: present
+    choices: ['present', 'absent', 'open', 'closed', 'status']
+  keystore_location:
+    description:
+      - Path where the keystore files are stored
+      - If not set, the module queries WALLET_ROOT or V$ENCRYPTION_WALLET for the location
+    required: false
+  keystore_password:
+    description: Password for the keystore
+    required: false
+  new_password:
+    description: New password when changing keystore password (state=present with change_password=true)
+    required: false
+  auto_login:
+    description: Type of auto-login keystore to create
+    default: none
+    choices: ['none', 'auto_login', 'local_auto_login']
+  change_password:
+    description: Whether to change the keystore password (requires new_password)
+    default: false
+    type: bool
+  backup:
+    description: Whether to create a backup before destructive operations (WITH BACKUP)
+    default: true
+    type: bool
+  backup_location:
+    description: Directory path for the backup file
+    required: false
+  backup_tag:
+    description: Tag identifier for the backup file
+    required: false
+  secret:
+    description: Secret value to store in the keystore
+    required: false
+  secret_client:
+    description: Client identifier for the secret (e.g. TDE_WALLET, HSM_WALLET, or custom name)
+    required: false
+  secret_tag:
+    description: Tag for the secret entry
+    required: false
+  secret_state:
+    description: State of the secret entry
+    choices: ['present', 'absent']
+    required: false
+  force_keystore:
+    description: Use FORCE KEYSTORE clause (temporarily opens an auto-login keystore for the operation)
+    default: false
+    type: bool
+  container:
+    description: Container clause for multitenant environments
+    default: current
+    choices: ['current', 'all']
+notes:
+  - Requires ADMINISTER KEY MANAGEMENT or SYSKM privilege
+  - oracledb Python module is required
+  - Keystore passwords are never logged (no_log=True)
+requirements: [ "oracledb" ]
+author:
+  - Cyrille Modiano
+'''
+
+EXAMPLES = '''
+- name: Create a software keystore
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    keystore_location: /opt/oracle/admin/wallets/tde
+    keystore_password: "MyKeystorePass123"
+
+- name: Open the keystore
+  oracle_wallet:
+    mode: sysdba
+    state: open
+    keystore_password: "MyKeystorePass123"
+
+- name: Open the keystore for all PDBs
+  oracle_wallet:
+    mode: sysdba
+    state: open
+    keystore_password: "MyKeystorePass123"
+    container: all
+
+- name: Close the keystore
+  oracle_wallet:
+    mode: sysdba
+    state: closed
+    keystore_password: "MyKeystorePass123"
+
+- name: Create auto-login keystore
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    auto_login: auto_login
+    keystore_password: "MyKeystorePass123"
+
+- name: Create local auto-login keystore (host-bound)
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    auto_login: local_auto_login
+    keystore_password: "MyKeystorePass123"
+
+- name: Backup keystore
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    backup_tag: "before_upgrade"
+    keystore_password: "MyKeystorePass123"
+    backup_location: /opt/oracle/backup/wallets
+
+- name: Change keystore password
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    change_password: true
+    keystore_password: "OldPass123"
+    new_password: "NewPass456"
+
+- name: Add a secret to the keystore
+  oracle_wallet:
+    mode: sysdba
+    secret: "my_secret_value"
+    secret_client: "MY_APP"
+    secret_state: present
+    keystore_password: "MyKeystorePass123"
+
+- name: Remove a secret from the keystore
+  oracle_wallet:
+    mode: sysdba
+    secret_client: "MY_APP"
+    secret_state: absent
+    keystore_password: "MyKeystorePass123"
+
+- name: Get keystore status
+  oracle_wallet:
+    mode: sysdba
+    state: status
+  register: wallet_info
+'''
+
+
+def get_wallet_status(conn):
+    """Query V$ENCRYPTION_WALLET for current keystore status."""
+    sql = """SELECT WRL_TYPE, WRL_PARAMETER, STATUS, WALLET_TYPE, WALLET_ORDER, KEYSTORE_MODE
+             FROM V$ENCRYPTION_WALLET
+             WHERE ROWNUM = 1"""
+    return conn.execute_select_to_dict(sql, fetchone=True)
+
+
+def get_wallet_root(conn):
+    """Get WALLET_ROOT parameter value."""
+    sql = "SELECT VALUE FROM V$PARAMETER WHERE NAME = 'wallet_root'"
+    r = conn.execute_select_to_dict(sql, fetchone=True)
+    return r.get('value') if r else None
+
+
+def get_secrets(conn):
+    """Query secrets stored in the keystore."""
+    sql = "SELECT CLIENT, SECRET_TAG FROM V$CLIENT_SECRETS"
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def secret_exists(conn, client_name):
+    """Check if a specific secret client entry exists."""
+    secrets = get_secrets(conn)
+    if not secrets:
+        return False
+    for s in secrets:
+        if s.get('client', '').upper() == client_name.upper():
+            return True
+    return False
+
+
+def build_backup_clause(backup, backup_tag):
+    """Build the WITH BACKUP clause for key management commands."""
+    if not backup:
+        return ''
+    clause = ' WITH BACKUP'
+    if backup_tag:
+        clause += " USING '%s'" % backup_tag
+    return clause
+
+
+def build_container_clause(container):
+    """Build CONTAINER clause."""
+    if container == 'all':
+        return ' CONTAINER = ALL'
+    return ''
+
+
+def build_force_clause(force_keystore):
+    """Build FORCE KEYSTORE clause."""
+    if force_keystore:
+        return 'FORCE KEYSTORE '
+    return ''
+
+
+def ensure_keystore_present(conn, module):
+    """Create a software keystore if it doesn't exist."""
+    status = get_wallet_status(conn)
+    keystore_location = module.params["keystore_location"]
+    keystore_password = module.params["keystore_password"]
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to create a keystore', changed=False)
+
+    # If keystore already exists (status is not NOT_AVAILABLE and not empty)
+    current_status = status.get('status', '') if status else ''
+    if current_status and current_status != 'NOT_AVAILABLE':
+        return status
+
+    # Determine location
+    if not keystore_location:
+        wallet_root = get_wallet_root(conn)
+        if wallet_root:
+            keystore_location = wallet_root + '/tde'
+        else:
+            module.fail_json(
+                msg='keystore_location is required when WALLET_ROOT is not set',
+                changed=False
+            )
+
+    sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
+        keystore_location, keystore_password
+    )
+    conn.execute_ddl(sql)
+    return get_wallet_status(conn)
+
+
+def ensure_keystore_open(conn, module):
+    """Open the keystore if it is closed."""
+    status = get_wallet_status(conn)
+    current_status = status.get('status', '') if status else ''
+    keystore_password = module.params["keystore_password"]
+    container = module.params["container"]
+    force_keystore = module.params["force_keystore"]
+
+    if current_status in ('OPEN', 'OPEN_NO_MASTER_KEY'):
+        return status
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to open the keystore', changed=False)
+
+    force = build_force_clause(force_keystore)
+    container_clause = build_container_clause(container)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sSET KEYSTORE OPEN IDENTIFIED BY \"%s\"%s" % (
+        force, keystore_password, container_clause
+    )
+    conn.execute_ddl(sql)
+    return get_wallet_status(conn)
+
+
+def ensure_keystore_closed(conn, module):
+    """Close the keystore if it is open."""
+    status = get_wallet_status(conn)
+    current_status = status.get('status', '') if status else ''
+    keystore_password = module.params["keystore_password"]
+    container = module.params["container"]
+
+    if current_status in ('CLOSED', 'NOT_AVAILABLE', ''):
+        return status
+
+    container_clause = build_container_clause(container)
+    wallet_type = status.get('wallet_type', '')
+
+    # Auto-login wallets don't need password to close
+    if wallet_type in ('AUTOLOGIN', 'LOCAL_AUTOLOGIN'):
+        sql = "ADMINISTER KEY MANAGEMENT SET KEYSTORE CLOSE%s" % container_clause
+    else:
+        if not keystore_password:
+            module.fail_json(msg='keystore_password is required to close a password-based keystore', changed=False)
+        sql = "ADMINISTER KEY MANAGEMENT SET KEYSTORE CLOSE IDENTIFIED BY \"%s\"%s" % (
+            keystore_password, container_clause
+        )
+    conn.execute_ddl(sql)
+    return get_wallet_status(conn)
+
+
+def create_auto_login(conn, module):
+    """Create an auto-login keystore from the existing password keystore."""
+    auto_login = module.params["auto_login"]
+    keystore_password = module.params["keystore_password"]
+    keystore_location = module.params["keystore_location"]
+
+    if auto_login == 'none':
+        return
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to create auto-login keystore', changed=False)
+
+    # Determine location
+    if not keystore_location:
+        status = get_wallet_status(conn)
+        keystore_location = status.get('wrl_parameter', '')
+        if not keystore_location:
+            wallet_root = get_wallet_root(conn)
+            if wallet_root:
+                keystore_location = wallet_root + '/tde'
+            else:
+                module.fail_json(
+                    msg='Cannot determine keystore location for auto-login creation',
+                    changed=False
+                )
+
+    local_clause = 'LOCAL ' if auto_login == 'local_auto_login' else ''
+
+    sql = "ADMINISTER KEY MANAGEMENT CREATE %sAUTO_LOGIN KEYSTORE FROM KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
+        local_clause, keystore_location, keystore_password
+    )
+    conn.execute_ddl(sql)
+
+
+def backup_keystore(conn, module):
+    """Create a backup of the keystore."""
+    keystore_password = module.params["keystore_password"]
+    backup_tag = module.params["backup_tag"]
+    backup_location = module.params["backup_location"]
+    force_keystore = module.params["force_keystore"]
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to backup the keystore', changed=False)
+
+    force = build_force_clause(force_keystore)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sBACKUP KEYSTORE" % force
+    if backup_tag:
+        sql += " USING '%s'" % backup_tag
+    sql += " IDENTIFIED BY \"%s\"" % keystore_password
+    if backup_location:
+        sql += " TO '%s'" % backup_location
+    conn.execute_ddl(sql)
+
+
+def change_keystore_password(conn, module):
+    """Change the keystore password."""
+    keystore_password = module.params["keystore_password"]
+    new_password = module.params["new_password"]
+    backup = module.params["backup"]
+    backup_tag = module.params["backup_tag"]
+    force_keystore = module.params["force_keystore"]
+
+    if not keystore_password or not new_password:
+        module.fail_json(msg='Both keystore_password and new_password are required', changed=False)
+
+    force = build_force_clause(force_keystore)
+    backup_clause = build_backup_clause(backup, backup_tag)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sALTER KEYSTORE PASSWORD IDENTIFIED BY \"%s\" SET \"%s\"%s" % (
+        force, keystore_password, new_password, backup_clause
+    )
+    conn.execute_ddl(sql)
+
+
+def manage_secret(conn, module):
+    """Add, update, or delete a secret in the keystore."""
+    secret = module.params["secret"]
+    secret_client = module.params["secret_client"]
+    secret_state = module.params["secret_state"]
+    secret_tag = module.params["secret_tag"]
+    keystore_password = module.params["keystore_password"]
+    backup = module.params["backup"]
+    backup_tag = module.params["backup_tag"]
+    force_keystore = module.params["force_keystore"]
+
+    if not secret_client:
+        module.fail_json(msg='secret_client is required for secret management', changed=False)
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required for secret management', changed=False)
+
+    force = build_force_clause(force_keystore)
+    backup_clause = build_backup_clause(backup, backup_tag)
+    exists = secret_exists(conn, secret_client)
+
+    if secret_state == 'present':
+        if not secret:
+            module.fail_json(msg='secret is required when secret_state=present', changed=False)
+
+        tag_clause = ""
+        if secret_tag:
+            tag_clause = " USING TAG '%s'" % secret_tag
+
+        if exists:
+            sql = "ADMINISTER KEY MANAGEMENT %sUPDATE SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
+                force, secret, secret_client, tag_clause, keystore_password, backup_clause
+            )
+        else:
+            sql = "ADMINISTER KEY MANAGEMENT %sADD SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
+                force, secret, secret_client, tag_clause, keystore_password, backup_clause
+            )
+        conn.execute_ddl(sql)
+
+    elif secret_state == 'absent':
+        if not exists:
+            return  # Already absent, idempotent
+        sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s' IDENTIFIED BY \"%s\"%s" % (
+            force, secret_client, keystore_password, backup_clause
+        )
+        conn.execute_ddl(sql)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            user=dict(required=False, aliases=['un', 'username']),
+            password=dict(required=False, no_log=True, aliases=['pw']),
+            mode=dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            hostname=dict(required=False, default='localhost', aliases=['host']),
+            port=dict(required=False, default=1521, type='int'),
+            service_name=dict(required=False, aliases=['sn']),
+            dsn=dict(required=False, aliases=['datasource_name']),
+            oracle_home=dict(required=False, aliases=['oh']),
+            session_container=dict(required=False),
+
+            state=dict(default="present",
+                       choices=["present", "absent", "open", "closed", "status"]),
+            keystore_location=dict(required=False),
+            keystore_password=dict(required=False, no_log=True),
+            new_password=dict(required=False, no_log=True),
+            auto_login=dict(default='none',
+                           choices=['none', 'auto_login', 'local_auto_login']),
+            change_password=dict(default=False, type='bool'),
+            backup=dict(default=True, type='bool'),
+            backup_location=dict(required=False),
+            backup_tag=dict(required=False),
+            force_keystore=dict(default=False, type='bool'),
+
+            secret=dict(required=False, no_log=True),
+            secret_client=dict(required=False),
+            secret_tag=dict(required=False),
+            secret_state=dict(required=False, choices=['present', 'absent']),
+
+            container=dict(default='current', choices=['current', 'all']),
+        ),
+        required_if=[
+            ('change_password', True, ('keystore_password', 'new_password')),
+        ],
+        supports_check_mode=True,
+    )
+    sanitize_string_params(module.params)
+
+    state = module.params["state"]
+    secret_state = module.params["secret_state"]
+    auto_login = module.params["auto_login"]
+    change_password_flag = module.params["change_password"]
+    backup_tag = module.params["backup_tag"]
+    backup_location = module.params["backup_location"]
+
+    conn = oracleConnection(module)
+
+    # Secret management takes priority if secret_state is set
+    if secret_state:
+        manage_secret(conn, module)
+        status = get_wallet_status(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='Secret managed successfully',
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+        )
+
+    if state == 'status':
+        status = get_wallet_status(conn)
+        secrets = get_secrets(conn)
+        module.exit_json(
+            changed=False,
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+            wrl_type=status.get('wrl_type', '') if status else '',
+            wrl_parameter=status.get('wrl_parameter', '') if status else '',
+            secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
+        )
+
+    elif state == 'present':
+        status = ensure_keystore_present(conn, module)
+
+        # Handle auto-login creation
+        if auto_login != 'none':
+            create_auto_login(conn, module)
+
+        # Handle password change
+        if change_password_flag:
+            change_keystore_password(conn, module)
+
+        # Handle explicit backup request
+        if backup_tag or backup_location:
+            # Only backup if explicitly requested via tag or location
+            if not change_password_flag:  # change_password already does WITH BACKUP
+                backup_keystore(conn, module)
+
+        status = get_wallet_status(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='Keystore managed successfully',
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+        )
+
+    elif state == 'open':
+        ensure_keystore_open(conn, module)
+        status = get_wallet_status(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='Keystore is open',
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+        )
+
+    elif state == 'closed':
+        ensure_keystore_closed(conn, module)
+        status = get_wallet_status(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='Keystore is closed',
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+        )
+
+    elif state == 'absent':
+        # Oracle does not have a DROP KEYSTORE command. Keystore removal is a filesystem operation.
+        module.fail_json(
+            msg='Oracle does not support dropping a keystore via SQL. '
+                'Remove the keystore files manually from the filesystem.',
+            changed=False,
+        )
+
+
+from ansible.module_utils.basic import *  # noqa: F403
+
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(_params):
+        pass
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -319,8 +319,13 @@ def _aggregate_wallet_rows(rows):
 
     all_open = bool(statuses) and all(_is_open(s) for s in statuses)
     all_closed = bool(statuses) and all(_is_closed(s) for s in statuses)
+    all_not_available = bool(statuses) and all(
+        s in ('NOT_AVAILABLE', '') or not s for s in statuses
+    )
     if all_open:
         agg_status = 'OPEN'
+    elif all_not_available:
+        agg_status = 'NOT_AVAILABLE'
     elif all_closed:
         agg_status = 'CLOSED'
     else:
@@ -335,6 +340,8 @@ def _aggregate_wallet_rows(rows):
 
     if open_rows and not all(_wtype(r) in auto_types for r in open_rows):
         rep_wallet_type = 'PASSWORD'
+    elif open_rows:
+        rep_wallet_type = _vwallet_field(open_rows[0], 'WALLET_TYPE')
     else:
         rep_wallet_type = _vwallet_field(first, 'WALLET_TYPE')
 

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -789,6 +789,18 @@ def main():
 
 from ansible.module_utils.basic import *  # noqa: F403
 
+# In these we do import from local project sub-directory <project-dir>/module_utils
+# While this file is placed in <project-dir>/library
+# No collections are used
+#try:
+#    from ansible.module_utils.oracle_utils import (
+#        oracleConnection, sanitize_string_params,
+#        build_backup_clause, build_container_clause, build_force_clause,
+#    )
+#except:
+#    pass
+
+# In these we do import from collections
 try:
     from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
         oracleConnection, sanitize_string_params,

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -163,13 +163,122 @@ EXAMPLES = '''
 import re as _re
 
 
+def escape_sql_literal(value, quote_char):
+    """Escape *value* for embedding in a SQL fragment bounded by *quote_char*.
+
+    Oracle string literals double embedded single quotes; delimited strings
+    double embedded double quotes. Newlines are rejected so DDL stays a single
+    statement line.
+    """
+    if not isinstance(value, str):
+        raise TypeError('escape_sql_literal expects a string value')
+    if '\n' in value or '\r' in value:
+        raise ValueError('SQL parameter values must not contain newline or carriage return characters')
+    if quote_char == "'":
+        return value.replace("'", "''")
+    if quote_char == '"':
+        return value.replace('"', '""')
+    raise ValueError('quote_char must be single or double quote')
+
+
+def escape_sql_literal_or_fail(value, quote_char, module):
+    try:
+        return escape_sql_literal(value, quote_char)
+    except (TypeError, ValueError) as e:
+        module.fail_json(msg=str(e), changed=False)
+
+
+def _assert_sql_embeddable_str(module, value, quote_char):
+    """Reject values that cannot legally be embedded in a SQL literal."""
+    if value is None or value == '':
+        return
+    try:
+        escape_sql_literal(value, quote_char)
+    except (TypeError, ValueError) as e:
+        module.fail_json(msg=str(e), changed=False)
+
+
+def validate_wallet_inputs_before_connect(module):
+    """Validate task arguments before opening any database connection."""
+    state = module.params['state']
+    secret_state = module.params['secret_state']
+    change_password_flag = module.params['change_password']
+    backup_tag = module.params['backup_tag']
+    backup_location = module.params['backup_location']
+
+    if state == 'absent':
+        module.fail_json(
+            msg='Oracle does not support dropping a keystore via SQL. '
+                'Remove the keystore files manually from the filesystem.',
+            changed=False,
+        )
+
+    if secret_state:
+        if not module.params.get('secret_client'):
+            module.fail_json(msg='secret_client is required for secret management', changed=False)
+        if not module.params.get('keystore_password'):
+            module.fail_json(msg='keystore_password is required for secret management', changed=False)
+        if secret_state == 'present' and not module.params.get('secret'):
+            module.fail_json(msg='secret is required when secret_state=present', changed=False)
+        _assert_sql_embeddable_str(module, module.params.get('secret_client'), "'")
+        _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
+        if module.params.get('secret'):
+            _assert_sql_embeddable_str(module, module.params['secret'], "'")
+        _assert_sql_embeddable_str(module, module.params.get('secret_tag'), "'")
+        _assert_sql_embeddable_str(module, backup_tag, "'")
+        return
+
+    if state == 'present':
+        loc = module.params.get('keystore_location')
+        if loc:
+            _assert_sql_embeddable_str(module, loc, "'")
+        _assert_sql_embeddable_str(module, backup_tag, "'")
+        _assert_sql_embeddable_str(module, backup_location, "'")
+        if change_password_flag:
+            _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
+            _assert_sql_embeddable_str(module, module.params.get('new_password'), '"')
+        if (backup_tag or backup_location) and not change_password_flag:
+            if not module.params.get('keystore_password'):
+                module.fail_json(
+                    msg='keystore_password is required when backup_tag or backup_location is set',
+                    changed=False,
+                )
+        return
+
+    if state == 'open':
+        ks = module.params.get('keystore_password')
+        if ks:
+            _assert_sql_embeddable_str(module, ks, '"')
+        return
+
+    if state == 'closed':
+        ks = module.params.get('keystore_password')
+        if ks:
+            _assert_sql_embeddable_str(module, ks, '"')
+
+
 def _redact_ddls(ddls):
     """Redact passwords and secrets from DDL statements before returning to user."""
+    # Oracle doubles embedded quotes inside literals; match full quoted spans.
+    _sq_lit = r"'(?:[^']|'')*'"
+    _dq_lit = r'"(?:[^"]|"")*"'
     redacted = []
     for ddl in ddls:
-        s = _re.sub(r'(IDENTIFIED\s+BY\s+)"[^"]*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
-        s = _re.sub(r"(SECRET\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
-        s = _re.sub(r"(USING\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r'(IDENTIFIED\s+BY\s+)' + _dq_lit, r'\1"***"', ddl, flags=_re.IGNORECASE)
+        s = _re.sub(r'(SECRET\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r'(USING\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(
+            r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _dq_lit,
+            r"\1'***'",
+            s,
+            flags=_re.IGNORECASE,
+        )
+        s = _re.sub(
+            r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _sq_lit,
+            r"\1'***'",
+            s,
+            flags=_re.IGNORECASE,
+        )
         redacted.append(s)
     return redacted
 
@@ -231,13 +340,10 @@ def ensure_keystore_present(conn, module):
                 changed=False
             )
 
-    if "'" in keystore_location:
-        module.fail_json(
-            msg='keystore_location must not contain single quotes',
-            changed=False,
-        )
+    loc_esc = escape_sql_literal_or_fail(keystore_location, "'", module)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
     sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
-        keystore_location, keystore_password
+        loc_esc, pwd_esc
     )
     conn.execute_ddl(sql)
     return get_wallet_status(conn)
@@ -259,9 +365,10 @@ def ensure_keystore_open(conn, module):
 
     force = build_force_clause(force_keystore)
     container_clause = build_container_clause(container)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
 
     sql = "ADMINISTER KEY MANAGEMENT %sSET KEYSTORE OPEN IDENTIFIED BY \"%s\"%s" % (
-        force, keystore_password, container_clause
+        force, pwd_esc, container_clause
     )
     conn.execute_ddl(sql)
     return get_wallet_status(conn)
@@ -286,8 +393,9 @@ def ensure_keystore_closed(conn, module):
     else:
         if not keystore_password:
             module.fail_json(msg='keystore_password is required to close a password-based keystore', changed=False)
+        pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
         sql = "ADMINISTER KEY MANAGEMENT SET KEYSTORE CLOSE IDENTIFIED BY \"%s\"%s" % (
-            keystore_password, container_clause
+            pwd_esc, container_clause
         )
     conn.execute_ddl(sql)
     return get_wallet_status(conn)
@@ -329,15 +437,25 @@ def create_auto_login(conn, module):
 
     local_clause = 'LOCAL ' if auto_login == 'local_auto_login' else ''
 
+    loc_esc = escape_sql_literal_or_fail(keystore_location, "'", module)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
     sql = "ADMINISTER KEY MANAGEMENT CREATE %sAUTO_LOGIN KEYSTORE FROM KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
-        local_clause, keystore_location, keystore_password
+        local_clause, loc_esc, pwd_esc
     )
     conn.execute_ddl(sql)
 
 
-def backup_keystore(conn, module):
-    """Create a backup of the keystore."""
-    keystore_password = module.params["keystore_password"]
+def backup_keystore(conn, module, identified_by_password=None):
+    """Create a backup of the keystore.
+
+    After ``ALTER KEYSTORE PASSWORD``, pass *identified_by_password* (the new
+    password) so ``IDENTIFIED BY`` matches the current keystore password.
+    """
+    keystore_password = (
+        identified_by_password
+        if identified_by_password is not None
+        else module.params["keystore_password"]
+    )
     backup_tag = module.params["backup_tag"]
     backup_location = module.params["backup_location"]
     force_keystore = module.params["force_keystore"]
@@ -346,13 +464,16 @@ def backup_keystore(conn, module):
         module.fail_json(msg='keystore_password is required to backup the keystore', changed=False)
 
     force = build_force_clause(force_keystore)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
 
     sql = "ADMINISTER KEY MANAGEMENT %sBACKUP KEYSTORE" % force
     if backup_tag:
-        sql += " USING '%s'" % backup_tag
-    sql += " IDENTIFIED BY \"%s\"" % keystore_password
+        tag_esc = escape_sql_literal_or_fail(backup_tag, "'", module)
+        sql += " USING '%s'" % tag_esc
+    sql += " IDENTIFIED BY \"%s\"" % pwd_esc
     if backup_location:
-        sql += " TO '%s'" % backup_location
+        loc_esc = escape_sql_literal_or_fail(backup_location, "'", module)
+        sql += " TO '%s'" % loc_esc
     conn.execute_ddl(sql)
 
 
@@ -369,9 +490,11 @@ def change_keystore_password(conn, module):
 
     force = build_force_clause(force_keystore)
     backup_clause = build_backup_clause(backup, backup_tag)
+    old_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
+    new_esc = escape_sql_literal_or_fail(new_password, '"', module)
 
     sql = "ADMINISTER KEY MANAGEMENT %sALTER KEYSTORE PASSWORD IDENTIFIED BY \"%s\" SET \"%s\"%s" % (
-        force, keystore_password, new_password, backup_clause
+        force, old_esc, new_esc, backup_clause
     )
     conn.execute_ddl(sql)
 
@@ -387,34 +510,27 @@ def manage_secret(conn, module):
     backup_tag = module.params["backup_tag"]
     force_keystore = module.params["force_keystore"]
 
-    if not secret_client:
-        module.fail_json(msg='secret_client is required for secret management', changed=False)
-    if not keystore_password:
-        module.fail_json(msg='keystore_password is required for secret management', changed=False)
-
     force = build_force_clause(force_keystore)
     backup_clause = build_backup_clause(backup, backup_tag)
     exists = secret_exists(conn, secret_client)
 
-    safe_client = secret_client.replace("'", "''")
+    safe_client = escape_sql_literal_or_fail(secret_client, "'", module)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
 
     if secret_state == 'present':
-        if not secret:
-            module.fail_json(msg='secret is required when secret_state=present', changed=False)
-
-        safe_secret = secret.replace("'", "''")
+        safe_secret = escape_sql_literal_or_fail(secret, "'", module)
         tag_clause = ""
         if secret_tag:
-            safe_tag = secret_tag.replace("'", "''")
+            safe_tag = escape_sql_literal_or_fail(secret_tag, "'", module)
             tag_clause = " USING TAG '%s'" % safe_tag
 
         if exists:
             sql = "ADMINISTER KEY MANAGEMENT %sUPDATE SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
-                force, safe_secret, safe_client, tag_clause, keystore_password, backup_clause
+                force, safe_secret, safe_client, tag_clause, pwd_esc, backup_clause
             )
         else:
             sql = "ADMINISTER KEY MANAGEMENT %sADD SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
-                force, safe_secret, safe_client, tag_clause, keystore_password, backup_clause
+                force, safe_secret, safe_client, tag_clause, pwd_esc, backup_clause
             )
         conn.execute_ddl(sql)
 
@@ -422,7 +538,7 @@ def manage_secret(conn, module):
         if not exists:
             return  # Already absent, idempotent
         sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s' IDENTIFIED BY \"%s\"%s" % (
-            force, safe_client, keystore_password, backup_clause
+            force, safe_client, pwd_esc, backup_clause
         )
         conn.execute_ddl(sql)
 
@@ -474,12 +590,31 @@ def main():
     backup_tag = module.params["backup_tag"]
     backup_location = module.params["backup_location"]
 
+    validate_wallet_inputs_before_connect(module)
+
+    def _exit_status_query(conn_):
+        status = get_wallet_status(conn_)
+        secrets = get_secrets(conn_)
+        module.exit_json(
+            changed=False,
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+            wrl_type=status.get('wrl_type', '') if status else '',
+            wrl_parameter=status.get('wrl_parameter', '') if status else '',
+            secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
+        )
+
+    if module.check_mode:
+        if state == 'status':
+            conn = oracleConnection(module)
+            _exit_status_query(conn)
+        module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
+
     conn = oracleConnection(module)
 
     # Secret management takes priority if secret_state is set
     if secret_state:
-        if module.check_mode:
-            module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
         manage_secret(conn, module)
         status = get_wallet_status(conn)
         module.exit_json(
@@ -492,20 +627,7 @@ def main():
         )
 
     if state == 'status':
-        status = get_wallet_status(conn)
-        secrets = get_secrets(conn)
-        module.exit_json(
-            changed=False,
-            wallet_status=status.get('status', '') if status else '',
-            wallet_type=status.get('wallet_type', '') if status else '',
-            keystore_mode=status.get('keystore_mode', '') if status else '',
-            wrl_type=status.get('wrl_type', '') if status else '',
-            wrl_parameter=status.get('wrl_parameter', '') if status else '',
-            secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
-        )
-
-    if module.check_mode:
-        module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
+        _exit_status_query(conn)
 
     if state == 'present':
         status = ensure_keystore_present(conn, module)
@@ -518,10 +640,16 @@ def main():
         if change_password_flag:
             change_keystore_password(conn, module)
 
-        # Handle explicit backup request
+        # Explicit BACKUP KEYSTORE (WITH BACKUP on ALTER has no TO clause; if
+        # backup_tag is set with backup=False, ALTER omits WITH BACKUP too).
         if backup_tag or backup_location:
-            # Only backup if explicitly requested via tag or location
-            if not change_password_flag:  # change_password already does WITH BACKUP
+            if change_password_flag:
+                if backup_location or not module.params["backup"]:
+                    backup_keystore(
+                        conn, module,
+                        identified_by_password=module.params["new_password"],
+                    )
+            else:
                 backup_keystore(conn, module)
 
         status = get_wallet_status(conn)
@@ -556,14 +684,6 @@ def main():
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',
             keystore_mode=status.get('keystore_mode', '') if status else '',
-        )
-
-    elif state == 'absent':
-        # Oracle does not have a DROP KEYSTORE command. Keystore removal is a filesystem operation.
-        module.fail_json(
-            msg='Oracle does not support dropping a keystore via SQL. '
-                'Remove the keystore files manually from the filesystem.',
-            changed=False,
         )
 
 

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -321,13 +321,13 @@ def ensure_keystore_present(conn, module):
     keystore_location = module.params["keystore_location"]
     keystore_password = module.params["keystore_password"]
 
-    if not keystore_password:
-        module.fail_json(msg='keystore_password is required to create a keystore', changed=False)
-
     # If keystore already exists (status is not NOT_AVAILABLE and not empty)
     current_status = status.get('status', '') if status else ''
     if current_status and current_status != 'NOT_AVAILABLE':
         return status
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to create a keystore', changed=False)
 
     # Determine location
     if not keystore_location:

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -160,6 +160,20 @@ EXAMPLES = '''
 '''
 
 
+import re as _re
+
+
+def _redact_ddls(ddls):
+    """Redact passwords and secrets from DDL statements before returning to user."""
+    redacted = []
+    for ddl in ddls:
+        s = _re.sub(r'(IDENTIFIED\s+BY\s+)"[^"]*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
+        s = _re.sub(r"(SECRET\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r"(USING\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        redacted.append(s)
+    return redacted
+
+
 def get_wallet_status(conn):
     """Query V$ENCRYPTION_WALLET for current keystore status."""
     sql = """SELECT WRL_TYPE, WRL_PARAMETER, STATUS, WALLET_TYPE, WALLET_ORDER, KEYSTORE_MODE
@@ -286,6 +300,14 @@ def create_auto_login(conn, module):
     keystore_location = module.params["keystore_location"]
 
     if auto_login == 'none':
+        return
+
+    # Check if the desired auto-login type already exists
+    status = get_wallet_status(conn)
+    current_type = status.get('wallet_type', '') if status else ''
+    if auto_login == 'auto_login' and current_type == 'AUTOLOGIN':
+        return
+    if auto_login == 'local_auto_login' and current_type == 'LOCAL_AUTOLOGIN':
         return
 
     if not keystore_password:
@@ -462,7 +484,7 @@ def main():
         status = get_wallet_status(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='Secret managed successfully',
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',
@@ -505,7 +527,7 @@ def main():
         status = get_wallet_status(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='Keystore managed successfully',
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',
@@ -517,7 +539,7 @@ def main():
         status = get_wallet_status(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='Keystore is open',
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',
@@ -529,7 +551,7 @@ def main():
         status = get_wallet_status(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='Keystore is closed',
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -213,6 +213,11 @@ def validate_wallet_inputs_before_connect(module):
             module.fail_json(msg='keystore_password is required for secret management', changed=False)
         if secret_state == 'present' and not module.params.get('secret'):
             module.fail_json(msg='secret is required when secret_state=present', changed=False)
+        if backup_location:
+            module.fail_json(
+                msg='backup_location is not supported for secret management (Oracle does not support TO clause with secret DDL)',
+                changed=False,
+            )
         _assert_sql_embeddable_str(module, module.params.get('secret_client'), "'")
         _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
         if module.params.get('secret'):
@@ -234,6 +239,11 @@ def validate_wallet_inputs_before_connect(module):
             _assert_sql_embeddable_str(module, loc, "'")
         _assert_sql_embeddable_str(module, backup_tag, "'")
         _assert_sql_embeddable_str(module, backup_location, "'")
+        auto_login = module.params.get('auto_login')
+        if auto_login and auto_login != 'none':
+            if not module.params.get('keystore_password'):
+                module.fail_json(msg='keystore_password is required when auto_login is set', changed=False)
+            _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
         if change_password_flag:
             _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
             _assert_sql_embeddable_str(module, module.params.get('new_password'), '"')
@@ -257,34 +267,35 @@ def validate_wallet_inputs_before_connect(module):
             _assert_sql_embeddable_str(module, ks, '"')
 
 
-def _redact_ddls(ddls):
-    """Redact passwords and secrets from DDL statements before returning to user.
+def _redact_ddl(ddl):
+    """Redact passwords and secrets from a single DDL statement.
 
     Backup identifiers in ``... USING 'tag'`` (BACKUP KEYSTORE / WITH BACKUP) are
     left visible; they are not credentials. ``USING TAG`` for secrets uses a
     different token sequence and is unaffected.
     """
-    # Oracle doubles embedded quotes inside literals; match full quoted spans.
     _sq_lit = r"'(?:[^']|'')*'"
     _dq_lit = r'"(?:[^"]|"")*"'
-    redacted = []
-    for ddl in ddls:
-        s = _re.sub(r'(IDENTIFIED\s+BY\s+)' + _dq_lit, r'\1"***"', ddl, flags=_re.IGNORECASE)
-        s = _re.sub(r'(SECRET\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
-        s = _re.sub(
-            r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _dq_lit,
-            r"\1'***'",
-            s,
-            flags=_re.IGNORECASE,
-        )
-        s = _re.sub(
-            r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _sq_lit,
-            r"\1'***'",
-            s,
-            flags=_re.IGNORECASE,
-        )
-        redacted.append(s)
-    return redacted
+    s = _re.sub(r'(IDENTIFIED\s+BY\s+)' + _dq_lit, r'\1"***"', ddl, flags=_re.IGNORECASE)
+    s = _re.sub(r'(SECRET\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
+    s = _re.sub(
+        r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _dq_lit,
+        r"\1'***'",
+        s,
+        flags=_re.IGNORECASE,
+    )
+    s = _re.sub(
+        r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _sq_lit,
+        r"\1'***'",
+        s,
+        flags=_re.IGNORECASE,
+    )
+    return s
+
+
+def _redact_ddls(ddls):
+    """Redact passwords and secrets from a list of DDL statements."""
+    return [_redact_ddl(d) for d in ddls]
 
 
 def _vwallet_field(row, col):
@@ -394,15 +405,12 @@ def secret_exists(conn, client_name, secret_tag=None):
     if not secrets:
         return False
     c_upper = client_name.upper()
-    want_tag = (secret_tag or '').strip()
-    want_tag_u = want_tag.upper() if want_tag else None
+    want_tag_u = (secret_tag or '').strip().upper()
     for s in secrets:
         cli = (_vwallet_field(s, 'CLIENT') or '').upper()
         if cli != c_upper:
             continue
-        if want_tag_u is None:
-            return True
-        tag = (_vwallet_field(s, 'SECRET_TAG') or '').upper()
+        tag = (_vwallet_field(s, 'SECRET_TAG') or '').strip().upper()
         if tag == want_tag_u:
             return True
     return False
@@ -438,7 +446,7 @@ def ensure_keystore_present(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
         loc_esc, pwd_esc
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
     return get_wallet_status(conn, module.params["container"])
 
 
@@ -463,7 +471,7 @@ def ensure_keystore_open(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT %sSET KEYSTORE OPEN IDENTIFIED BY \"%s\"%s" % (
         force, pwd_esc, container_clause
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
     return get_wallet_status(conn, module.params["container"])
 
 
@@ -490,7 +498,7 @@ def ensure_keystore_closed(conn, module):
         sql = "ADMINISTER KEY MANAGEMENT SET KEYSTORE CLOSE IDENTIFIED BY \"%s\"%s" % (
             pwd_esc, container_clause
         )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
     return get_wallet_status(conn, module.params["container"])
 
 
@@ -535,7 +543,7 @@ def create_auto_login(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT CREATE %sAUTO_LOGIN KEYSTORE FROM KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
         local_clause, loc_esc, pwd_esc
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
 
 def backup_keystore(conn, module, identified_by_password=None):
@@ -567,7 +575,7 @@ def backup_keystore(conn, module, identified_by_password=None):
     if backup_location:
         loc_esc = escape_sql_literal_or_fail(backup_location, "'", module)
         sql += " TO '%s'" % loc_esc
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
 
 def change_keystore_password(conn, module):
@@ -589,7 +597,7 @@ def change_keystore_password(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT %sALTER KEYSTORE PASSWORD IDENTIFIED BY \"%s\" SET \"%s\"%s" % (
         force, old_esc, new_esc, backup_clause
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
 
 def manage_secret(conn, module):
@@ -625,7 +633,7 @@ def manage_secret(conn, module):
             sql = "ADMINISTER KEY MANAGEMENT %sADD SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
                 force, safe_secret, safe_client, tag_clause, pwd_esc, backup_clause
             )
-        conn.execute_ddl(sql)
+        conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
     elif secret_state == 'absent':
         if not exists:
@@ -637,7 +645,7 @@ def manage_secret(conn, module):
         sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
             force, safe_client, tag_clause, pwd_esc, backup_clause
         )
-        conn.execute_ddl(sql)
+        conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
 
 def main():
@@ -681,7 +689,7 @@ def main():
     if not HAS_ORACLE_UTILS:
         module.fail_json(msg='oracle_utils is required for oracle_wallet: %s' % _ORACLE_UTILS_ERR)
 
-    sanitize_string_params(module.params)
+    sanitize_string_params(module.params, no_trim={'password', 'keystore_password', 'new_password', 'secret'})
 
     state = module.params["state"]
     secret_state = module.params["secret_state"]
@@ -810,8 +818,11 @@ except ImportError as e:
     HAS_ORACLE_UTILS = False
     _ORACLE_UTILS_ERR = str(e)
 
-    def sanitize_string_params(module_params):
+    def sanitize_string_params(module_params, no_trim=None):
+        skip = set(no_trim) if no_trim else set()
         for key, value in module_params.items():
+            if key in skip:
+                continue
             if isinstance(value, str):
                 module_params[key] = value.strip()
 

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -310,12 +310,26 @@ def _vwallet_field(row, col):
     return ''
 
 
+def _normalize_wallet_row(row):
+    """Normalize a V$ENCRYPTION_WALLET row dict to lowercase keys."""
+    if not row:
+        return {}
+    return {
+        'wrl_type': _vwallet_field(row, 'WRL_TYPE'),
+        'wrl_parameter': _vwallet_field(row, 'WRL_PARAMETER'),
+        'status': _vwallet_field(row, 'STATUS'),
+        'wallet_type': _vwallet_field(row, 'WALLET_TYPE'),
+        'wallet_order': _vwallet_field(row, 'WALLET_ORDER'),
+        'keystore_mode': _vwallet_field(row, 'KEYSTORE_MODE'),
+    }
+
+
 def _aggregate_wallet_rows(rows):
     """Merge multiple V$ENCRYPTION_WALLET rows when ``container`` is ``all``."""
     if not rows:
         return {}
     if len(rows) == 1:
-        return rows[0]
+        return _normalize_wallet_row(rows[0])
 
     statuses = []
     for r in rows:
@@ -383,14 +397,14 @@ def get_wallet_status(conn, container=None):
             return {}
         return _aggregate_wallet_rows(rows)
     sql = base_sql + "\n             WHERE ROWNUM = 1"
-    return conn.execute_select_to_dict(sql, fetchone=True)
+    return _normalize_wallet_row(conn.execute_select_to_dict(sql, fetchone=True))
 
 
 def get_wallet_root(conn):
     """Get WALLET_ROOT parameter value."""
     sql = "SELECT VALUE FROM V$PARAMETER WHERE NAME = 'wallet_root'"
     r = conn.execute_select_to_dict(sql, fetchone=True)
-    return r.get('value') if r else None
+    return _vwallet_field(r, 'VALUE') if r else None
 
 
 def get_secrets(conn):
@@ -710,7 +724,7 @@ def main():
             keystore_mode=status.get('keystore_mode', '') if status else '',
             wrl_type=status.get('wrl_type', '') if status else '',
             wrl_parameter=status.get('wrl_parameter', '') if status else '',
-            secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
+            secrets=[{'client': _vwallet_field(s, 'CLIENT'), 'tag': _vwallet_field(s, 'SECRET_TAG')} for s in secrets],
         )
 
     if module.check_mode:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,7 +30,67 @@ def module_path(*parts):
     return REPO_ROOT.joinpath(*parts)
 
 
+_OU_PATH = "ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils"
+
+
+def _sql_single_quoted_literal_stub(value):
+    if value is None:
+        return ''
+    return str(value).replace("'", "''")
+
+
+def _ensure_fake_oracle_utils():
+    """Register (or patch) the collection shim so dynamic module loads always see required symbols."""
+    if _OU_PATH not in sys.modules:
+        class _StubOracleConnection:
+            """Stub that raises RuntimeError — tests must monkeypatch mod.oracleConnection."""
+            def __init__(self, module):
+                raise RuntimeError(
+                    "oracleConnection called without monkeypatching — "
+                    "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
+                )
+
+        _ou_mod = types.ModuleType(_OU_PATH)
+        _ou_mod.oracleConnection = _StubOracleConnection
+        _ou_mod.sanitize_string_params = lambda _params: None
+        _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal_stub
+        _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
+        _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+
+        def _build_backup(backup=True, backup_tag=None):
+            if not backup:
+                return ''
+            clause = ' WITH BACKUP'
+            if backup_tag:
+                clause += " USING '%s'" % backup_tag
+            return clause
+
+        _ou_mod.build_backup_clause = _build_backup
+        sys.modules[_OU_PATH] = _ou_mod
+        return
+
+    ou = sys.modules[_OU_PATH]
+    if not hasattr(ou, 'sql_single_quoted_literal'):
+        ou.sql_single_quoted_literal = _sql_single_quoted_literal_stub
+    if not hasattr(ou, 'build_force_clause'):
+        ou.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
+    if not hasattr(ou, 'build_container_clause'):
+        ou.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+
+    if not hasattr(ou, 'build_backup_clause'):
+        def _build_backup(backup=True, backup_tag=None):
+            if not backup:
+                return ''
+            clause = ' WITH BACKUP'
+            if backup_tag:
+                clause += " USING '%s'" % backup_tag
+            return clause
+        ou.build_backup_clause = _build_backup
+
+
 def _ensure_fake_ansible_basic():
+    _ensure_fake_oracle_utils()
+
     if "ansible.module_utils.basic" in sys.modules:
         return
 
@@ -48,44 +108,6 @@ def _ensure_fake_ansible_basic():
         _fake_oracledb.connect = lambda *a, **kw: None
         _fake_oracledb.makedsn = lambda **kw: "fake_dsn"
         sys.modules["oracledb"] = _fake_oracledb
-
-    # Inject a minimal fake oracle_utils so modules that do
-    #   from ansible_collections...oracle_utils import oracleConnection
-    # get a stub oracleConnection.  Individual tests monkeypatch mod.oracleConnection
-    # to control behaviour.
-    _ou_path = "ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils"
-    if _ou_path not in sys.modules:
-        class _StubOracleConnection:
-            """Stub that raises RuntimeError — tests must monkeypatch mod.oracleConnection."""
-            def __init__(self, module):
-                raise RuntimeError(
-                    "oracleConnection called without monkeypatching — "
-                    "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
-                )
-
-        def _sql_single_quoted_literal(value):
-            if value is None:
-                return ''
-            return str(value).replace("'", "''")
-
-        _ou_mod = types.ModuleType(_ou_path)
-        _ou_mod.oracleConnection = _StubOracleConnection
-        _ou_mod.sanitize_string_params = lambda _params: None
-        _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
-
-        # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
-        _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
-        _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
-        def _build_backup(backup=True, backup_tag=None):
-            if not backup:
-                return ''
-            clause = ' WITH BACKUP'
-            if backup_tag:
-                clause += " USING '%s'" % backup_tag
-            return clause
-        _ou_mod.build_backup_clause = _build_backup
-
-        sys.modules[_ou_path] = _ou_mod
 
     ansible_mod = types.ModuleType("ansible")
     module_utils_mod = types.ModuleType("ansible.module_utils")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,9 +63,16 @@ def _ensure_fake_ansible_basic():
                     "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
                 )
 
+        def _sanitize_string_params(module_params):
+            """Mirror production oracle_utils.sanitize_string_params; return dict for tests."""
+            for key, value in module_params.items():
+                if isinstance(value, str):
+                    module_params[key] = value.strip()
+            return module_params
+
         _ou_mod = types.ModuleType(_ou_path)
         _ou_mod.oracleConnection = _StubOracleConnection
-        _ou_mod.sanitize_string_params = lambda _params: None
+        _ou_mod.sanitize_string_params = _sanitize_string_params
         _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
 
         # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,9 +63,12 @@ def _ensure_fake_ansible_basic():
                     "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
                 )
 
-        def _sanitize_string_params(module_params):
+        def _sanitize_string_params(module_params, no_trim=None):
             """Mirror production oracle_utils.sanitize_string_params; return dict for tests."""
+            skip = set(no_trim) if no_trim else set()
             for key, value in module_params.items():
+                if key in skip:
+                    continue
                 if isinstance(value, str):
                     module_params[key] = value.strip()
             return module_params

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,11 +63,6 @@ def _ensure_fake_ansible_basic():
                     "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
                 )
 
-        def _sql_single_quoted_literal(value):
-            if value is None:
-                return ''
-            return str(value).replace("'", "''")
-
         _ou_mod = types.ModuleType(_ou_path)
         _ou_mod.oracleConnection = _StubOracleConnection
         _ou_mod.sanitize_string_params = lambda _params: None
@@ -76,13 +71,12 @@ def _ensure_fake_ansible_basic():
         # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
         _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
         _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+
         def _sql_single_quoted_literal(value):
             """Match oracle_utils.sql_single_quoted_literal for unit tests (no package import)."""
             if value is None:
-                return None
-            if not isinstance(value, str):
-                raise TypeError('sql_single_quoted_literal expects str or None')
-            return value.replace("'", "''")
+                return ''
+            return str(value).replace("'", "''")
 
         _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -76,13 +76,24 @@ def _ensure_fake_ansible_basic():
         # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
         _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
         _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+        def _sql_single_quoted_literal(value):
+            """Match oracle_utils.sql_single_quoted_literal for unit tests (no package import)."""
+            if value is None:
+                return None
+            if not isinstance(value, str):
+                raise TypeError('sql_single_quoted_literal expects str or None')
+            return value.replace("'", "''")
+
+        _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
+
         def _build_backup(backup=True, backup_tag=None):
             if not backup:
                 return ''
             clause = ' WITH BACKUP'
             if backup_tag:
-                clause += " USING '%s'" % backup_tag
+                clause += " USING '%s'" % _sql_single_quoted_literal(backup_tag)
             return clause
+
         _ou_mod.build_backup_clause = _build_backup
         sys.modules[_ou_path] = _ou_mod
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -72,6 +72,19 @@ def _ensure_fake_ansible_basic():
         _ou_mod.oracleConnection = _StubOracleConnection
         _ou_mod.sanitize_string_params = lambda _params: None
         _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
+
+        # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
+        _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
+        _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+        def _build_backup(backup=True, backup_tag=None):
+            if not backup:
+                return ''
+            clause = ' WITH BACKUP'
+            if backup_tag:
+                clause += " USING '%s'" % backup_tag
+            return clause
+        _ou_mod.build_backup_clause = _build_backup
+
         sys.modules[_ou_path] = _ou_mod
 
     ansible_mod = types.ModuleType("ansible")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,6 +70,12 @@ def _ensure_fake_ansible_basic():
                     module_params[key] = value.strip()
             return module_params
 
+        def _sql_single_quoted_literal(value):
+            """Match oracle_utils.sql_single_quoted_literal for unit tests (no package import)."""
+            if value is None:
+                return ''
+            return str(value).replace("'", "''")
+
         _ou_mod = types.ModuleType(_ou_path)
         _ou_mod.oracleConnection = _StubOracleConnection
         _ou_mod.sanitize_string_params = _sanitize_string_params
@@ -78,14 +84,6 @@ def _ensure_fake_ansible_basic():
         # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
         _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
         _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
-
-        def _sql_single_quoted_literal(value):
-            """Match oracle_utils.sql_single_quoted_literal for unit tests (no package import)."""
-            if value is None:
-                return ''
-            return str(value).replace("'", "''")
-
-        _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
 
         def _build_backup(backup=True, backup_tag=None):
             if not backup:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -52,7 +52,16 @@ def _ensure_fake_oracle_utils():
 
         _ou_mod = types.ModuleType(_OU_PATH)
         _ou_mod.oracleConnection = _StubOracleConnection
-        _ou_mod.sanitize_string_params = lambda _params: None
+        def _sanitize_string_params(module_params, no_trim=None):
+            skip = set(no_trim) if no_trim else set()
+            for key, value in module_params.items():
+                if key in skip:
+                    continue
+                if isinstance(value, str):
+                    module_params[key] = value.strip()
+            return module_params
+
+        _ou_mod.sanitize_string_params = _sanitize_string_params
         _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal_stub
         _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
         _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -72,6 +72,18 @@ def _ensure_fake_ansible_basic():
         _ou_mod.oracleConnection = _StubOracleConnection
         _ou_mod.sanitize_string_params = lambda _params: None
         _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
+
+        # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
+        _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
+        _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+        def _build_backup(backup=True, backup_tag=None):
+            if not backup:
+                return ''
+            clause = ' WITH BACKUP'
+            if backup_tag:
+                clause += " USING '%s'" % backup_tag
+            return clause
+        _ou_mod.build_backup_clause = _build_backup
         sys.modules[_ou_path] = _ou_mod
 
     ansible_mod = types.ModuleType("ansible")

--- a/tests/unit/test_all_modules_contracts.py
+++ b/tests/unit/test_all_modules_contracts.py
@@ -10,7 +10,9 @@ def _module_files():
 
 
 def test_all_modules_keep_original_name_prefix():
-    for module_file in _module_files():
+    files = _module_files()
+    assert files, "expected at least one plugins/modules/oracle_*.py module"
+    for module_file in files:
         assert module_file.name.startswith("oracle_")
 
 

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -1,0 +1,552 @@
+"""Unit tests for oracle_dataguard module."""
+import pytest
+
+from conftest import ExitJson, FailJson, load_module_from_path, module_path
+from helpers import BASE_CONN_PARAMS, BaseFakeConn, BaseFakeModule
+
+
+def _load():
+    return load_module_from_path(
+        module_path("plugins", "modules", "oracle_dataguard.py"), "oracle_dataguard_test"
+    )
+
+
+def _dg_params(**overrides):
+    base = {
+        **BASE_CONN_PARAMS,
+        "mode_dg": "broker",
+        "state": "status",
+        "dgmgrl_user": None,
+        "dgmgrl_password": None,
+        "dgmgrl_connect_identifier": None,
+        "dgmgrl_as": "sysdg",
+        "configuration_name": None,
+        "primary_database": None,
+        "connect_identifier": None,
+        "database_name": None,
+        "properties": None,
+        "protection_mode": None,
+        "database_state": None,
+        "fsfo": None,
+        "fsfo_target": None,
+        "far_sync_name": None,
+        "far_sync_connect_identifier": None,
+        "observer_state": None,
+        "output_format": "text",
+        "force_logging": None,
+        "apply_state": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# DGMGRL output fixtures
+# ===========================================================================
+
+SHOW_CONFIG_OUTPUT = """Configuration - my_dg_config
+
+  Protection Mode: MaxPerformance
+  Members:
+  PROD    - Primary database
+    STDBY   - Physical standby database
+
+Fast-Start Failover:  Disabled
+
+Configuration Status:
+SUCCESS   (status updated 5 seconds ago)
+"""
+
+SHOW_CONFIG_NOT_CONFIGURED = """ORA-16532: Oracle Data Guard broker configuration does not exist
+Configuration details cannot be determined by DGMGRL
+"""
+
+
+class _DgBrokerModule(BaseFakeModule):
+    """Module that stubs run_command for DGMGRL."""
+
+    _dgmgrl_responses = {}
+
+    def run_command(self, command, **kwargs):
+        data = kwargs.get('data', '')
+        # Check which commands are in the script
+        for key, (rc, stdout, stderr) in self._dgmgrl_responses.items():
+            if key in data.upper():
+                return (rc, stdout, stderr)
+        # Default: show configuration
+        return (0, SHOW_CONFIG_OUTPUT, '')
+
+
+# ===========================================================================
+# Tests: Broker mode - status
+# ===========================================================================
+
+def test_dg_broker_status(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle")
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["configuration"]["name"] == "my_dg_config"
+    assert result["configuration"]["protection_mode"] == "MaxPerformance"
+
+
+def test_dg_broker_status_not_configured(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle")
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (1, SHOW_CONFIG_NOT_CONFIGURED, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["configuration"]["status"] == "NOT_CONFIGURED"
+
+
+# ===========================================================================
+# Tests: Broker mode - create configuration
+# ===========================================================================
+
+def test_dg_broker_create_config(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            configuration_name="my_dg",
+            primary_database="PROD",
+            connect_identifier="prod-host:1521/PROD",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (1, SHOW_CONFIG_NOT_CONFIGURED, ''),
+            'CREATE CONFIGURATION': (0, 'Succeeded.', ''),
+        }
+        _call_count = 0
+
+        def run_command(self, command, **kwargs):
+            data = kwargs.get('data', '')
+            # First call: show config returns not configured
+            # Second call: create succeeds
+            # Third call: show config returns success
+            self.__class__._call_count += 1
+            if self.__class__._call_count <= 1:
+                return (1, SHOW_CONFIG_NOT_CONFIGURED, '')
+            elif 'CREATE' in data.upper():
+                return (0, 'Succeeded.', '')
+            else:
+                return (0, SHOW_CONFIG_OUTPUT, '')
+
+    Mod._call_count = 0
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+# ===========================================================================
+# Tests: Broker mode - absent (remove)
+# ===========================================================================
+
+def test_dg_broker_remove_database(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="absent",
+            database_name="STDBY",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'REMOVE DATABASE': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_dg_broker_remove_configuration(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="absent",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'REMOVE CONFIGURATION': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_dg_broker_absent_when_not_configured(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="absent",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (1, SHOW_CONFIG_NOT_CONFIGURED, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: Broker mode - enable/disable
+# ===========================================================================
+
+def test_dg_broker_enable_configuration(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="enabled")
+        _dgmgrl_responses = {
+            'ENABLE CONFIGURATION': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_dg_broker_disable_database(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="disabled", database_name="STDBY")
+        _dgmgrl_responses = {
+            'DISABLE DATABASE': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+# ===========================================================================
+# Tests: Broker mode - switchover/failover
+# ===========================================================================
+
+def test_dg_broker_switchover(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="switchover", database_name="STDBY")
+        _dgmgrl_responses = {
+            'SWITCHOVER TO': (0, 'Switchover succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert "switchover" in result["msg"].lower()
+
+
+def test_dg_broker_failover(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="failover", database_name="STDBY")
+        _dgmgrl_responses = {
+            'FAILOVER TO': (0, 'Failover succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+# ===========================================================================
+# Tests: Broker mode - convert
+# ===========================================================================
+
+def test_dg_broker_convert_snapshot(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="snapshot_standby", database_name="STDBY")
+        _dgmgrl_responses = {
+            'CONVERT DATABASE': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert "snapshot" in result["msg"].lower()
+
+
+# ===========================================================================
+# Tests: SQL mode - status
+# ===========================================================================
+
+class _DgSqlConn(BaseFakeConn):
+    """Simulates V$DATABASE, V$DATAGUARD_STATS, etc."""
+
+    def __init__(self, module, db_role='PRIMARY', force_logging='YES',
+                 protection_mode='MAXIMUM PERFORMANCE', dg_processes=None):
+        super().__init__(module)
+        self._db_role = db_role
+        self._force_logging = force_logging
+        self._protection_mode = protection_mode
+        self._dg_processes = dg_processes or []
+
+    def execute_select_to_dict(self, sql, params=None, fetchone=False, fail_on_error=True):
+        sql_upper = sql.upper()
+        if 'V$DATABASE' in sql_upper:
+            row = {
+                'database_role': self._db_role,
+                'protection_mode': self._protection_mode,
+                'protection_level': self._protection_mode,
+                'switchover_status': 'TO STANDBY',
+                'dataguard_broker': 'ENABLED',
+                'force_logging': self._force_logging,
+                'flashback_on': 'YES',
+                'db_unique_name': 'PROD',
+            }
+            return row if fetchone else [row]
+        if 'V$DATAGUARD_STATS' in sql_upper:
+            return [
+                {'name': 'transport lag', 'value': '+00 00:00:00', 'unit': 'day(2) to second(0) interval', 'time_computed': '2024-01-01', 'datum_time': '2024-01-01'},
+                {'name': 'apply lag', 'value': '+00 00:00:02', 'unit': 'day(2) to second(0) interval', 'time_computed': '2024-01-01', 'datum_time': '2024-01-01'},
+            ]
+        if 'V$ARCHIVE_DEST_STATUS' in sql_upper:
+            return [{'dest_id': 2, 'status': 'VALID', 'type': 'PHYSICAL', 'database_mode': 'MOUNTED',
+                     'recovery_mode': 'MANAGED REAL TIME APPLY', 'gap_status': 'NO GAP',
+                     'synchronized': 'YES', 'error': '', 'db_unique_name': 'STDBY'}]
+        if 'V$DATAGUARD_PROCESS' in sql_upper:
+            return self._dg_processes
+        return {} if fetchone else []
+
+
+def test_dg_sql_status(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="status")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["database"]["database_role"] == "PRIMARY"
+    assert len(result["dataguard_stats"]) == 2
+
+
+# ===========================================================================
+# Tests: SQL mode - apply management
+# ===========================================================================
+
+def test_dg_sql_start_apply(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", apply_state="started")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, db_role='PHYSICAL STANDBY'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("RECOVER MANAGED STANDBY" in d for d in result["ddls"])
+
+
+def test_dg_sql_start_apply_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", apply_state="started")
+
+    processes = [{'role': 'MRP', 'action': 'APPLYING_LOG', 'client_role': '', 'thread#': 1, 'sequence#': 100, 'block#': 1}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, dg_processes=processes), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_dg_sql_stop_apply(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", apply_state="stopped")
+
+    processes = [{'role': 'MRP', 'action': 'APPLYING_LOG', 'client_role': '', 'thread#': 1, 'sequence#': 100, 'block#': 1}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, dg_processes=processes), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("CANCEL" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: SQL mode - force logging
+# ===========================================================================
+
+def test_dg_sql_enable_force_logging(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", force_logging="enable")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, force_logging='NO'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("FORCE LOGGING" in d for d in result["ddls"])
+
+
+def test_dg_sql_force_logging_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", force_logging="enable")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, force_logging='YES'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: SQL mode - protection mode
+# ===========================================================================
+
+def test_dg_sql_set_protection_mode(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", protection_mode="maximum_availability")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, protection_mode='MAXIMUM PERFORMANCE'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("MAXIMIZE AVAILABILITY" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: parse_show_configuration
+# ===========================================================================
+
+def test_parse_show_configuration():
+    mod = _load()
+    result = mod.parse_show_configuration(SHOW_CONFIG_OUTPUT)
+    assert result["name"] == "my_dg_config"
+    assert result["protection_mode"] == "MaxPerformance"
+    assert result["fast_start_failover"] == "Disabled"
+    assert len(result["databases"]) == 2
+    assert result["databases"][0]["role"] == "PRIMARY"
+    assert result["databases"][1]["role"] == "PHYSICAL STANDBY"
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+class _FakeOs:
+    """Fake os module that makes path.exists return True for oracle_home."""
+
+    def __init__(self, oracle_home):
+        self._oracle_home = oracle_home
+        self.environ = dict(ORACLE_HOME=oracle_home)
+
+    class path:
+        _oracle_home = None
+
+        @classmethod
+        def exists(cls, path_str):
+            return True
+
+        @classmethod
+        def join(cls, *args):
+            import os as _os
+            return _os.path.join(*args)
+
+    def __getattr__(self, name):
+        import os as _os
+        return getattr(_os, name)
+
+
+# Ensure _FakeOs.path methods work for all tests
+_FakeOs.path._oracle_home = "/fake/oracle"

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -69,11 +69,13 @@ Configuration details cannot be determined by DGMGRL
 class _DgBrokerModule(BaseFakeModule):
     """Module that stubs run_command for DGMGRL."""
 
-    _dgmgrl_responses = {}
-    _run_command_calls = []
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._dgmgrl_responses = getattr(type(self), '_dgmgrl_responses', {})
+        self._run_command_calls = getattr(type(self), '_run_command_calls', [])
 
     def run_command(self, command, **kwargs):
-        type(self)._run_command_calls.append((command, kwargs))
+        self._run_command_calls.append((command, kwargs))
         data = kwargs.get('data', '')
         # Check which commands are in the script
         for key, (rc, stdout, stderr) in self._dgmgrl_responses.items():

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -528,12 +528,9 @@ class _FakeOs:
     """Fake os module that makes path.exists return True for oracle_home."""
 
     def __init__(self, oracle_home):
-        self._oracle_home = oracle_home
         self.environ = dict(ORACLE_HOME=oracle_home)
 
     class path:
-        _oracle_home = None
-
         @classmethod
         def exists(cls, path_str):
             return True
@@ -546,7 +543,3 @@ class _FakeOs:
     def __getattr__(self, name):
         import os as _os
         return getattr(_os, name)
-
-
-# Ensure _FakeOs.path methods work for all tests
-_FakeOs.path._oracle_home = "/fake/oracle"

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -836,6 +836,7 @@ def test_parse_show_configuration():
     assert len(result["databases"]) == 2
     assert result["databases"][0]["role"] == "PRIMARY"
     assert result["databases"][1]["role"] == "PHYSICAL STANDBY"
+    assert result["status"] == "SUCCESS"
 
 
 # ===========================================================================

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -32,6 +32,10 @@ def _dg_params(**overrides):
         "far_sync_name": None,
         "far_sync_connect_identifier": None,
         "observer_state": None,
+        "validate_connect_identifier": None,
+        "primary_database_candidates": None,
+        "tags": None,
+        "reset_tags": None,
         "output_format": "text",
         "force_logging": None,
         "apply_state": None,
@@ -66,8 +70,10 @@ class _DgBrokerModule(BaseFakeModule):
     """Module that stubs run_command for DGMGRL."""
 
     _dgmgrl_responses = {}
+    _run_command_calls = []
 
     def run_command(self, command, **kwargs):
+        type(self)._run_command_calls.append((command, kwargs))
         data = kwargs.get('data', '')
         # Check which commands are in the script
         for key, (rc, stdout, stderr) in self._dgmgrl_responses.items():
@@ -503,6 +509,318 @@ def test_dg_sql_set_protection_mode(monkeypatch):
     result = exc.value.args[0]
     assert result["changed"] is True
     assert any("MAXIMIZE AVAILABILITY" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: FSFO Target
+# ===========================================================================
+
+def test_dg_broker_fsfo_enable_with_target(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            fsfo="enabled",
+            fsfo_target="STDBY",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'ENABLE FAST_START FAILOVER': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    # Verify the target was included in the command
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('TARGET TO STDBY' in c for c in calls)
+
+
+def test_dg_broker_fsfo_enable_without_target(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            fsfo="enabled",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'ENABLE FAST_START FAILOVER': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('ENABLE FAST_START FAILOVER' in c and 'TARGET' not in c for c in calls)
+
+
+# ===========================================================================
+# Tests: VALIDATE DGConnectIdentifier (26ai)
+# ===========================================================================
+
+def test_dg_broker_validate_connect_identifier(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="status",
+            validate_connect_identifier="stdby-host:1521/STDBY",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'VALIDATE DGCONNECTIDENTIFIER': (0, 'Validation succeeded.', ''),
+            'SHOW': (0, '', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["validate_connect_identifier"] is not None
+    assert result["validate_connect_identifier"]["rc"] == 0
+
+
+def test_dg_broker_validate_connect_identifier_injection(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="status",
+            validate_connect_identifier="host:1521/SVC; DROP CONFIGURATION",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert 'Invalid' in exc.value.args[0]['msg']
+
+
+# ===========================================================================
+# Tests: PrimaryDatabaseCandidates (26ai)
+# ===========================================================================
+
+def test_dg_broker_set_primary_db_candidates(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            primary_database_candidates=["PROD", "STDBY"],
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'PRIMARYDATABASECANDIDATES': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_dg_broker_primary_db_candidates_invalid_name(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            primary_database_candidates=["PROD", "BAD NAME"],
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert 'Invalid' in exc.value.args[0]['msg']
+
+
+def test_dg_broker_primary_db_candidates_unsupported(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            primary_database_candidates=["PROD"],
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'PRIMARYDATABASECANDIDATES': (1, 'ORA-16599: invalid property', ''),
+        }
+        _warnings = []
+
+        def warn(self, msg):
+            type(self)._warnings.append(msg)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    # changed=False because the feature was skipped
+    assert any('not supported' in w for w in Mod._warnings)
+
+
+# ===========================================================================
+# Tests: Tagging (26ai)
+# ===========================================================================
+
+def test_dg_broker_set_tags_database(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            database_name="STDBY",
+            tags={"environment": "production", "tier": "dr"},
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'SET TAG': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('EDIT DATABASE STDBY SET TAG' in c for c in calls)
+
+
+def test_dg_broker_set_tags_configuration(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            tags={"site": "dc1"},
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'SET TAG': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('EDIT CONFIGURATION SET TAG' in c for c in calls)
+
+
+def test_dg_broker_reset_tags(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            database_name="STDBY",
+            reset_tags=["environment"],
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'RESET TAG': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('EDIT DATABASE STDBY RESET TAG environment' in c for c in calls)
+
+
+def test_dg_broker_show_tags_in_status(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="status",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'SHOW': (0, 'environment=production\ntier=dr\n', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["tags"] is not None
+
+
+def test_dg_broker_tags_invalid_name(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            tags={"bad tag!": "value"},
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert 'Invalid tag name' in exc.value.args[0]['msg']
 
 
 # ===========================================================================

--- a/tests/unit/test_oracle_tde.py
+++ b/tests/unit/test_oracle_tde.py
@@ -1,0 +1,397 @@
+"""Unit tests for oracle_tde module."""
+import pytest
+
+from conftest import ExitJson, FailJson, load_module_from_path, module_path
+from helpers import BASE_CONN_PARAMS, BaseFakeConn, BaseFakeModule
+
+
+def _load():
+    return load_module_from_path(
+        module_path("plugins", "modules", "oracle_tde.py"), "oracle_tde_test"
+    )
+
+
+def _tde_params(**overrides):
+    base = {
+        **BASE_CONN_PARAMS,
+        "state": "present",
+        "master_key_action": None,
+        "algorithm": "AES256",
+        "key_tag": None,
+        "keystore_password": "TestKeystorePass123",
+        "tablespace": None,
+        "tablespace_state": None,
+        "file_name_convert": None,
+        "online": True,
+        "export_file": None,
+        "export_secret": None,
+        "tablespace_encryption_policy": None,
+        "force_keystore": False,
+        "container": "current",
+    }
+    base.update(overrides)
+    return base
+
+
+class _TdeConn(BaseFakeConn):
+    """Simulates V$ENCRYPTION_WALLET, V$ENCRYPTION_KEYS, V$ENCRYPTED_TABLESPACES."""
+
+    def __init__(self, module, wallet_status='OPEN', has_master_key=True,
+                 encrypted_tablespaces=None, param_value=None):
+        super().__init__(module)
+        self._wallet_status = wallet_status
+        self._has_master_key = has_master_key
+        self._encrypted_tablespaces = encrypted_tablespaces or []
+        self._param_value = param_value
+
+    def execute_select_to_dict(self, sql, params=None, fetchone=False, fail_on_error=True):
+        sql_upper = sql.upper()
+        if 'V$ENCRYPTION_WALLET' in sql_upper:
+            row = {'status': self._wallet_status, 'wallet_type': 'PASSWORD', 'keystore_mode': 'UNITED'}
+            return row if fetchone else [row]
+        if 'V$ENCRYPTION_KEYS' in sql_upper:
+            if self._has_master_key:
+                row = {
+                    'key_id': 'AABBCCDD11223344',
+                    'tag': 'test_key',
+                    'creation_time': '2024-01-01',
+                    'activation_time': '2024-01-01',
+                    'key_use': 'TDE IN PDB',
+                    'keystore_type': 'SOFTWARE KEYSTORE',
+                    'origin': 'LOCAL',
+                }
+                return [row]
+            return []
+        if 'V$ENCRYPTED_TABLESPACES' in sql_upper:
+            if params and params.get('tablespace'):
+                ts_name = params['tablespace'].upper()
+                for ts in self._encrypted_tablespaces:
+                    if ts['tablespace_name'].upper() == ts_name:
+                        return ts if fetchone else [ts]
+                return {} if fetchone else []
+            return self._encrypted_tablespaces
+        if 'V$PARAMETER' in sql_upper:
+            row = {'value': self._param_value}
+            return row if fetchone else [row]
+        return {} if fetchone else []
+
+
+# ===========================================================================
+# Tests: state=status
+# ===========================================================================
+
+def test_tde_status(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(state="status")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["wallet_status"] == "OPEN"
+    assert result["master_key"]["key_id"] == "AABBCCDD11223344"
+
+
+# ===========================================================================
+# Tests: set_key
+# ===========================================================================
+
+def test_tde_set_key(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(master_key_action="set_key")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("SET KEY" in d for d in result["ddls"])
+
+
+def test_tde_set_key_with_algorithm_and_tag(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(master_key_action="set_key", algorithm="AES128", key_tag="prod_key")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    ddl = result["ddls"][0]
+    assert "AES128" in ddl
+    assert "prod_key" in ddl
+
+
+def test_tde_set_key_with_container_all(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(master_key_action="set_key", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert any("CONTAINER = ALL" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: rotate_key
+# ===========================================================================
+
+def test_tde_rotate_key(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(master_key_action="rotate_key")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("SET KEY" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: create_key
+# ===========================================================================
+
+def test_tde_create_key(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(master_key_action="create_key")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("CREATE KEY" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: encrypt_tablespace
+# ===========================================================================
+
+def test_tde_encrypt_tablespace(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace="USERS", tablespace_state="encrypted")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("ENCRYPT" in d and "USERS" in d for d in result["ddls"])
+
+
+def test_tde_encrypt_tablespace_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace="USERS", tablespace_state="encrypted")
+
+    encrypted_ts = [{'tablespace_name': 'USERS', 'encryptionalg': 'AES256', 'encryptedts': 'YES', 'status': 'NORMAL', 'key_version': 1}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m, encrypted_tablespaces=encrypted_ts), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: decrypt_tablespace
+# ===========================================================================
+
+def test_tde_decrypt_tablespace(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace="USERS", tablespace_state="decrypted")
+
+    encrypted_ts = [{'tablespace_name': 'USERS', 'encryptionalg': 'AES256', 'encryptedts': 'YES', 'status': 'NORMAL', 'key_version': 1}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m, encrypted_tablespaces=encrypted_ts), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("DECRYPT" in d for d in result["ddls"])
+
+
+def test_tde_decrypt_tablespace_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace="USERS", tablespace_state="decrypted")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m, encrypted_tablespaces=[]), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: rekey_tablespace
+# ===========================================================================
+
+def test_tde_rekey_tablespace(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace="USERS", tablespace_state="rekeyed")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("REKEY" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: export_keys
+# ===========================================================================
+
+def test_tde_export_keys(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(
+            master_key_action="export_keys",
+            export_file="/tmp/keys.exp",
+            export_secret="ExportPass123",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("EXPORT" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: import_keys
+# ===========================================================================
+
+def test_tde_import_keys(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(
+            master_key_action="import_keys",
+            export_file="/tmp/keys.exp",
+            export_secret="ExportPass123",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("IMPORT" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: prerequisites check
+# ===========================================================================
+
+def test_tde_fails_when_keystore_not_open(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(master_key_action="set_key")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m, wallet_status='CLOSED'), raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "not open" in exc.value.args[0]["msg"]
+
+
+def test_tde_encrypt_fails_without_master_key(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace="USERS", tablespace_state="encrypted")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m, has_master_key=False), raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "master key" in exc.value.args[0]["msg"].lower()
+
+
+# ===========================================================================
+# Tests: tablespace_encryption_policy
+# ===========================================================================
+
+def test_tde_set_encryption_policy(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace_encryption_policy="AUTO_ENABLE")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m, param_value='DDL'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("TABLESPACE_ENCRYPTION" in d for d in result["ddls"])
+
+
+def test_tde_set_encryption_policy_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace_encryption_policy="AUTO_ENABLE")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m, param_value='AUTO_ENABLE'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False

--- a/tests/unit/test_oracle_tde.py
+++ b/tests/unit/test_oracle_tde.py
@@ -210,6 +210,42 @@ def test_tde_encrypt_tablespace(monkeypatch):
     assert any("ENCRYPT" in d and "USERS" in d for d in result["ddls"])
 
 
+def test_tde_encrypt_tablespace_offline_includes_algorithm(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace="USERS", tablespace_state="encrypted", online=False, algorithm="AES256")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    ddl = [d for d in result["ddls"] if "ENCRYPT" in d and "USERS" in d][0]
+    assert "OFFLINE" in ddl
+    assert "AES256" in ddl
+
+
+def test_tde_rekey_tablespace_offline_includes_algorithm(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace="USERS", tablespace_state="rekeyed", online=False, algorithm="AES256")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    ddl = [d for d in result["ddls"] if "REKEY" in d and "USERS" in d][0]
+    assert "OFFLINE" in ddl
+    assert "AES256" in ddl
+
+
 def test_tde_encrypt_tablespace_idempotent(monkeypatch):
     mod = _load()
 

--- a/tests/unit/test_oracle_tde.py
+++ b/tests/unit/test_oracle_tde.py
@@ -70,7 +70,7 @@ class _TdeConn(BaseFakeConn):
                         return ts if fetchone else [ts]
                 return {} if fetchone else []
             return self._encrypted_tablespaces
-        if 'V$PARAMETER' in sql_upper:
+        if 'V$SPPARAMETER' in sql_upper or 'V$PARAMETER' in sql_upper:
             row = {'value': self._param_value}
             return row if fetchone else [row]
         return {} if fetchone else []

--- a/tests/unit/test_oracle_tde.py
+++ b/tests/unit/test_oracle_tde.py
@@ -395,3 +395,19 @@ def test_tde_set_encryption_policy_idempotent(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is False
+
+
+def test_tde_set_encryption_policy_container_all(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(tablespace_encryption_policy="AUTO_ENABLE", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m, param_value='DDL'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("CONTAINER = ALL" in d and "TABLESPACE_ENCRYPTION" in d for d in result["ddls"])

--- a/tests/unit/test_oracle_tde.py
+++ b/tests/unit/test_oracle_tde.py
@@ -411,3 +411,84 @@ def test_tde_set_encryption_policy_container_all(monkeypatch):
     result = exc.value.args[0]
     assert result["changed"] is True
     assert any("CONTAINER = ALL" in d and "TABLESPACE_ENCRYPTION" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: FORCE KEYSTORE clause placement (must appear before IDENTIFIED BY)
+# ===========================================================================
+
+def _assert_force_before_identified(ddls):
+    """Verify FORCE KEYSTORE appears immediately before IDENTIFIED BY in any DDL."""
+    for d in ddls:
+        if 'FORCE KEYSTORE' in d:
+            assert 'FORCE KEYSTORE IDENTIFIED BY' in d, (
+                "FORCE KEYSTORE must appear immediately before IDENTIFIED BY, got: %s" % d
+            )
+            return
+    pytest.fail("No DDL contains FORCE KEYSTORE")
+
+
+def test_tde_set_key_force_keystore_placement(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(master_key_action="set_key", force_keystore=True)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    _assert_force_before_identified(exc.value.args[0]["ddls"])
+
+
+def test_tde_create_key_force_keystore_placement(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(master_key_action="create_key", force_keystore=True)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    _assert_force_before_identified(exc.value.args[0]["ddls"])
+
+
+def test_tde_export_keys_force_keystore_placement(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(
+            master_key_action="export_keys",
+            export_file="/tmp/keys.exp",
+            export_secret="ExportPass123",
+            force_keystore=True,
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    _assert_force_before_identified(exc.value.args[0]["ddls"])
+
+
+def test_tde_import_keys_force_keystore_placement(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _tde_params(
+            master_key_action="import_keys",
+            export_file="/tmp/keys.exp",
+            export_secret="ExportPass123",
+            force_keystore=True,
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _TdeConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    _assert_force_before_identified(exc.value.args[0]["ddls"])

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -1,0 +1,383 @@
+"""Unit tests for oracle_wallet module."""
+import pytest
+
+from conftest import ExitJson, FailJson, load_module_from_path, module_path
+from helpers import BASE_CONN_PARAMS, BaseFakeConn, BaseFakeModule, SequencedFakeConn
+
+
+def _load():
+    return load_module_from_path(
+        module_path("plugins", "modules", "oracle_wallet.py"), "oracle_wallet_test"
+    )
+
+
+def _wallet_params(**overrides):
+    base = {
+        **BASE_CONN_PARAMS,
+        "state": "present",
+        "keystore_location": "/opt/oracle/wallets/tde",
+        "keystore_password": "TestKeystorePass123",
+        "new_password": None,
+        "auto_login": "none",
+        "change_password": False,
+        "backup": True,
+        "backup_location": None,
+        "backup_tag": None,
+        "force_keystore": False,
+        "secret": None,
+        "secret_client": None,
+        "secret_tag": None,
+        "secret_state": None,
+        "container": "current",
+    }
+    base.update(overrides)
+    return base
+
+
+class _WalletConn(BaseFakeConn):
+    """Simulates V$ENCRYPTION_WALLET responses."""
+
+    def __init__(self, module, wallet_status='NOT_AVAILABLE', wallet_type='', keystore_mode='NONE', secrets=None):
+        super().__init__(module)
+        self._wallet_status = wallet_status
+        self._wallet_type = wallet_type
+        self._keystore_mode = keystore_mode
+        self._secrets = secrets or []
+
+    def execute_select_to_dict(self, sql, params=None, fetchone=False, fail_on_error=True):
+        sql_upper = sql.upper()
+        if 'V$ENCRYPTION_WALLET' in sql_upper:
+            row = {
+                'wrl_type': 'FILE',
+                'wrl_parameter': '/opt/oracle/wallets/tde',
+                'status': self._wallet_status,
+                'wallet_type': self._wallet_type,
+                'wallet_order': 'SINGLE',
+                'keystore_mode': self._keystore_mode,
+            }
+            return row if fetchone else [row]
+        if 'V$CLIENT_SECRETS' in sql_upper:
+            return self._secrets
+        if 'V$PARAMETER' in sql_upper:
+            return {'value': '/opt/oracle/admin/wallets'} if fetchone else [{'value': '/opt/oracle/admin/wallets'}]
+        return {} if fetchone else []
+
+
+# ===========================================================================
+# Tests: state=status
+# ===========================================================================
+
+def test_wallet_status(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="status")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', 'UNITED'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["wallet_status"] == "OPEN"
+    assert result["wallet_type"] == "PASSWORD"
+    assert result["keystore_mode"] == "UNITED"
+
+
+# ===========================================================================
+# Tests: state=present (create keystore)
+# ===========================================================================
+
+def test_wallet_create_when_not_exists(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present")
+
+    conn = _WalletConn(None, 'NOT_AVAILABLE')
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'NOT_AVAILABLE'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert len(result["ddls"]) >= 1
+    assert "CREATE KEYSTORE" in result["ddls"][0]
+
+
+def test_wallet_create_idempotent_when_exists(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: state=open
+# ===========================================================================
+
+def test_wallet_open_when_closed(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'CLOSED', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("SET KEYSTORE OPEN" in d for d in result["ddls"])
+
+
+def test_wallet_open_idempotent_when_already_open(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_wallet_open_with_container_all(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'CLOSED', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("CONTAINER = ALL" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: state=closed
+# ===========================================================================
+
+def test_wallet_close_when_open(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="closed")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("SET KEYSTORE CLOSE" in d for d in result["ddls"])
+
+
+def test_wallet_close_idempotent_when_already_closed(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="closed")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'CLOSED'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: auto-login
+# ===========================================================================
+
+def test_wallet_create_auto_login(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", auto_login="auto_login")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("AUTO_LOGIN KEYSTORE" in d for d in result["ddls"])
+
+
+def test_wallet_create_local_auto_login(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", auto_login="local_auto_login")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("LOCAL AUTO_LOGIN" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: change_password
+# ===========================================================================
+
+def test_wallet_change_password(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            state="present", change_password=True,
+            new_password="NewPass456"
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("ALTER KEYSTORE PASSWORD" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: secret management
+# ===========================================================================
+
+def test_wallet_add_secret(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret="my_secret", secret_client="MY_APP",
+            secret_state="present"
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("ADD SECRET" in d for d in result["ddls"])
+
+
+def test_wallet_update_existing_secret(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret="new_value", secret_client="MY_APP",
+            secret_state="present"
+        )
+
+    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("UPDATE SECRET" in d for d in result["ddls"])
+
+
+def test_wallet_delete_secret(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret_client="MY_APP", secret_state="absent"
+        )
+
+    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("DELETE SECRET" in d for d in result["ddls"])
+
+
+def test_wallet_delete_secret_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret_client="MY_APP", secret_state="absent"
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=[]), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: state=absent
+# ===========================================================================
+
+def test_wallet_absent_fails(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="absent")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN'), raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "does not support dropping" in exc.value.args[0]["msg"]
+
+
+# ===========================================================================
+# Tests: missing password
+# ===========================================================================
+
+def test_wallet_create_without_password_fails(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", keystore_password=None)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'NOT_AVAILABLE'), raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "keystore_password" in exc.value.args[0]["msg"]

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -398,7 +398,8 @@ def test_wallet_update_existing_secret(monkeypatch):
             secret_state="present"
         )
 
-    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    # Tagless secret — matches the tagless query from params above.
+    secrets = [{'client': 'MY_APP', 'secret_tag': ''}]
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
     monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets), raising=False)
 
@@ -417,7 +418,8 @@ def test_wallet_delete_secret(monkeypatch):
             secret_client="MY_APP", secret_state="absent"
         )
 
-    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    # Tagless secret — matches the tagless delete from params above.
+    secrets = [{'client': 'MY_APP', 'secret_tag': ''}]
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
     monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets), raising=False)
 

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -148,6 +148,20 @@ def test_wallet_create_idempotent_when_exists(monkeypatch):
     assert result["changed"] is False
 
 
+def test_wallet_present_idempotent_without_password_when_already_exists(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", keystore_password=None)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is False
+
+
 # ===========================================================================
 # Tests: state=open
 # ===========================================================================

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -11,6 +11,31 @@ def _load():
     )
 
 
+def test_escape_sql_literal_doubles_quotes():
+    mod = _load()
+    assert mod.escape_sql_literal("a'b", "'") == "a''b"
+    assert mod.escape_sql_literal('a"b', '"') == 'a""b'
+
+
+def test_escape_sql_literal_rejects_newlines():
+    mod = _load()
+    with pytest.raises(ValueError):
+        mod.escape_sql_literal("a\nb", "'")
+    with pytest.raises(ValueError):
+        mod.escape_sql_literal("a\rb", '"')
+
+
+def test_redact_ddls_handles_doubled_quotes_in_secret():
+    mod = _load()
+    ddl = (
+        "ADMINISTER KEY MANAGEMENT FORCE ADD SECRET 'foo''bar' FOR CLIENT 'X' "
+        'IDENTIFIED BY "***"'
+    )
+    out = mod._redact_ddls([ddl])[0]
+    assert "foo" not in out
+    assert "SECRET '***'" in out
+
+
 def _wallet_params(**overrides):
     base = {
         **BASE_CONN_PARAMS,
@@ -266,6 +291,58 @@ def test_wallet_change_password(monkeypatch):
     result = exc.value.args[0]
     assert result["changed"] is True
     assert any("ALTER KEYSTORE PASSWORD" in d for d in result["ddls"])
+    joined = "\n".join(result["ddls"])
+    assert "NewPass456" not in joined
+    assert "TestKeystorePass123" not in joined
+    assert "SET '***'" in joined
+
+
+def test_wallet_change_password_with_backup_location_runs_backup_keystore(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            state="present",
+            change_password=True,
+            new_password="NewPass456",
+            backup_location="/opt/oracle/backup/wallets",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    ddls = result["ddls"]
+    assert any("ALTER KEYSTORE PASSWORD" in d for d in ddls)
+    assert any("BACKUP KEYSTORE" in d for d in ddls)
+    assert any("TO '/opt/oracle/backup/wallets'" in d for d in ddls)
+
+
+def test_wallet_change_password_backup_false_still_honors_backup_tag(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            state="present",
+            change_password=True,
+            new_password="NewPass456",
+            backup=False,
+            backup_tag="before_pw_change",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    ddls = result["ddls"]
+    assert any("ALTER KEYSTORE PASSWORD" in d for d in ddls)
+    backup_ddls = [d for d in ddls if "BACKUP KEYSTORE" in d]
+    assert backup_ddls
+    assert any("USING '***'" in d for d in backup_ddls)
 
 
 # ===========================================================================
@@ -350,6 +427,96 @@ def test_wallet_delete_secret_idempotent(monkeypatch):
 # ===========================================================================
 # Tests: state=absent
 # ===========================================================================
+
+def test_wallet_absent_skips_connection(monkeypatch):
+    mod = _load()
+    called = []
+
+    def _track_conn(m):
+        called.append(1)
+        return _WalletConn(m, 'OPEN')
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="absent")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", _track_conn, raising=False)
+
+    with pytest.raises(FailJson):
+        mod.main()
+    assert called == []
+
+
+def test_wallet_secret_missing_value_skips_connection(monkeypatch):
+    mod = _load()
+    called = []
+
+    def _track_conn(m):
+        called.append(1)
+        return _WalletConn(m, 'OPEN', 'PASSWORD')
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret_state="present",
+            secret_client="MY_APP",
+            secret=None,
+            keystore_password="pw",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", _track_conn, raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "secret is required" in exc.value.args[0]["msg"]
+    assert called == []
+
+
+def test_wallet_check_mode_secret_skips_connection(monkeypatch):
+    mod = _load()
+    called = []
+
+    def _track_conn(m):
+        called.append(1)
+        return _WalletConn(m, 'OPEN', 'PASSWORD')
+
+    class Mod(BaseFakeModule):
+        check_mode = True
+        params = _wallet_params(
+            secret_state="present",
+            secret_client="MY_APP",
+            secret="s",
+            keystore_password="pw",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", _track_conn, raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is False
+    assert called == []
+
+
+def test_wallet_check_mode_status_opens_connection(monkeypatch):
+    mod = _load()
+    called = []
+
+    def _track_conn(m):
+        called.append(1)
+        return _WalletConn(m, 'OPEN', 'PASSWORD', secrets=[])
+
+    class Mod(BaseFakeModule):
+        check_mode = True
+        params = _wallet_params(state="status")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", _track_conn, raising=False)
+
+    with pytest.raises(ExitJson):
+        mod.main()
+    assert called == [1]
+
 
 def test_wallet_absent_fails(monkeypatch):
     mod = _load()

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -62,16 +62,23 @@ def _wallet_params(**overrides):
 class _WalletConn(BaseFakeConn):
     """Simulates V$ENCRYPTION_WALLET responses."""
 
-    def __init__(self, module, wallet_status='NOT_AVAILABLE', wallet_type='', keystore_mode='NONE', secrets=None):
+    def __init__(
+        self, module, wallet_status='NOT_AVAILABLE', wallet_type='', keystore_mode='NONE',
+        secrets=None, wallet_rows=None,
+    ):
         super().__init__(module)
         self._wallet_status = wallet_status
         self._wallet_type = wallet_type
         self._keystore_mode = keystore_mode
         self._secrets = secrets or []
+        self._wallet_rows = wallet_rows
 
     def execute_select_to_dict(self, sql, params=None, fetchone=False, fail_on_error=True):
         sql_upper = sql.upper()
         if 'V$ENCRYPTION_WALLET' in sql_upper:
+            if self._wallet_rows is not None:
+                rows = self._wallet_rows
+                return rows[0] if fetchone else rows
             row = {
                 'wrl_type': 'FILE',
                 'wrl_parameter': '/opt/oracle/wallets/tde',
@@ -436,6 +443,114 @@ def test_wallet_delete_secret_idempotent(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is False
+
+
+def test_wallet_secret_task_not_blocked_by_state_absent(monkeypatch):
+    """secret_state validation runs before the state==absent keystore guard."""
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            state="absent",
+            secret_state="absent",
+            secret_client="MY_APP",
+            keystore_password="pw",
+        )
+
+    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["msg"] == "Secret managed successfully"
+
+
+def test_wallet_delete_secret_includes_using_tag_when_requested(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret_client="MY_APP",
+            secret_state="absent",
+            secret_tag="mytag",
+            keystore_password="pw",
+        )
+
+    secrets = [{'client': 'MY_APP', 'secret_tag': 'mytag'}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    ddl = "\n".join(exc.value.args[0]["ddls"])
+    assert "DELETE SECRET" in ddl
+    assert "USING TAG 'mytag'" in ddl
+
+
+def test_wallet_open_container_all_mixed_runs_open(monkeypatch):
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'OPEN',
+            'wallet_type': 'PASSWORD', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'CLOSED',
+            'wallet_type': 'PASSWORD', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+    ]
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, wallet_rows=rows),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is True
+    assert any("SET KEYSTORE OPEN" in d for d in exc.value.args[0]["ddls"])
+
+
+def test_wallet_open_container_all_idempotent_when_all_open(monkeypatch):
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'OPEN',
+            'wallet_type': 'PASSWORD', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'OPEN_NO_MASTER_KEY',
+            'wallet_type': 'PASSWORD', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+    ]
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, wallet_rows=rows),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is False
 
 
 # ===========================================================================

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -553,6 +553,70 @@ def test_wallet_open_container_all_idempotent_when_all_open(monkeypatch):
     assert exc.value.args[0]["changed"] is False
 
 
+def test_aggregate_wallet_rows_autologin_uses_open_row():
+    """When open rows are all autologin, wallet_type should come from an open row, not first."""
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'CLOSED',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'OPEN',
+            'wallet_type': 'AUTOLOGIN', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+    ]
+    result = mod._aggregate_wallet_rows(rows)
+    assert result['wallet_type'] == 'AUTOLOGIN'
+
+
+def test_aggregate_wallet_rows_all_not_available():
+    """All-NOT_AVAILABLE rows must aggregate to NOT_AVAILABLE, not CLOSED."""
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'NOT_AVAILABLE',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'NONE',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'NOT_AVAILABLE',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'NONE',
+        },
+    ]
+    result = mod._aggregate_wallet_rows(rows)
+    assert result['status'] == 'NOT_AVAILABLE'
+
+
+def test_wallet_present_container_all_not_available_creates(monkeypatch):
+    """state=present with container=all and all NOT_AVAILABLE should create the keystore."""
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'NOT_AVAILABLE',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'NONE',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'NOT_AVAILABLE',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'NONE',
+        },
+    ]
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, wallet_rows=rows),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is True
+    assert any("CREATE KEYSTORE" in d for d in exc.value.args[0]["ddls"])
+
+
 # ===========================================================================
 # Tests: state=absent
 # ===========================================================================

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -356,7 +356,7 @@ def test_wallet_change_password_backup_false_still_honors_backup_tag(monkeypatch
     assert any("ALTER KEYSTORE PASSWORD" in d for d in ddls)
     backup_ddls = [d for d in ddls if "BACKUP KEYSTORE" in d]
     assert backup_ddls
-    assert any("USING '***'" in d for d in backup_ddls)
+    assert any("USING 'before_pw_change'" in d for d in backup_ddls)
 
 
 # ===========================================================================


### PR DESCRIPTION
 ## Summary                                                                                                                                   
  - New `oracle_tde` module for managing Oracle Transparent Data Encryption (TDE): master key lifecycle (create, set, rotate, export, import),
  online/offline tablespace encryption/decryption/rekey, encryption status queries, and TDE parameter configuration                           
  - Supports Oracle 19c, 23ai, and 26ai (including 26ai algorithm defaults and desupported cipher handling)                                    
  - Supports multitenant (CDB/PDB) environments and check mode throughout                                  
  - Security hardening: SQL identifier quoting, quote escaping in passwords/tags/FILE_NAME_CONVERT, secret redaction in DDL trace output       
  - Reuses shared clause builders from `oracle_utils`                                                                                          
                                                                                                                                               
  ## Test plan                                                                                                                                 
  - [x] Unit tests added (`tests/unit/test_oracle_tde.py`, 397 lines)                                                                          
  - [ ] Functional test against Oracle 19c with software keystore                                                                            
  - [ ] Functional test against Oracle 23ai/26ai for algorithm defaults                                                                        
  - [ ] Verify check_mode returns correct changed status without executing DDL                                                                 
  - [ ] Verify secret redaction in `-vvv` output                