### PR TITLE
Add oracle_orapki module for PKI wallet and certificate management 

### DIFF
--- a/plugins/modules/oracle_gi_facts.py
+++ b/plugins/modules/oracle_gi_facts.py
@@ -254,7 +254,7 @@ def main():
     else:
         for i in ['releaseversion', 'releasepatch', 'softwareversion', 'softwarepatch']:
             version = exec_program([ohomes.crsctl, 'query', 'has', i])
-            m = re.search('\[([0-9\.]+)\]$', version)
+            m = re.search(r'\[([0-9.]+)\]$', version)
             if m:
                 facts.update({i: m.group(1)})
                 facts.update({"version": m.group(1)})  # for backward compatibility

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -610,7 +610,7 @@ def _manage_credential(module):
     exists = _credential_exists(module, lookup_key, credential_type)
 
     if credential_state == 'present':
-        return _upsert_credential(module, exists)
+        return _upsert_credential(module, exists, lookup_key)
 
     if credential_state == 'absent':
         if not exists:
@@ -633,8 +633,12 @@ def _manage_credential(module):
     return False
 
 
-def _upsert_credential(module, exists):
-    """Create or modify a credential/entry."""
+def _upsert_credential(module, exists, connect_key):
+    """Create or modify a credential/entry.
+
+    connect_key is the resolved identifier (credential_db or credential_alias
+    fallback) used as the -connect_string for credential operations.
+    """
     credential_type = module.params["credential_type"]
     credential_alias = module.params["credential_alias"]
     wallet_location = module.params["wallet_location"]
@@ -650,7 +654,7 @@ def _upsert_credential(module, exists):
         if exists:
             args = ['secretstore', 'modify_credential',
                     '-wallet', wallet_location,
-                    '-connect_string', credential_db]
+                    '-connect_string', connect_key]
             if credential_user:
                 args.extend(['-username', credential_user])
             if credential_password:

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -272,13 +272,26 @@ def _run_orapki(module, args):
     Uses list-form command to avoid shell injection.
     Fails the module on non-zero return code.
     """
+    sensitive_flags = frozenset(('-pwd', '-oldpwd', '-newpwd', '-password', '-secret'))
+    safe_args = []
+    redact_next = False
+    for arg in args:
+        if redact_next:
+            safe_args.append('********')
+            redact_next = False
+        elif arg in sensitive_flags:
+            safe_args.append(arg)
+            redact_next = True
+        else:
+            safe_args.append(arg)
+
     cmd = [_get_orapki_bin(module)] + args
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
         module.fail_json(
             msg='orapki failed: %s' % (stderr or stdout).strip(),
             rc=rc,
-            cmd=' '.join(args),
+            cmd=' '.join(safe_args),
             changed=False,
         )
     return stdout, stderr
@@ -374,7 +387,6 @@ def _ensure_wallet_present(module):
     wallet_password = module.params["wallet_password"]
     auto_login = module.params["auto_login"]
 
-    p12 = os.path.join(wallet_location, 'ewallet.p12')
     sso = os.path.join(wallet_location, 'cwallet.sso')
 
     if _wallet_exists(wallet_location):
@@ -474,6 +486,15 @@ def _change_wallet_password(module):
 # Certificate management
 # ============================================================================
 
+def _get_cert_dn(module, cert_file):
+    """Extract the Subject DN from a certificate file using orapki."""
+    stdout, _stderr = _run_orapki(module, ['cert', 'display', '-cert', cert_file])
+    for line in stdout.split('\n'):
+        if line.strip().startswith('Subject:'):
+            return line.split(':', 1)[1].strip()
+    return None
+
+
 def _cert_exists_in_wallet(module, dn=None, alias=None):
     """Check if a certificate with given DN or alias exists in the wallet."""
     parsed = _wallet_display(module)
@@ -543,9 +564,9 @@ def _add_cert(module):
                 msg='cert_file is required for %s' % cert_type,
                 changed=False,
             )
-        # For trusted/user certs, check DN from file would require parsing
-        # the cert. Instead, we let orapki handle duplicates (it will error).
-        # For self_signed, we can check by DN.
+        dn_from_file = cert_dn or _get_cert_dn(module, cert_file)
+        if dn_from_file and _cert_exists_in_wallet(module, dn=dn_from_file):
+            return False
         if module.check_mode:
             return True
         type_flag = '-trusted_cert' if cert_type == 'trusted_cert' else '-user_cert'

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -635,7 +635,7 @@ def _upsert_credential(module, exists):
             if credential_user:
                 args.extend(['-user', credential_user])
             if credential_password:
-                args.extend(['-pwd', credential_password])
+                args.extend(['-password', credential_password])
         else:
             if not credential_db:
                 module.fail_json(
@@ -649,7 +649,9 @@ def _upsert_credential(module, exists):
             if credential_user:
                 args.extend(['-user', credential_user])
             if credential_password:
-                args.extend(['-pwd', credential_password])
+                args.extend(['-password', credential_password])
+        if wallet_password:
+            args.extend(['-pwd', wallet_password])
         _run_orapki(module, args)
         return True
 

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -291,7 +291,7 @@ def _run_orapki(module, args):
         module.fail_json(
             msg='orapki failed: %s' % (stderr or stdout).strip(),
             rc=rc,
-            cmd=' '.join(safe_args),
+            cmd=' '.join([_get_orapki_bin(module), *safe_args]),
             changed=False,
         )
     return stdout, stderr
@@ -732,6 +732,12 @@ def _upsert_credential(module, exists, connect_key):
         credential_db = module.params["credential_db"]
         credential_user = module.params["credential_user"]
         credential_password = module.params["credential_password"]
+
+        if not exists and (not credential_user or not credential_password):
+            module.fail_json(
+                msg='credential_user and credential_password are required to create a credential',
+                changed=False,
+            )
 
         # Nothing to modify when credential already exists and no
         # user/password params are provided.

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -515,10 +515,14 @@ def _manage_cert(module):
             )
         if module.check_mode:
             return True
-        _run_orapki(module, [
-            'wallet', 'export', '-wallet', wallet_location,
-            '-dn', cert_dn, '-cert', cert_export_file,
-        ])
+        wallet_password = module.params["wallet_password"]
+        args = ['wallet', 'export', '-wallet', wallet_location,
+                '-dn', cert_dn, '-cert', cert_export_file]
+        if _is_sso_only_wallet(wallet_location):
+            args.append('-auto_login_only')
+        elif wallet_password:
+            args.extend(['-pwd', wallet_password])
+        _run_orapki(module, args)
         return True
 
     return False
@@ -695,14 +699,6 @@ def _upsert_credential(module, exists, connect_key):
     wallet_location = module.params["wallet_location"]
     wallet_password = module.params["wallet_password"]
 
-    if credential_type == 'entry':
-        credential_secret = module.params["credential_secret"]
-        if not credential_secret:
-            module.fail_json(
-                msg='credential_secret is required for entry type',
-                changed=False,
-            )
-
     if credential_type == 'credential':
         credential_db = module.params["credential_db"]
         credential_user = module.params["credential_user"]
@@ -737,7 +733,13 @@ def _upsert_credential(module, exists, connect_key):
         _run_orapki(module, args)
         return True
 
-    if credential_type == 'entry':
+    elif credential_type == 'entry':
+        credential_secret = module.params["credential_secret"]
+        if not credential_secret:
+            module.fail_json(
+                msg='credential_secret is required for entry type',
+                changed=False,
+            )
 
         if module.check_mode:
             return True

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -323,16 +323,10 @@ def _parse_wallet_display(stdout):
     return result
 
 
-def _parse_list_credentials(stdout):
-    """Parse 'orapki secretstore list_credentials' output.
+def _parse_numbered_list(stdout):
+    """Parse orapki output lines of the form ``N: value ...``.
 
-    Expected format::
-
-        List credential (index: connect_string username)
-        1: PROD sys
-        2: DEV admin
-
-    Returns list of connect_string values.
+    Returns list of the first token after the index on each matching line.
     """
     aliases = []
     for line in stdout.split('\n'):
@@ -343,24 +337,9 @@ def _parse_list_credentials(stdout):
     return aliases
 
 
-def _parse_list_entries(stdout):
-    """Parse 'orapki secretstore list_entries' output.
-
-    Expected format::
-
-        List secret store entries:
-        1: my_entry_alias
-        2: another_entry
-
-    Returns list of entry alias strings.
-    """
-    aliases = []
-    for line in stdout.split('\n'):
-        line = line.strip()
-        m = re.match(r'^\d+:\s+(\S+)', line)
-        if m:
-            aliases.append(m.group(1))
-    return aliases
+# Convenience aliases so call sites stay descriptive.
+_parse_list_credentials = _parse_numbered_list
+_parse_list_entries = _parse_numbered_list
 
 
 # ============================================================================

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -554,16 +554,42 @@ def _manage_cert(module):
                 msg='cert_dn is required for certificate export',
                 changed=False,
             )
+        if not _cert_exists_in_wallet(module, dn=cert_dn):
+            module.fail_json(
+                msg='certificate with DN %s not found in wallet' % cert_dn,
+                changed=False,
+            )
+        # Export to a temporary location to compare with the existing file.
+        wallet_password = module.params["wallet_password"]
+        export_args = ['wallet', 'export', '-wallet', wallet_location,
+                       '-dn', cert_dn, '-cert', cert_export_file]
+        if _is_sso_only_wallet(wallet_location):
+            export_args.append('-auto_login_only')
+        elif wallet_password:
+            export_args.extend(['-pwd', wallet_password])
+        if os.path.isfile(cert_export_file):
+            # Export to a temp file and compare with the existing one.
+            import tempfile
+            tmp_fd, tmp_path = tempfile.mkstemp(suffix='.crt')
+            os.close(tmp_fd)
+            try:
+                tmp_args = list(export_args)
+                # Replace the cert_export_file with the temp path.
+                cert_idx = tmp_args.index('-cert') + 1
+                tmp_args[cert_idx] = tmp_path
+                _run_orapki(module, tmp_args)
+                with open(tmp_path, 'r') as f:
+                    new_content = f.read()
+                with open(cert_export_file, 'r') as f:
+                    existing_content = f.read()
+                if new_content == existing_content:
+                    return False
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
         if module.check_mode:
             return True
-        wallet_password = module.params["wallet_password"]
-        args = ['wallet', 'export', '-wallet', wallet_location,
-                '-dn', cert_dn, '-cert', cert_export_file]
-        if _is_sso_only_wallet(wallet_location):
-            args.append('-auto_login_only')
-        elif wallet_password:
-            args.extend(['-pwd', wallet_password])
-        _run_orapki(module, args)
+        _run_orapki(module, export_args)
         return True
 
     return False

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -285,7 +285,7 @@ def _run_orapki(module, args):
         else:
             safe_args.append(arg)
 
-    cmd = [_get_orapki_bin(module)] + args
+    cmd = [_get_orapki_bin(module), *args]
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
         module.fail_json(
@@ -565,7 +565,15 @@ def _add_cert(module):
                 changed=False,
             )
         dn_from_file = cert_dn or _get_cert_dn(module, cert_file)
-        if dn_from_file and _cert_exists_in_wallet(module, dn=dn_from_file):
+        if not dn_from_file:
+            module.warn(
+                'Could not extract DN from %s; supply cert_dn to enable idempotency checks' % cert_file
+            )
+            module.fail_json(
+                msg='cert_dn is required when DN cannot be extracted from cert_file',
+                changed=False,
+            )
+        if _cert_exists_in_wallet(module, dn=dn_from_file):
             return False
         if module.check_mode:
             return True
@@ -877,7 +885,7 @@ def main():
         _handle_wallet(module)
 
 
-from ansible.module_utils.basic import *  # noqa: F403
+from ansible.module_utils.basic import AnsibleModule
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -508,23 +508,31 @@ def _get_cert_dn(module, cert_file):
 
 
 def _cert_exists_in_wallet(module, dn=None, alias=None):
-    """Check if a certificate with given DN or alias exists in the wallet."""
+    """Check if a certificate with given DN or alias exists in the wallet.
+
+    Returns the cert section key ('trusted_cert', 'user_cert', 'requested_cert')
+    if found by DN, 'alias' if found by alias, or None if not found.
+    The return value is truthy when the cert exists.
+    """
     parsed = _wallet_display(module)
 
     if dn:
-        all_certs = (parsed['trusted_certs']
-                     + parsed['user_certs']
-                     + parsed['requested_certs'])
-        for cert_dn in all_certs:
-            if cert_dn.upper() == dn.upper():
-                return True
+        section_type_map = {
+            'trusted_certs': 'trusted_cert',
+            'user_certs': 'user_cert',
+            'requested_certs': 'requested_cert',
+        }
+        for section, cert_type in section_type_map.items():
+            for cert_dn in parsed[section]:
+                if cert_dn.upper() == dn.upper():
+                    return cert_type
 
     if alias:
         for wallet_alias in parsed.get('aliases', []):
             if wallet_alias.upper() == alias.upper():
-                return True
+                return 'alias'
 
-    return False
+    return None
 
 
 def _manage_cert(module):
@@ -644,14 +652,28 @@ def _remove_cert(module):
             changed=False,
         )
 
-    if not _cert_exists_in_wallet(module, dn=cert_dn, alias=cert_alias):
+    found_type = _cert_exists_in_wallet(module, dn=cert_dn, alias=cert_alias)
+    if not found_type:
         return False
 
     if module.check_mode:
         return True
 
+    # orapki wallet remove requires a certificate type flag
+    type_flag_map = {
+        'trusted_cert': '-trusted_cert',
+        'user_cert': '-user_cert',
+        'requested_cert': '-cert_req',
+    }
+
     args = ['wallet', 'remove', '-wallet', wallet_location]
     if cert_dn:
+        if found_type not in type_flag_map:
+            module.fail_json(
+                msg='Cannot determine certificate type for DN %s' % cert_dn,
+                changed=False,
+            )
+        args.append(type_flag_map[found_type])
         args.extend(['-dn', cert_dn])
     elif cert_alias:
         args.extend(['-alias', cert_alias])

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -698,13 +698,9 @@ def _manage_credential(module):
     wallet_password = module.params["wallet_password"]
 
     # For credentials, Oracle identifies by connect_string (credential_db).
+    # credential_alias is optional metadata (e.g. TNS alias label).
     # For entries, the identifier is the alias (credential_alias).
     if credential_type == 'credential':
-        if credential_alias:
-            module.fail_json(
-                msg='credential_alias is not supported for credential_type=credential; use credential_db instead',
-                changed=False,
-            )
         if not credential_db:
             module.fail_json(
                 msg='credential_db is required for credential operations',

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -600,10 +600,14 @@ def _manage_credential(module):
     credential_state = module.params["credential_state"]
     credential_type = module.params["credential_type"]
     credential_alias = module.params["credential_alias"]
+    credential_db = module.params["credential_db"]
     wallet_location = module.params["wallet_location"]
     wallet_password = module.params["wallet_password"]
 
-    exists = _credential_exists(module, credential_alias, credential_type)
+    # For credentials, Oracle identifies by connect_string (credential_db).
+    # For entries, the identifier is the alias (credential_alias).
+    lookup_key = credential_db if credential_type == 'credential' and credential_db else credential_alias
+    exists = _credential_exists(module, lookup_key, credential_type)
 
     if credential_state == 'present':
         return _upsert_credential(module, exists)
@@ -616,7 +620,7 @@ def _manage_credential(module):
         if credential_type == 'credential':
             args = ['secretstore', 'delete_credential',
                     '-wallet', wallet_location,
-                    '-connect_string', credential_alias]
+                    '-connect_string', lookup_key]
         else:
             args = ['secretstore', 'delete_entry',
                     '-wallet', wallet_location,
@@ -646,7 +650,7 @@ def _upsert_credential(module, exists):
         if exists:
             args = ['secretstore', 'modify_credential',
                     '-wallet', wallet_location,
-                    '-connect_string', credential_alias]
+                    '-connect_string', credential_db]
             if credential_user:
                 args.extend(['-username', credential_user])
             if credential_password:

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -421,6 +421,12 @@ def _ensure_wallet_present(module):
             return True
         return False
 
+    if auto_login != 'auto_login_only' and not wallet_password:
+        module.fail_json(
+            msg='wallet_password is required to create a wallet',
+            changed=False,
+        )
+
     if module.check_mode:
         return True
 
@@ -428,11 +434,6 @@ def _ensure_wallet_present(module):
         args = ['wallet', 'create', '-wallet', wallet_location,
                 '-auto_login_only']
     else:
-        if not wallet_password:
-            module.fail_json(
-                msg='wallet_password is required to create a wallet',
-                changed=False,
-            )
         args = ['wallet', 'create', '-wallet', wallet_location,
                 '-pwd', wallet_password]
         if auto_login == 'auto_login':
@@ -567,6 +568,8 @@ def _manage_cert(module):
             export_args.append('-auto_login_only')
         elif wallet_password:
             export_args.extend(['-pwd', wallet_password])
+        if module.check_mode:
+            return True
         if os.path.isfile(cert_export_file):
             # Export to a temp file and compare with the existing one.
             import tempfile
@@ -587,8 +590,6 @@ def _manage_cert(module):
             finally:
                 if os.path.exists(tmp_path):
                     os.unlink(tmp_path)
-        if module.check_mode:
-            return True
         _run_orapki(module, export_args)
         return True
 

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -651,7 +651,7 @@ def _credential_exists(module, alias, credential_type='credential'):
         aliases = _parse_list_entries(stdout)
     else:
         aliases = _parse_list_credentials(stdout)
-    return alias in aliases
+    return alias.upper() in (a.upper() for a in aliases)
 
 
 def _manage_credential(module):
@@ -710,6 +710,15 @@ def _upsert_credential(module, exists, connect_key):
     credential_alias = module.params["credential_alias"]
     wallet_location = module.params["wallet_location"]
     wallet_password = module.params["wallet_password"]
+
+    if credential_type == 'entry':
+        credential_secret = module.params["credential_secret"]
+        if not credential_secret:
+            module.fail_json(
+                msg='credential_secret is required for entry type',
+                changed=False,
+            )
+
     if module.check_mode:
         return True
 
@@ -740,12 +749,6 @@ def _upsert_credential(module, exists, connect_key):
         return True
 
     if credential_type == 'entry':
-        credential_secret = module.params["credential_secret"]
-        if not credential_secret:
-            module.fail_json(
-                msg='credential_secret is required for entry type',
-                changed=False,
-            )
 
         if exists:
             subcmd = 'modify_entry'

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -1,0 +1,781 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: oracle_orapki
+short_description: Manage Oracle PKI wallets, certificates, and credentials via orapki
+description:
+  - Manage Oracle PKI wallets (TLS/SSL, password stores, observer wallets) using the orapki CLI
+  - Create, delete, and display wallets (PKCS#12 and auto-login SSO)
+  - Add, remove, and export certificates (trusted CA, user/server, self-signed)
+  - Manage credentials and secrets via orapki secretstore (replaces mkstore)
+  - Supports Data Guard observer wallet setup, OUD wallets, TLS listener wallets
+  - Does NOT manage TDE keystores (use oracle_wallet for that)
+  - Compatible with Oracle 19c, 23ai, and 26ai
+  - In Oracle 26ai, mkstore is deprecated - use orapki secretstore instead
+version_added: "3.4.0"
+options:
+  oracle_home:
+    description: ORACLE_HOME path where orapki binary is located
+    required: true
+    aliases: ['oh']
+  state:
+    description: The intended state of the wallet
+    default: present
+    choices: ['present', 'absent', 'status']
+  wallet_location:
+    description: Path to the wallet directory (where ewallet.p12 / cwallet.sso reside)
+    required: true
+  wallet_password:
+    description: Password for the wallet
+    required: false
+  new_password:
+    description: New password when changing wallet password (with change_password=true)
+    required: false
+  change_password:
+    description: Whether to change the wallet password
+    default: false
+    type: bool
+  auto_login:
+    description:
+      - Type of auto-login wallet to create
+      - auto_login creates cwallet.sso alongside ewallet.p12
+      - local_auto_login creates a host-bound auto-login wallet
+      - auto_login_only creates only cwallet.sso without ewallet.p12
+    default: none
+    choices: ['none', 'auto_login', 'local_auto_login', 'auto_login_only']
+  cert_state:
+    description: State of certificate management operation
+    choices: ['present', 'absent', 'exported']
+    required: false
+  cert_type:
+    description:
+      - Type of certificate to add (required when cert_state=present)
+      - trusted_cert for CA certificates
+      - user_cert for server/client identity certificates
+      - self_signed for test/development self-signed certificates
+    choices: ['trusted_cert', 'user_cert', 'self_signed']
+    required: false
+  cert_file:
+    description: Path to certificate file (for trusted_cert and user_cert)
+    required: false
+  cert_dn:
+    description: Distinguished Name for the certificate (e.g. CN=myserver,O=MyOrg)
+    required: false
+  cert_alias:
+    description: Alias name for the certificate (Oracle 26ai+)
+    required: false
+  cert_keysize:
+    description: Key size for self-signed certificate generation
+    default: 2048
+    type: int
+  cert_validity:
+    description: Validity period in days for self-signed certificates
+    default: 3650
+    type: int
+  cert_export_file:
+    description: Output file path for certificate export
+    required: false
+  credential_state:
+    description: State of credential/secret management operation
+    choices: ['present', 'absent']
+    required: false
+  credential_type:
+    description:
+      - Type of secret store entry
+      - credential for database connection credentials (alias/db/user/password)
+      - entry for generic secret values
+    default: credential
+    choices: ['credential', 'entry']
+  credential_alias:
+    description: Alias name for the credential or entry
+    required: false
+  credential_db:
+    description: Database connect string / TNS alias for the credential
+    required: false
+  credential_user:
+    description: Username for the credential
+    required: false
+  credential_password:
+    description: Password for the credential (no_log)
+    required: false
+  credential_secret:
+    description: Secret value for a generic entry (no_log)
+    required: false
+notes:
+  - Requires orapki binary in ORACLE_HOME/bin
+  - Does not require a database connection (pure CLI tool)
+  - For TDE keystore management, use oracle_wallet instead
+  - In Oracle 26ai, mkstore is deprecated - this module uses orapki secretstore
+  - Wallet passwords are never logged (no_log=True)
+requirements: []
+author:
+  - Cyrille Modiano
+'''
+
+EXAMPLES = '''
+# --- TLS Wallet ---
+- name: Create TLS wallet with local auto-login
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    state: present
+    wallet_location: /opt/oracle/wallets/tls
+    wallet_password: "WalletPass123"
+    auto_login: local_auto_login
+
+- name: Add trusted CA certificate
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/tls
+    wallet_password: "WalletPass123"
+    cert_state: present
+    cert_type: trusted_cert
+    cert_file: /tmp/ca-root.crt
+
+- name: Add server certificate
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/tls
+    wallet_password: "WalletPass123"
+    cert_state: present
+    cert_type: user_cert
+    cert_file: /tmp/server.crt
+
+- name: Create self-signed certificate for testing
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/test
+    wallet_password: "TestPass123"
+    cert_state: present
+    cert_type: self_signed
+    cert_dn: "CN=testserver.local,O=TestOrg"
+    cert_keysize: 4096
+    cert_validity: 365
+
+- name: Remove a certificate by DN
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/tls
+    wallet_password: "WalletPass123"
+    cert_state: absent
+    cert_dn: "CN=oldserver.example.com"
+
+- name: Export certificate to file
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/tls
+    cert_state: exported
+    cert_dn: "CN=myserver.example.com"
+    cert_export_file: /tmp/myserver.crt
+
+# --- Observer Wallet ---
+- name: Create observer wallet with auto-login
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    state: present
+    wallet_location: /opt/oracle/wallets/observer
+    wallet_password: "ObsPass123"
+    auto_login: auto_login
+
+- name: Add primary DB credential to observer wallet
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/observer
+    wallet_password: "ObsPass123"
+    credential_state: present
+    credential_alias: primary_db
+    credential_db: PROD
+    credential_user: sys
+    credential_password: "SysPass123"
+
+- name: Add standby DB credential to observer wallet
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/observer
+    wallet_password: "ObsPass123"
+    credential_state: present
+    credential_alias: standby_db
+    credential_db: STDBY
+    credential_user: sys
+    credential_password: "SysPass123"
+
+# --- OUD Wallet ---
+- name: Add OUD credential
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/oud
+    wallet_password: "OudPass123"
+    credential_state: present
+    credential_alias: oud_server
+    credential_db: "oud.example.com:1636"
+    credential_user: "cn=admin"
+    credential_password: "LdapPass123"
+
+# --- Password Store ---
+- name: Add generic secret entry
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    wallet_location: /opt/oracle/wallets/secrets
+    wallet_password: "StorePass123"
+    credential_state: present
+    credential_type: entry
+    credential_alias: api_key
+    credential_secret: "sk-abc123..."
+
+# --- Status / Cleanup ---
+- name: Display wallet contents
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    state: status
+    wallet_location: /opt/oracle/wallets/tls
+  register: wallet_info
+
+- name: Delete a wallet
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    state: absent
+    wallet_location: /opt/oracle/wallets/old
+
+- name: Change wallet password
+  oracle_orapki:
+    oracle_home: /u01/app/oracle/product/19c
+    state: present
+    wallet_location: /opt/oracle/wallets/tls
+    change_password: true
+    wallet_password: "OldPass123"
+    new_password: "NewPass456"
+'''
+
+import os
+
+
+# ============================================================================
+# Core orapki execution
+# ============================================================================
+
+def _get_orapki_bin(module):
+    """Resolve the orapki binary path from oracle_home."""
+    oracle_home = module.params["oracle_home"]
+    orapki_bin = os.path.join(oracle_home, 'bin', 'orapki')
+    if not os.path.exists(orapki_bin):
+        module.fail_json(
+            msg='orapki not found at %s' % orapki_bin, changed=False
+        )
+    return orapki_bin
+
+
+def _run_orapki(module, args):
+    """Execute an orapki command and return (stdout, stderr).
+
+    Uses list-form command to avoid shell injection.
+    Fails the module on non-zero return code.
+    """
+    cmd = [_get_orapki_bin(module)] + args
+    rc, stdout, stderr = module.run_command(cmd)
+    if rc != 0:
+        module.fail_json(
+            msg='orapki failed: %s' % (stderr or stdout).strip(),
+            rc=rc,
+            cmd=' '.join(args),
+            changed=False,
+        )
+    return stdout, stderr
+
+
+# ============================================================================
+# Output parsing
+# ============================================================================
+
+def _parse_wallet_display(stdout):
+    """Parse 'orapki wallet display' output into structured data.
+
+    Returns dict with keys: requested_certs, user_certs, trusted_certs (lists of DNs).
+    """
+    result = {
+        'requested_certs': [],
+        'user_certs': [],
+        'trusted_certs': [],
+    }
+    current_section = None
+    section_map = {
+        'requested certificates:': 'requested_certs',
+        'user certificates:': 'user_certs',
+        'trusted certificates:': 'trusted_certs',
+    }
+
+    for line in stdout.split('\n'):
+        stripped = line.strip().lower()
+        if stripped in section_map:
+            current_section = section_map[stripped]
+            continue
+        if current_section and line.strip().startswith('Subject:'):
+            dn = line.split(':', 1)[1].strip()
+            result[current_section].append(dn)
+
+    return result
+
+
+def _parse_list_credentials(stdout):
+    """Parse 'orapki secretstore list_credentials' output.
+
+    Returns list of alias strings extracted from output lines.
+    """
+    aliases = []
+    for line in stdout.split('\n'):
+        line = line.strip()
+        if '=' in line and line.startswith('oracle.security.client'):
+            alias = line.split('=', 1)[1].strip()
+            if alias:
+                aliases.append(alias)
+    return aliases
+
+
+# ============================================================================
+# Wallet lifecycle
+# ============================================================================
+
+def _wallet_exists(wallet_location):
+    """Check if a wallet exists at the given location."""
+    p12 = os.path.join(wallet_location, 'ewallet.p12')
+    sso = os.path.join(wallet_location, 'cwallet.sso')
+    return os.path.isfile(p12) or os.path.isfile(sso)
+
+
+def _wallet_display(module):
+    """Run orapki wallet display and return parsed result."""
+    wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
+
+    args = ['wallet', 'display', '-wallet', wallet_location]
+    if wallet_password:
+        args.extend(['-pwd', wallet_password])
+
+    stdout, _stderr = _run_orapki(module, args)
+    parsed = _parse_wallet_display(stdout)
+    parsed['raw_output'] = stdout
+    return parsed
+
+
+def _ensure_wallet_present(module):
+    """Create a wallet if it doesn't exist."""
+    wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
+    auto_login = module.params["auto_login"]
+
+    if _wallet_exists(wallet_location):
+        return False
+
+    if module.check_mode:
+        return True
+
+    if auto_login == 'auto_login_only':
+        args = ['wallet', 'create', '-wallet', wallet_location,
+                '-auto_login_only']
+    else:
+        if not wallet_password:
+            module.fail_json(
+                msg='wallet_password is required to create a wallet',
+                changed=False,
+            )
+        args = ['wallet', 'create', '-wallet', wallet_location,
+                '-pwd', wallet_password]
+        if auto_login == 'auto_login':
+            args.append('-auto_login')
+        elif auto_login == 'local_auto_login':
+            args.append('-auto_login_local')
+
+    _run_orapki(module, args)
+    return True
+
+
+def _ensure_wallet_absent(module):
+    """Delete a wallet if it exists."""
+    wallet_location = module.params["wallet_location"]
+
+    if not _wallet_exists(wallet_location):
+        return False
+
+    if module.check_mode:
+        return True
+
+    _run_orapki(module, ['wallet', 'delete', '-wallet', wallet_location])
+    return True
+
+
+def _change_wallet_password(module):
+    """Change the wallet password."""
+    wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
+    new_password = module.params["new_password"]
+
+    if not wallet_password or not new_password:
+        module.fail_json(
+            msg='Both wallet_password and new_password are required',
+            changed=False,
+        )
+
+    if module.check_mode:
+        return True
+
+    _run_orapki(module, [
+        'wallet', 'change_pwd', '-wallet', wallet_location,
+        '-oldpwd', wallet_password, '-newpwd', new_password,
+    ])
+    return True
+
+
+# ============================================================================
+# Certificate management
+# ============================================================================
+
+def _cert_exists_in_wallet(module, dn=None, alias=None):
+    """Check if a certificate with given DN or alias exists in the wallet."""
+    try:
+        parsed = _wallet_display(module)
+    except SystemExit:
+        return False
+
+    if dn:
+        all_certs = (parsed['trusted_certs']
+                     + parsed['user_certs']
+                     + parsed['requested_certs'])
+        for cert_dn in all_certs:
+            if cert_dn.upper() == dn.upper():
+                return True
+
+    if alias:
+        raw = parsed.get('raw_output', '')
+        if alias in raw:
+            return True
+
+    return False
+
+
+def _manage_cert(module):
+    """Add, remove, or export certificates."""
+    cert_state = module.params["cert_state"]
+
+    if cert_state == 'present':
+        return _add_cert(module)
+
+    if cert_state == 'absent':
+        return _remove_cert(module)
+
+    if cert_state == 'exported':
+        cert_dn = module.params["cert_dn"]
+        cert_export_file = module.params["cert_export_file"]
+        wallet_location = module.params["wallet_location"]
+        if not cert_dn:
+            module.fail_json(
+                msg='cert_dn is required for certificate export',
+                changed=False,
+            )
+        if module.check_mode:
+            return True
+        _run_orapki(module, [
+            'wallet', 'export', '-wallet', wallet_location,
+            '-dn', cert_dn, '-cert', cert_export_file,
+        ])
+        return True
+
+    return False
+
+
+def _add_cert(module):
+    """Add a certificate to the wallet."""
+    cert_type = module.params["cert_type"]
+    cert_file = module.params["cert_file"]
+    cert_dn = module.params["cert_dn"]
+    cert_keysize = module.params["cert_keysize"]
+    cert_validity = module.params["cert_validity"]
+    wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
+    if cert_type in ('trusted_cert', 'user_cert'):
+        if not cert_file:
+            module.fail_json(
+                msg='cert_file is required for %s' % cert_type,
+                changed=False,
+            )
+        # For trusted/user certs, check DN from file would require parsing
+        # the cert. Instead, we let orapki handle duplicates (it will error).
+        # For self_signed, we can check by DN.
+        if module.check_mode:
+            return True
+        type_flag = '-trusted_cert' if cert_type == 'trusted_cert' else '-user_cert'
+        args = ['wallet', 'add', '-wallet', wallet_location,
+                type_flag, '-cert', cert_file]
+        if wallet_password:
+            args.extend(['-pwd', wallet_password])
+        _run_orapki(module, args)
+        return True
+
+    if cert_type == 'self_signed':
+        if not cert_dn:
+            module.fail_json(
+                msg='cert_dn is required for self_signed certificates',
+                changed=False,
+            )
+        if _cert_exists_in_wallet(module, dn=cert_dn):
+            return False
+        if module.check_mode:
+            return True
+        args = ['wallet', 'add', '-wallet', wallet_location,
+                '-dn', cert_dn, '-keysize', str(cert_keysize),
+                '-self_signed', '-validity', str(cert_validity)]
+        if wallet_password:
+            args.extend(['-pwd', wallet_password])
+        _run_orapki(module, args)
+        return True
+
+    return False
+
+
+def _remove_cert(module):
+    """Remove a certificate from the wallet."""
+    cert_dn = module.params["cert_dn"]
+    cert_alias = module.params["cert_alias"]
+    wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
+    if not cert_dn and not cert_alias:
+        module.fail_json(
+            msg='cert_dn or cert_alias is required to remove a certificate',
+            changed=False,
+        )
+
+    if not _cert_exists_in_wallet(module, dn=cert_dn, alias=cert_alias):
+        return False
+
+    if module.check_mode:
+        return True
+
+    args = ['wallet', 'remove', '-wallet', wallet_location]
+    if cert_dn:
+        args.extend(['-dn', cert_dn])
+    elif cert_alias:
+        args.extend(['-alias', cert_alias])
+    if wallet_password:
+        args.extend(['-pwd', wallet_password])
+
+    _run_orapki(module, args)
+    return True
+
+
+# ============================================================================
+# Credential / secret store management
+# ============================================================================
+
+def _credential_exists(module, alias):
+    """Check if a credential alias exists in the wallet."""
+    wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
+
+    args = ['secretstore', 'list_credentials',
+            '-wallet', wallet_location]
+    if wallet_password:
+        args.extend(['-pwd', wallet_password])
+
+    try:
+        stdout, _stderr = _run_orapki(module, args)
+    except SystemExit:
+        return False
+
+    aliases = _parse_list_credentials(stdout)
+    return alias in aliases
+
+
+def _manage_credential(module):
+    """Create, modify, or delete credentials/entries."""
+    credential_state = module.params["credential_state"]
+    credential_type = module.params["credential_type"]
+    credential_alias = module.params["credential_alias"]
+    wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
+
+    exists = _credential_exists(module, credential_alias)
+
+    if credential_state == 'present':
+        return _upsert_credential(module, exists)
+
+    if credential_state == 'absent':
+        if not exists:
+            return False
+        if module.check_mode:
+            return True
+        subcmd = 'delete_credential' if credential_type == 'credential' else 'delete_entry'
+        args = ['secretstore', subcmd,
+                '-wallet', wallet_location,
+                '-alias', credential_alias]
+        if wallet_password:
+            args.extend(['-pwd', wallet_password])
+        _run_orapki(module, args)
+        return True
+
+    return False
+
+
+def _upsert_credential(module, exists):
+    """Create or modify a credential/entry."""
+    credential_type = module.params["credential_type"]
+    credential_alias = module.params["credential_alias"]
+    wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
+    if module.check_mode:
+        return True
+
+    if credential_type == 'credential':
+        credential_db = module.params["credential_db"]
+        credential_user = module.params["credential_user"]
+        credential_password = module.params["credential_password"]
+
+        if exists:
+            args = ['secretstore', 'modify_credential',
+                    '-wallet', wallet_location,
+                    '-alias', credential_alias]
+            if credential_user:
+                args.extend(['-user', credential_user])
+            if credential_password:
+                args.extend(['-pwd', credential_password])
+        else:
+            if not credential_db:
+                module.fail_json(
+                    msg='credential_db is required to create a credential',
+                    changed=False,
+                )
+            args = ['secretstore', 'create_credential',
+                    '-wallet', wallet_location,
+                    '-alias', credential_alias,
+                    '-db', credential_db]
+            if credential_user:
+                args.extend(['-user', credential_user])
+            if credential_password:
+                args.extend(['-pwd', credential_password])
+        _run_orapki(module, args)
+        return True
+
+    if credential_type == 'entry':
+        credential_secret = module.params["credential_secret"]
+        if not credential_secret:
+            module.fail_json(
+                msg='credential_secret is required for entry type',
+                changed=False,
+            )
+
+        if exists:
+            subcmd = 'modify_entry'
+        else:
+            subcmd = 'create_entry'
+
+        args = ['secretstore', subcmd,
+                '-wallet', wallet_location,
+                '-alias', credential_alias,
+                '-secret', credential_secret]
+        if wallet_password:
+            args.extend(['-pwd', wallet_password])
+        _run_orapki(module, args)
+        return True
+
+    return False
+
+
+# ============================================================================
+# Main dispatch
+# ============================================================================
+
+def _handle_wallet(module):
+    """Handle wallet lifecycle operations."""
+    state = module.params["state"]
+    change_password_flag = module.params["change_password"]
+
+    if state == 'status':
+        result = _wallet_display(module)
+        module.exit_json(changed=False, **result)
+
+    elif state == 'present':
+        changed = _ensure_wallet_present(module)
+        if change_password_flag:
+            _change_wallet_password(module)
+            changed = True
+        module.exit_json(changed=changed, msg='Wallet managed successfully')
+
+    elif state == 'absent':
+        changed = _ensure_wallet_absent(module)
+        module.exit_json(changed=changed, msg='Wallet removed')
+
+
+def _handle_certs(module):
+    """Handle certificate management operations."""
+    changed = _manage_cert(module)
+    module.exit_json(changed=changed, msg='Certificate managed successfully')
+
+
+def _handle_credentials(module):
+    """Handle credential/secret store operations."""
+    changed = _manage_credential(module)
+    module.exit_json(changed=changed, msg='Credential managed successfully')
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            oracle_home=dict(required=True, aliases=['oh']),
+
+            state=dict(default='present',
+                       choices=['present', 'absent', 'status']),
+            wallet_location=dict(required=True, type='path'),
+            wallet_password=dict(required=False, no_log=True),
+            new_password=dict(required=False, no_log=True),
+            change_password=dict(default=False, type='bool'),
+            auto_login=dict(default='none',
+                           choices=['none', 'auto_login',
+                                    'local_auto_login', 'auto_login_only']),
+
+            cert_state=dict(required=False,
+                           choices=['present', 'absent', 'exported']),
+            cert_type=dict(required=False,
+                          choices=['trusted_cert', 'user_cert', 'self_signed']),
+            cert_file=dict(required=False, type='path'),
+            cert_dn=dict(required=False),
+            cert_alias=dict(required=False),
+            cert_keysize=dict(required=False, type='int', default=2048),
+            cert_validity=dict(required=False, type='int', default=3650),
+            cert_export_file=dict(required=False, type='path'),
+
+            credential_state=dict(required=False,
+                                 choices=['present', 'absent']),
+            credential_type=dict(default='credential',
+                                choices=['credential', 'entry']),
+            credential_alias=dict(required=False),
+            credential_db=dict(required=False),
+            credential_user=dict(required=False),
+            credential_password=dict(required=False, no_log=True),
+            credential_secret=dict(required=False, no_log=True),
+        ),
+        required_if=[
+            ('cert_state', 'present', ('cert_type',)),
+            ('cert_state', 'exported', ('cert_export_file',)),
+            ('credential_state', 'present', ('credential_alias',)),
+            ('credential_state', 'absent', ('credential_alias',)),
+            ('change_password', True, ('wallet_password', 'new_password')),
+        ],
+        mutually_exclusive=[
+            ('cert_state', 'credential_state'),
+        ],
+        supports_check_mode=True,
+    )
+
+    credential_state = module.params["credential_state"]
+    cert_state = module.params["cert_state"]
+
+    if credential_state:
+        _handle_credentials(module)
+    elif cert_state:
+        _handle_certs(module)
+    else:
+        _handle_wallet(module)
+
+
+from ansible.module_utils.basic import *  # noqa: F403
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -290,12 +290,14 @@ def _run_orapki(module, args):
 def _parse_wallet_display(stdout):
     """Parse 'orapki wallet display' output into structured data.
 
-    Returns dict with keys: requested_certs, user_certs, trusted_certs (lists of DNs).
+    Returns dict with keys: requested_certs, user_certs, trusted_certs (lists of DNs),
+    and aliases (list of alias strings extracted from -complete output).
     """
     result = {
         'requested_certs': [],
         'user_certs': [],
         'trusted_certs': [],
+        'aliases': [],
     }
     current_section = None
     section_map = {
@@ -312,6 +314,10 @@ def _parse_wallet_display(stdout):
         if current_section and line.strip().startswith('Subject:'):
             dn = line.split(':', 1)[1].strip()
             result[current_section].append(dn)
+        if line.strip().startswith('Alias:'):
+            alias = line.split(':', 1)[1].strip()
+            if alias:
+                result['aliases'].append(alias)
 
     return result
 
@@ -347,7 +353,7 @@ def _wallet_display(module):
     wallet_location = module.params["wallet_location"]
     wallet_password = module.params["wallet_password"]
 
-    args = ['wallet', 'display', '-wallet', wallet_location]
+    args = ['wallet', 'display', '-wallet', wallet_location, '-complete']
     if wallet_password:
         args.extend(['-pwd', wallet_password])
 
@@ -392,6 +398,7 @@ def _ensure_wallet_present(module):
 def _ensure_wallet_absent(module):
     """Delete a wallet if it exists."""
     wallet_location = module.params["wallet_location"]
+    wallet_password = module.params["wallet_password"]
 
     if not _wallet_exists(wallet_location):
         return False
@@ -399,7 +406,10 @@ def _ensure_wallet_absent(module):
     if module.check_mode:
         return True
 
-    _run_orapki(module, ['wallet', 'delete', '-wallet', wallet_location])
+    args = ['wallet', 'delete', '-wallet', wallet_location]
+    if wallet_password:
+        args.extend(['-pwd', wallet_password])
+    _run_orapki(module, args)
     return True
 
 
@@ -445,9 +455,9 @@ def _cert_exists_in_wallet(module, dn=None, alias=None):
                 return True
 
     if alias:
-        raw = parsed.get('raw_output', '')
-        if alias in raw:
-            return True
+        for wallet_alias in parsed.get('aliases', []):
+            if wallet_alias.upper() == alias.upper():
+                return True
 
     return False
 
@@ -565,12 +575,13 @@ def _remove_cert(module):
 # Credential / secret store management
 # ============================================================================
 
-def _credential_exists(module, alias):
-    """Check if a credential alias exists in the wallet."""
+def _credential_exists(module, alias, credential_type='credential'):
+    """Check if a credential or entry alias exists in the wallet."""
     wallet_location = module.params["wallet_location"]
     wallet_password = module.params["wallet_password"]
 
-    args = ['secretstore', 'list_credentials',
+    subcmd = 'list_entries' if credential_type == 'entry' else 'list_credentials'
+    args = ['secretstore', subcmd,
             '-wallet', wallet_location]
     if wallet_password:
         args.extend(['-pwd', wallet_password])
@@ -592,7 +603,7 @@ def _manage_credential(module):
     wallet_location = module.params["wallet_location"]
     wallet_password = module.params["wallet_password"]
 
-    exists = _credential_exists(module, credential_alias)
+    exists = _credential_exists(module, credential_alias, credential_type)
 
     if credential_state == 'present':
         return _upsert_credential(module, exists)
@@ -602,10 +613,14 @@ def _manage_credential(module):
             return False
         if module.check_mode:
             return True
-        subcmd = 'delete_credential' if credential_type == 'credential' else 'delete_entry'
-        args = ['secretstore', subcmd,
-                '-wallet', wallet_location,
-                '-alias', credential_alias]
+        if credential_type == 'credential':
+            args = ['secretstore', 'delete_credential',
+                    '-wallet', wallet_location,
+                    '-connect_string', credential_alias]
+        else:
+            args = ['secretstore', 'delete_entry',
+                    '-wallet', wallet_location,
+                    '-alias', credential_alias]
         if wallet_password:
             args.extend(['-pwd', wallet_password])
         _run_orapki(module, args)
@@ -631,9 +646,9 @@ def _upsert_credential(module, exists):
         if exists:
             args = ['secretstore', 'modify_credential',
                     '-wallet', wallet_location,
-                    '-alias', credential_alias]
+                    '-connect_string', credential_alias]
             if credential_user:
-                args.extend(['-user', credential_user])
+                args.extend(['-username', credential_user])
             if credential_password:
                 args.extend(['-password', credential_password])
         else:
@@ -644,10 +659,9 @@ def _upsert_credential(module, exists):
                 )
             args = ['secretstore', 'create_credential',
                     '-wallet', wallet_location,
-                    '-alias', credential_alias,
-                    '-db', credential_db]
+                    '-connect_string', credential_db]
             if credential_user:
-                args.extend(['-user', credential_user])
+                args.extend(['-username', credential_user])
             if credential_password:
                 args.extend(['-password', credential_password])
         if wallet_password:

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -285,11 +285,23 @@ def _run_orapki(module, args):
         else:
             safe_args.append(arg)
 
+    # Collect the actual sensitive values so we can scrub them from output.
+    sensitive_values = set()
+    prev = None
+    for arg in args:
+        if prev in sensitive_flags:
+            sensitive_values.add(arg)
+        prev = arg
+
     cmd = [_get_orapki_bin(module), *args]
     rc, stdout, stderr = module.run_command(cmd)
     if rc != 0:
+        output = (stderr or stdout).strip()
+        for val in sensitive_values:
+            if val:
+                output = output.replace(val, '********')
         module.fail_json(
-            msg='orapki failed: %s' % (stderr or stdout).strip(),
+            msg='orapki failed: %s' % output,
             rc=rc,
             cmd=' '.join([_get_orapki_bin(module), *safe_args]),
             changed=False,
@@ -554,6 +566,7 @@ def _add_cert(module):
     cert_type = module.params["cert_type"]
     cert_file = module.params["cert_file"]
     cert_dn = module.params["cert_dn"]
+    cert_alias = module.params["cert_alias"]
     cert_keysize = module.params["cert_keysize"]
     cert_validity = module.params["cert_validity"]
     wallet_location = module.params["wallet_location"]
@@ -573,13 +586,15 @@ def _add_cert(module):
                 msg='cert_dn is required when DN cannot be extracted from cert_file',
                 changed=False,
             )
-        if _cert_exists_in_wallet(module, dn=dn_from_file):
+        if _cert_exists_in_wallet(module, dn=dn_from_file, alias=cert_alias):
             return False
         if module.check_mode:
             return True
         type_flag = '-trusted_cert' if cert_type == 'trusted_cert' else '-user_cert'
         args = ['wallet', 'add', '-wallet', wallet_location,
                 type_flag, '-cert', cert_file]
+        if cert_alias:
+            args.extend(['-alias', cert_alias])
         if _is_sso_only_wallet(wallet_location):
             args.append('-auto_login_only')
         elif wallet_password:
@@ -593,13 +608,15 @@ def _add_cert(module):
                 msg='cert_dn is required for self_signed certificates',
                 changed=False,
             )
-        if _cert_exists_in_wallet(module, dn=cert_dn):
+        if _cert_exists_in_wallet(module, dn=cert_dn, alias=cert_alias):
             return False
         if module.check_mode:
             return True
         args = ['wallet', 'add', '-wallet', wallet_location,
                 '-dn', cert_dn, '-keysize', str(cert_keysize),
                 '-self_signed', '-validity', str(cert_validity)]
+        if cert_alias:
+            args.extend(['-alias', cert_alias])
         if _is_sso_only_wallet(wallet_location):
             args.append('-auto_login_only')
         elif wallet_password:
@@ -619,6 +636,11 @@ def _remove_cert(module):
     if not cert_dn and not cert_alias:
         module.fail_json(
             msg='cert_dn or cert_alias is required to remove a certificate',
+            changed=False,
+        )
+    if cert_dn and cert_alias:
+        module.fail_json(
+            msg='cert_dn and cert_alias are mutually exclusive for certificate removal',
             changed=False,
         )
 
@@ -678,6 +700,11 @@ def _manage_credential(module):
     # For credentials, Oracle identifies by connect_string (credential_db).
     # For entries, the identifier is the alias (credential_alias).
     if credential_type == 'credential':
+        if credential_alias:
+            module.fail_json(
+                msg='credential_alias is not supported for credential_type=credential; use credential_db instead',
+                changed=False,
+            )
         if not credential_db:
             module.fail_json(
                 msg='credential_db is required for credential operations',

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -248,6 +248,7 @@ EXAMPLES = '''
 '''
 
 import os
+import re
 
 
 # ============================================================================
@@ -325,15 +326,40 @@ def _parse_wallet_display(stdout):
 def _parse_list_credentials(stdout):
     """Parse 'orapki secretstore list_credentials' output.
 
-    Returns list of alias strings extracted from output lines.
+    Expected format::
+
+        List credential (index: connect_string username)
+        1: PROD sys
+        2: DEV admin
+
+    Returns list of connect_string values.
     """
     aliases = []
     for line in stdout.split('\n'):
         line = line.strip()
-        if '=' in line and line.startswith('oracle.security.client'):
-            alias = line.split('=', 1)[1].strip()
-            if alias:
-                aliases.append(alias)
+        m = re.match(r'^\d+:\s+(\S+)', line)
+        if m:
+            aliases.append(m.group(1))
+    return aliases
+
+
+def _parse_list_entries(stdout):
+    """Parse 'orapki secretstore list_entries' output.
+
+    Expected format::
+
+        List secret store entries:
+        1: my_entry_alias
+        2: another_entry
+
+    Returns list of entry alias strings.
+    """
+    aliases = []
+    for line in stdout.split('\n'):
+        line = line.strip()
+        m = re.match(r'^\d+:\s+(\S+)', line)
+        if m:
+            aliases.append(m.group(1))
     return aliases
 
 
@@ -364,12 +390,32 @@ def _wallet_display(module):
 
 
 def _ensure_wallet_present(module):
-    """Create a wallet if it doesn't exist."""
+    """Create a wallet if it doesn't exist, or add auto-login to existing wallet."""
     wallet_location = module.params["wallet_location"]
     wallet_password = module.params["wallet_password"]
     auto_login = module.params["auto_login"]
 
+    p12 = os.path.join(wallet_location, 'ewallet.p12')
+    sso = os.path.join(wallet_location, 'cwallet.sso')
+
     if _wallet_exists(wallet_location):
+        # Wallet exists — check if auto-login needs to be added
+        if auto_login in ('auto_login', 'local_auto_login') and not os.path.isfile(sso):
+            if not wallet_password:
+                module.fail_json(
+                    msg='wallet_password is required to add auto-login to an existing wallet',
+                    changed=False,
+                )
+            if module.check_mode:
+                return True
+            args = ['wallet', 'create', '-wallet', wallet_location,
+                    '-pwd', wallet_password]
+            if auto_login == 'auto_login':
+                args.append('-auto_login')
+            else:
+                args.append('-auto_login_local')
+            _run_orapki(module, args)
+            return True
         return False
 
     if module.check_mode:
@@ -395,6 +441,13 @@ def _ensure_wallet_present(module):
     return True
 
 
+def _is_sso_only_wallet(wallet_location):
+    """Check if the wallet is SSO-only (cwallet.sso without ewallet.p12)."""
+    p12 = os.path.join(wallet_location, 'ewallet.p12')
+    sso = os.path.join(wallet_location, 'cwallet.sso')
+    return os.path.isfile(sso) and not os.path.isfile(p12)
+
+
 def _ensure_wallet_absent(module):
     """Delete a wallet if it exists."""
     wallet_location = module.params["wallet_location"]
@@ -406,8 +459,11 @@ def _ensure_wallet_absent(module):
     if module.check_mode:
         return True
 
+    sso_only = _is_sso_only_wallet(wallet_location)
     args = ['wallet', 'delete', '-wallet', wallet_location]
-    if wallet_password:
+    if sso_only:
+        args.append('-sso')
+    elif wallet_password:
         args.extend(['-pwd', wallet_password])
     _run_orapki(module, args)
     return True
@@ -441,10 +497,7 @@ def _change_wallet_password(module):
 
 def _cert_exists_in_wallet(module, dn=None, alias=None):
     """Check if a certificate with given DN or alias exists in the wallet."""
-    try:
-        parsed = _wallet_display(module)
-    except SystemExit:
-        return False
+    parsed = _wallet_display(module)
 
     if dn:
         all_certs = (parsed['trusted_certs']
@@ -515,7 +568,9 @@ def _add_cert(module):
         type_flag = '-trusted_cert' if cert_type == 'trusted_cert' else '-user_cert'
         args = ['wallet', 'add', '-wallet', wallet_location,
                 type_flag, '-cert', cert_file]
-        if wallet_password:
+        if _is_sso_only_wallet(wallet_location):
+            args.append('-auto_login_only')
+        elif wallet_password:
             args.extend(['-pwd', wallet_password])
         _run_orapki(module, args)
         return True
@@ -533,7 +588,9 @@ def _add_cert(module):
         args = ['wallet', 'add', '-wallet', wallet_location,
                 '-dn', cert_dn, '-keysize', str(cert_keysize),
                 '-self_signed', '-validity', str(cert_validity)]
-        if wallet_password:
+        if _is_sso_only_wallet(wallet_location):
+            args.append('-auto_login_only')
+        elif wallet_password:
             args.extend(['-pwd', wallet_password])
         _run_orapki(module, args)
         return True
@@ -564,7 +621,9 @@ def _remove_cert(module):
         args.extend(['-dn', cert_dn])
     elif cert_alias:
         args.extend(['-alias', cert_alias])
-    if wallet_password:
+    if _is_sso_only_wallet(wallet_location):
+        args.append('-auto_login_only')
+    elif wallet_password:
         args.extend(['-pwd', wallet_password])
 
     _run_orapki(module, args)
@@ -586,12 +645,12 @@ def _credential_exists(module, alias, credential_type='credential'):
     if wallet_password:
         args.extend(['-pwd', wallet_password])
 
-    try:
-        stdout, _stderr = _run_orapki(module, args)
-    except SystemExit:
-        return False
+    stdout, _stderr = _run_orapki(module, args)
 
-    aliases = _parse_list_credentials(stdout)
+    if credential_type == 'entry':
+        aliases = _parse_list_entries(stdout)
+    else:
+        aliases = _parse_list_credentials(stdout)
     return alias in aliases
 
 
@@ -606,7 +665,15 @@ def _manage_credential(module):
 
     # For credentials, Oracle identifies by connect_string (credential_db).
     # For entries, the identifier is the alias (credential_alias).
-    lookup_key = credential_db if credential_type == 'credential' and credential_db else credential_alias
+    if credential_type == 'credential':
+        if not credential_db:
+            module.fail_json(
+                msg='credential_db is required for credential operations',
+                changed=False,
+            )
+        lookup_key = credential_db
+    else:
+        lookup_key = credential_alias
     exists = _credential_exists(module, lookup_key, credential_type)
 
     if credential_state == 'present':
@@ -660,11 +727,6 @@ def _upsert_credential(module, exists, connect_key):
             if credential_password:
                 args.extend(['-password', credential_password])
         else:
-            if not credential_db:
-                module.fail_json(
-                    msg='credential_db is required to create a credential',
-                    changed=False,
-                )
             args = ['secretstore', 'create_credential',
                     '-wallet', wallet_location,
                     '-connect_string', credential_db]

--- a/plugins/modules/oracle_orapki.py
+++ b/plugins/modules/oracle_orapki.py
@@ -652,6 +652,11 @@ def _manage_credential(module):
             )
         lookup_key = credential_db
     else:
+        if not credential_alias:
+            module.fail_json(
+                msg='credential_alias is required for entry operations',
+                changed=False,
+            )
         lookup_key = credential_alias
     exists = _credential_exists(module, lookup_key, credential_type)
 
@@ -698,13 +703,18 @@ def _upsert_credential(module, exists, connect_key):
                 changed=False,
             )
 
-    if module.check_mode:
-        return True
-
     if credential_type == 'credential':
         credential_db = module.params["credential_db"]
         credential_user = module.params["credential_user"]
         credential_password = module.params["credential_password"]
+
+        # Nothing to modify when credential already exists and no
+        # user/password params are provided.
+        if exists and not credential_user and not credential_password:
+            return False
+
+        if module.check_mode:
+            return True
 
         if exists:
             args = ['secretstore', 'modify_credential',
@@ -728,6 +738,9 @@ def _upsert_credential(module, exists, connect_key):
         return True
 
     if credential_type == 'entry':
+
+        if module.check_mode:
+            return True
 
         if exists:
             subcmd = 'modify_entry'
@@ -822,8 +835,6 @@ def main():
         required_if=[
             ('cert_state', 'present', ('cert_type',)),
             ('cert_state', 'exported', ('cert_export_file',)),
-            ('credential_state', 'present', ('credential_alias',)),
-            ('credential_state', 'absent', ('credential_alias',)),
             ('change_password', True, ('wallet_password', 'new_password')),
         ],
         mutually_exclusive=[

--- a/tests/unit/test_oracle_orapki.py
+++ b/tests/unit/test_oracle_orapki.py
@@ -1,0 +1,685 @@
+"""Unit tests for oracle_orapki module."""
+import pytest
+
+from conftest import ExitJson, FailJson, load_module_from_path, module_path
+from helpers import BaseFakeModule
+
+
+def _load():
+    return load_module_from_path(
+        module_path("plugins", "modules", "oracle_orapki.py"), "oracle_orapki_test"
+    )
+
+
+def _orapki_params(**overrides):
+    base = {
+        "oracle_home": "/fake/oracle",
+        "state": "present",
+        "wallet_location": "/opt/oracle/wallets/test",
+        "wallet_password": "TestPass123",
+        "new_password": None,
+        "change_password": False,
+        "auto_login": "none",
+        "cert_state": None,
+        "cert_type": None,
+        "cert_file": None,
+        "cert_dn": None,
+        "cert_alias": None,
+        "cert_keysize": 2048,
+        "cert_validity": 3650,
+        "cert_export_file": None,
+        "credential_state": None,
+        "credential_type": "credential",
+        "credential_alias": None,
+        "credential_db": None,
+        "credential_user": None,
+        "credential_password": None,
+        "credential_secret": None,
+    }
+    base.update(overrides)
+    return base
+
+
+WALLET_DISPLAY_OUTPUT = """Oracle PKI Tool Release 19.0.0.0.0
+Requested Certificates:
+User Certificates:
+Subject:        CN=myserver.example.com,O=MyCompany
+Trusted Certificates:
+Subject:        CN=RootCA,O=MyCompany
+Subject:        CN=IntermediateCA,O=MyCompany
+"""
+
+WALLET_DISPLAY_EMPTY = """Oracle PKI Tool Release 19.0.0.0.0
+Requested Certificates:
+User Certificates:
+Trusted Certificates:
+"""
+
+LIST_CREDENTIALS_OUTPUT = """oracle.security.client.connect_string1 = primary_db
+oracle.security.client.connect_string2 = standby_db
+"""
+
+LIST_CREDENTIALS_EMPTY = ""
+
+
+class _OrapkiModule(BaseFakeModule):
+    """Module that stubs run_command for orapki."""
+
+    _orapki_responses = {}
+    _commands_run = []
+
+    def run_command(self, command, **kwargs):
+        self.__class__._commands_run.append(command)
+        # Match on subcommand keywords in the command list
+        cmd_str = ' '.join(command) if isinstance(command, list) else command
+        for key, response in self._orapki_responses.items():
+            if key in cmd_str:
+                return response
+        # Default: success with empty output
+        return (0, '', '')
+
+
+class _FakeOs:
+    """Fake os module for path checks."""
+
+    def __init__(self, orapki_exists=True, wallet_exists=False):
+        self._orapki_exists = orapki_exists
+        self._wallet_exists = wallet_exists
+        self.environ = {}
+
+    class path:
+        _orapki_exists = True
+        _wallet_exists = False
+        _wallet_location = '/opt/oracle/wallets/test'
+
+        @classmethod
+        def exists(cls, path_str):
+            if 'orapki' in path_str:
+                return cls._orapki_exists
+            return cls._wallet_exists
+
+        @classmethod
+        def isfile(cls, path_str):
+            if 'ewallet.p12' in path_str or 'cwallet.sso' in path_str:
+                return cls._wallet_exists
+            return False
+
+        @classmethod
+        def join(cls, *args):
+            return '/'.join(args)
+
+
+def _make_fake_os(orapki_exists=True, wallet_exists=False):
+    """Create a _FakeOs with specific settings."""
+    fake = _FakeOs(orapki_exists, wallet_exists)
+    fake.path._orapki_exists = orapki_exists
+    fake.path._wallet_exists = wallet_exists
+    return fake
+
+
+# ===========================================================================
+# Tests: Wallet lifecycle
+# ===========================================================================
+
+def test_orapki_wallet_create(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params()
+        _orapki_responses = {'wallet create': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=False))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_wallet_create_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params()
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_orapki_wallet_create_auto_login(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(auto_login="auto_login")
+        _orapki_responses = {'wallet create': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=False))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    # Verify -auto_login was in the command
+    cmd_str = ' '.join(Mod._commands_run[-1])
+    assert '-auto_login' in cmd_str
+
+
+def test_orapki_wallet_create_local_auto_login(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(auto_login="local_auto_login")
+        _orapki_responses = {'wallet create': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=False))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    cmd_str = ' '.join(Mod._commands_run[-1])
+    assert '-auto_login_local' in cmd_str
+
+
+def test_orapki_wallet_create_auto_login_only(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(auto_login="auto_login_only", wallet_password=None)
+        _orapki_responses = {'wallet create': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=False))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    cmd_str = ' '.join(Mod._commands_run[-1])
+    assert '-auto_login_only' in cmd_str
+
+
+def test_orapki_wallet_absent(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(state="absent")
+        _orapki_responses = {'wallet delete': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_wallet_absent_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(state="absent")
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=False))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_orapki_wallet_status(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(state="status")
+        _orapki_responses = {'wallet display': (0, WALLET_DISPLAY_OUTPUT, '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert 'CN=RootCA,O=MyCompany' in result["trusted_certs"]
+    assert 'CN=myserver.example.com,O=MyCompany' in result["user_certs"]
+    assert len(result["trusted_certs"]) == 2
+
+
+def test_orapki_wallet_change_password(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(change_password=True, new_password="NewPass456")
+        _orapki_responses = {'change_pwd': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_missing_binary_fails(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params()
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=False, wallet_exists=False))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "orapki not found" in exc.value.args[0]["msg"]
+
+
+# ===========================================================================
+# Tests: Certificate management
+# ===========================================================================
+
+def test_orapki_add_trusted_cert(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            cert_state="present", cert_type="trusted_cert",
+            cert_file="/tmp/ca.crt",
+        )
+        _orapki_responses = {'wallet add': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    cmd_str = ' '.join(Mod._commands_run[-1])
+    assert '-trusted_cert' in cmd_str
+
+
+def test_orapki_add_user_cert(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            cert_state="present", cert_type="user_cert",
+            cert_file="/tmp/server.crt",
+        )
+        _orapki_responses = {'wallet add': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    cmd_str = ' '.join(Mod._commands_run[-1])
+    assert '-user_cert' in cmd_str
+
+
+def test_orapki_add_self_signed(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            cert_state="present", cert_type="self_signed",
+            cert_dn="CN=test.local,O=TestOrg",
+            cert_keysize=4096, cert_validity=365,
+        )
+        _orapki_responses = {
+            'wallet display': (0, WALLET_DISPLAY_EMPTY, ''),
+            'wallet add': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    cmd_str = ' '.join(Mod._commands_run[-1])
+    assert '-self_signed' in cmd_str
+    assert '4096' in cmd_str
+    assert '365' in cmd_str
+
+
+def test_orapki_add_self_signed_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            cert_state="present", cert_type="self_signed",
+            cert_dn="CN=myserver.example.com,O=MyCompany",
+        )
+        _orapki_responses = {
+            'wallet display': (0, WALLET_DISPLAY_OUTPUT, ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_orapki_remove_cert(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            cert_state="absent", cert_dn="CN=RootCA,O=MyCompany",
+        )
+        _orapki_responses = {
+            'wallet display': (0, WALLET_DISPLAY_OUTPUT, ''),
+            'wallet remove': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_remove_cert_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            cert_state="absent", cert_dn="CN=nonexistent.com",
+        )
+        _orapki_responses = {
+            'wallet display': (0, WALLET_DISPLAY_OUTPUT, ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_orapki_export_cert(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            cert_state="exported",
+            cert_dn="CN=myserver.example.com",
+            cert_export_file="/tmp/export.crt",
+        )
+        _orapki_responses = {'wallet export': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+# ===========================================================================
+# Tests: Credential management
+# ===========================================================================
+
+def test_orapki_create_credential(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            credential_state="present",
+            credential_alias="primary_db",
+            credential_db="PROD",
+            credential_user="sys",
+            credential_password="SysPass123",
+        )
+        _orapki_responses = {
+            'list_credentials': (0, LIST_CREDENTIALS_EMPTY, ''),
+            'create_credential': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_modify_credential(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            credential_state="present",
+            credential_alias="primary_db",
+            credential_db="PROD",
+            credential_user="newsys",
+            credential_password="NewPass123",
+        )
+        _orapki_responses = {
+            'list_credentials': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'modify_credential': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_delete_credential(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            credential_state="absent",
+            credential_alias="primary_db",
+        )
+        _orapki_responses = {
+            'list_credentials': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'delete_credential': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_delete_credential_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            credential_state="absent",
+            credential_alias="nonexistent",
+        )
+        _orapki_responses = {
+            'list_credentials': (0, LIST_CREDENTIALS_EMPTY, ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_orapki_create_entry(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            credential_state="present",
+            credential_type="entry",
+            credential_alias="api_key",
+            credential_secret="sk-abc123",
+        )
+        _orapki_responses = {
+            'list_credentials': (0, LIST_CREDENTIALS_EMPTY, ''),
+            'create_entry': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_modify_entry(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            credential_state="present",
+            credential_type="entry",
+            credential_alias="primary_db",
+            credential_secret="new-secret-value",
+        )
+        _orapki_responses = {
+            'list_credentials': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'modify_entry': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_orapki_delete_entry(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            credential_state="absent",
+            credential_type="entry",
+            credential_alias="primary_db",
+        )
+        _orapki_responses = {
+            'list_credentials': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'delete_entry': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+# ===========================================================================
+# Tests: Check mode
+# ===========================================================================
+
+def test_orapki_check_mode_no_commands(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params()
+        check_mode = True
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=False))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    # No orapki commands should have been run
+    assert len(Mod._commands_run) == 0
+
+
+# ===========================================================================
+# Tests: Parser
+# ===========================================================================
+
+def test_parse_wallet_display():
+    mod = _load()
+    result = mod._parse_wallet_display(WALLET_DISPLAY_OUTPUT)
+    assert len(result['user_certs']) == 1
+    assert result['user_certs'][0] == 'CN=myserver.example.com,O=MyCompany'
+    assert len(result['trusted_certs']) == 2
+    assert 'CN=RootCA,O=MyCompany' in result['trusted_certs']
+    assert 'CN=IntermediateCA,O=MyCompany' in result['trusted_certs']
+
+
+def test_parse_list_credentials():
+    mod = _load()
+    result = mod._parse_list_credentials(LIST_CREDENTIALS_OUTPUT)
+    assert 'primary_db' in result
+    assert 'standby_db' in result
+    assert len(result) == 2
+
+
+def test_parse_list_credentials_empty():
+    mod = _load()
+    result = mod._parse_list_credentials(LIST_CREDENTIALS_EMPTY)
+    assert result == []

--- a/tests/unit/test_oracle_orapki.py
+++ b/tests/unit/test_oracle_orapki.py
@@ -55,11 +55,17 @@ User Certificates:
 Trusted Certificates:
 """
 
-LIST_CREDENTIALS_OUTPUT = """oracle.security.client.connect_string1 = primary_db
-oracle.security.client.connect_string2 = standby_db
+LIST_CREDENTIALS_OUTPUT = """List credential (index: connect_string username)
+1: primary_db sys
+2: standby_db admin
 """
 
 LIST_CREDENTIALS_EMPTY = ""
+
+LIST_ENTRIES_OUTPUT = """List secret store entries:
+1: primary_db
+2: standby_db
+"""
 
 
 class _OrapkiModule(BaseFakeModule):
@@ -90,6 +96,8 @@ class _FakeOs:
     class path:
         _orapki_exists = True
         _wallet_exists = False
+        _p12_exists = False
+        _sso_exists = False
         _wallet_location = '/opt/oracle/wallets/test'
 
         @classmethod
@@ -100,8 +108,10 @@ class _FakeOs:
 
         @classmethod
         def isfile(cls, path_str):
-            if 'ewallet.p12' in path_str or 'cwallet.sso' in path_str:
-                return cls._wallet_exists
+            if 'ewallet.p12' in path_str:
+                return cls._p12_exists
+            if 'cwallet.sso' in path_str:
+                return cls._sso_exists
             return False
 
         @classmethod
@@ -109,11 +119,21 @@ class _FakeOs:
             return '/'.join(args)
 
 
-def _make_fake_os(orapki_exists=True, wallet_exists=False):
+def _make_fake_os(orapki_exists=True, wallet_exists=False, sso_only=False):
     """Create a _FakeOs with specific settings."""
     fake = _FakeOs(orapki_exists, wallet_exists)
     fake.path._orapki_exists = orapki_exists
     fake.path._wallet_exists = wallet_exists
+    if wallet_exists:
+        if sso_only:
+            fake.path._p12_exists = False
+            fake.path._sso_exists = True
+        else:
+            fake.path._p12_exists = True
+            fake.path._sso_exists = True
+    else:
+        fake.path._p12_exists = False
+        fake.path._sso_exists = False
     return fake
 
 
@@ -503,7 +523,7 @@ def test_orapki_modify_credential(monkeypatch):
     mod = _load()
 
     # Simulate a wallet where credential_db "PROD" already exists
-    existing_creds = "oracle.security.client.connect_string1 = PROD\n"
+    existing_creds = "List credential (index: connect_string username)\n1: PROD sys\n"
 
     class Mod(_OrapkiModule):
         params = _orapki_params(
@@ -545,6 +565,7 @@ def test_orapki_delete_credential(monkeypatch):
         params = _orapki_params(
             credential_state="absent",
             credential_alias="primary_db",
+            credential_db="primary_db",
         )
         _orapki_responses = {
             'list_credentials': (0, LIST_CREDENTIALS_OUTPUT, ''),
@@ -559,6 +580,9 @@ def test_orapki_delete_credential(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is True
+    cmd = Mod._commands_run[-1]
+    assert '-connect_string' in cmd
+    assert cmd[cmd.index('-connect_string') + 1] == 'primary_db'
 
 
 def test_orapki_delete_credential_idempotent(monkeypatch):
@@ -568,6 +592,7 @@ def test_orapki_delete_credential_idempotent(monkeypatch):
         params = _orapki_params(
             credential_state="absent",
             credential_alias="nonexistent",
+            credential_db="nonexistent",
         )
         _orapki_responses = {
             'list_credentials': (0, LIST_CREDENTIALS_EMPTY, ''),
@@ -619,7 +644,7 @@ def test_orapki_modify_entry(monkeypatch):
             credential_secret="new-secret-value",
         )
         _orapki_responses = {
-            'list_entries': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'list_entries': (0, LIST_ENTRIES_OUTPUT, ''),
             'modify_entry': (0, '', ''),
         }
         _commands_run = []
@@ -643,7 +668,7 @@ def test_orapki_delete_entry(monkeypatch):
             credential_alias="primary_db",
         )
         _orapki_responses = {
-            'list_entries': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'list_entries': (0, LIST_ENTRIES_OUTPUT, ''),
             'delete_entry': (0, '', ''),
         }
         _commands_run = []
@@ -655,6 +680,70 @@ def test_orapki_delete_entry(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is True
+
+
+def test_orapki_credential_requires_credential_db(monkeypatch):
+    """credential_type='credential' must have credential_db set."""
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            credential_state="present",
+            credential_alias="myalias",
+            credential_user="sys",
+            credential_password="pass",
+        )
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert 'credential_db is required' in exc.value.args[0]['msg']
+
+
+def test_orapki_wallet_delete_sso_only(monkeypatch):
+    """Deleting an SSO-only wallet should use -sso flag."""
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(state="absent", wallet_password=None)
+        _orapki_responses = {'wallet delete': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True, wallet_exists=True, sso_only=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    cmd = Mod._commands_run[-1]
+    assert '-sso' in cmd
+
+
+def test_orapki_wallet_add_auto_login_to_existing(monkeypatch):
+    """Adding auto-login to an existing PKCS#12 wallet (no cwallet.sso yet)."""
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(auto_login="auto_login")
+        _orapki_responses = {'wallet create': (0, '', '')}
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    # Wallet exists with p12 but no sso
+    fake_os = _make_fake_os(orapki_exists=True, wallet_exists=True)
+    fake_os.path._sso_exists = False
+    monkeypatch.setattr(mod, "os", fake_os)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    cmd_str = ' '.join(Mod._commands_run[-1])
+    assert '-auto_login' in cmd_str
 
 
 # ===========================================================================
@@ -705,4 +794,18 @@ def test_parse_list_credentials():
 def test_parse_list_credentials_empty():
     mod = _load()
     result = mod._parse_list_credentials(LIST_CREDENTIALS_EMPTY)
+    assert result == []
+
+
+def test_parse_list_entries():
+    mod = _load()
+    result = mod._parse_list_entries(LIST_ENTRIES_OUTPUT)
+    assert 'primary_db' in result
+    assert 'standby_db' in result
+    assert len(result) == 2
+
+
+def test_parse_list_entries_empty():
+    mod = _load()
+    result = mod._parse_list_entries('')
     assert result == []

--- a/tests/unit/test_oracle_orapki.py
+++ b/tests/unit/test_oracle_orapki.py
@@ -71,11 +71,16 @@ LIST_ENTRIES_OUTPUT = """List secret store entries:
 class _OrapkiModule(BaseFakeModule):
     """Module that stubs run_command for orapki."""
 
-    _orapki_responses = {}
-    _commands_run = []
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Bind class-level containers as instance attributes so each
+        # instance references its own subclass's state (silences lint
+        # warnings about mutable class defaults on the base class).
+        self._orapki_responses = getattr(type(self), '_orapki_responses', {})
+        self._commands_run = getattr(type(self), '_commands_run', [])
 
     def run_command(self, command, **kwargs):
-        self.__class__._commands_run.append(command)
+        self._commands_run.append(command)
         # Match on subcommand keywords in the command list
         cmd_str = ' '.join(command) if isinstance(command, list) else command
         for key, response in self._orapki_responses.items():
@@ -347,6 +352,33 @@ def test_orapki_add_trusted_cert(monkeypatch):
     assert '-trusted_cert' in cmd_str
 
 
+def test_orapki_add_trusted_cert_with_alias(monkeypatch):
+    mod = _load()
+
+    class Mod(_OrapkiModule):
+        params = _orapki_params(
+            cert_state="present", cert_type="trusted_cert",
+            cert_file="/tmp/ca.crt", cert_alias="my_ca_alias",
+        )
+        _orapki_responses = {
+            'cert display': (0, 'Subject: CN=ca.example.com', ''),
+            'wallet display': (0, WALLET_DISPLAY_EMPTY, ''),
+            'wallet add': (0, '', ''),
+        }
+        _commands_run = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _make_fake_os(orapki_exists=True))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    cmd_str = ' '.join(Mod._commands_run[-1])
+    assert '-alias' in cmd_str
+    assert 'my_ca_alias' in cmd_str
+
+
 def test_orapki_add_user_cert(monkeypatch):
     mod = _load()
 
@@ -472,10 +504,13 @@ def test_orapki_export_cert(monkeypatch):
     class Mod(_OrapkiModule):
         params = _orapki_params(
             cert_state="exported",
-            cert_dn="CN=myserver.example.com",
+            cert_dn="CN=myserver.example.com,O=MyCompany",
             cert_export_file="/tmp/export.crt",
         )
-        _orapki_responses = {'wallet export': (0, '', '')}
+        _orapki_responses = {
+            'wallet display': (0, WALLET_DISPLAY_OUTPUT, ''),
+            'wallet export': (0, '', ''),
+        }
         _commands_run = []
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)

--- a/tests/unit/test_oracle_orapki.py
+++ b/tests/unit/test_oracle_orapki.py
@@ -329,7 +329,11 @@ def test_orapki_add_trusted_cert(monkeypatch):
             cert_state="present", cert_type="trusted_cert",
             cert_file="/tmp/ca.crt",
         )
-        _orapki_responses = {'wallet add': (0, '', '')}
+        _orapki_responses = {
+            'cert display': (0, 'Subject: CN=ca.example.com', ''),
+            'wallet display': (0, WALLET_DISPLAY_EMPTY, ''),
+            'wallet add': (0, '', ''),
+        }
         _commands_run = []
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
@@ -351,7 +355,11 @@ def test_orapki_add_user_cert(monkeypatch):
             cert_state="present", cert_type="user_cert",
             cert_file="/tmp/server.crt",
         )
-        _orapki_responses = {'wallet add': (0, '', '')}
+        _orapki_responses = {
+            'cert display': (0, 'Subject: CN=server.example.com', ''),
+            'wallet display': (0, WALLET_DISPLAY_EMPTY, ''),
+            'wallet add': (0, '', ''),
+        }
         _commands_run = []
 
     monkeypatch.setattr(mod, "AnsibleModule", Mod)

--- a/tests/unit/test_oracle_orapki.py
+++ b/tests/unit/test_oracle_orapki.py
@@ -487,6 +487,14 @@ def test_orapki_create_credential(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is True
+    # Verify -password is used for credential password, -pwd for wallet password
+    cmd = Mod._commands_run[-1]
+    assert '-password' in cmd, "credential password should use -password flag"
+    pwd_idx = cmd.index('-password')
+    assert cmd[pwd_idx + 1] == 'SysPass123'
+    assert '-pwd' in cmd, "wallet password should use -pwd flag"
+    wpwd_idx = cmd.index('-pwd')
+    assert cmd[wpwd_idx + 1] == 'TestPass123'
 
 
 def test_orapki_modify_credential(monkeypatch):
@@ -513,6 +521,12 @@ def test_orapki_modify_credential(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is True
+    # Verify -password for credential, -pwd for wallet
+    cmd = Mod._commands_run[-1]
+    assert '-password' in cmd
+    assert cmd[cmd.index('-password') + 1] == 'NewPass123'
+    assert '-pwd' in cmd
+    assert cmd[cmd.index('-pwd') + 1] == 'TestPass123'
 
 
 def test_orapki_delete_credential(monkeypatch):

--- a/tests/unit/test_oracle_orapki.py
+++ b/tests/unit/test_oracle_orapki.py
@@ -502,6 +502,9 @@ def test_orapki_create_credential(monkeypatch):
 def test_orapki_modify_credential(monkeypatch):
     mod = _load()
 
+    # Simulate a wallet where credential_db "PROD" already exists
+    existing_creds = "oracle.security.client.connect_string1 = PROD\n"
+
     class Mod(_OrapkiModule):
         params = _orapki_params(
             credential_state="present",
@@ -511,7 +514,7 @@ def test_orapki_modify_credential(monkeypatch):
             credential_password="NewPass123",
         )
         _orapki_responses = {
-            'list_credentials': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'list_credentials': (0, existing_creds, ''),
             'modify_credential': (0, '', ''),
         }
         _commands_run = []
@@ -523,10 +526,10 @@ def test_orapki_modify_credential(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is True
-    # Verify correct orapki flags for modify
+    # Verify correct orapki flags for modify — uses credential_db (connect_string)
     cmd = Mod._commands_run[-1]
     assert '-connect_string' in cmd, "should use -connect_string for modify"
-    assert cmd[cmd.index('-connect_string') + 1] == 'primary_db'
+    assert cmd[cmd.index('-connect_string') + 1] == 'PROD'
     assert '-username' in cmd, "should use -username flag"
     assert cmd[cmd.index('-username') + 1] == 'newsys'
     assert '-password' in cmd

--- a/tests/unit/test_oracle_orapki.py
+++ b/tests/unit/test_oracle_orapki.py
@@ -487,14 +487,16 @@ def test_orapki_create_credential(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is True
-    # Verify -password is used for credential password, -pwd for wallet password
+    # Verify correct orapki flags
     cmd = Mod._commands_run[-1]
+    assert '-connect_string' in cmd, "should use -connect_string flag"
+    assert cmd[cmd.index('-connect_string') + 1] == 'PROD'
+    assert '-username' in cmd, "should use -username flag"
+    assert cmd[cmd.index('-username') + 1] == 'sys'
     assert '-password' in cmd, "credential password should use -password flag"
-    pwd_idx = cmd.index('-password')
-    assert cmd[pwd_idx + 1] == 'SysPass123'
+    assert cmd[cmd.index('-password') + 1] == 'SysPass123'
     assert '-pwd' in cmd, "wallet password should use -pwd flag"
-    wpwd_idx = cmd.index('-pwd')
-    assert cmd[wpwd_idx + 1] == 'TestPass123'
+    assert cmd[cmd.index('-pwd') + 1] == 'TestPass123'
 
 
 def test_orapki_modify_credential(monkeypatch):
@@ -521,8 +523,12 @@ def test_orapki_modify_credential(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is True
-    # Verify -password for credential, -pwd for wallet
+    # Verify correct orapki flags for modify
     cmd = Mod._commands_run[-1]
+    assert '-connect_string' in cmd, "should use -connect_string for modify"
+    assert cmd[cmd.index('-connect_string') + 1] == 'primary_db'
+    assert '-username' in cmd, "should use -username flag"
+    assert cmd[cmd.index('-username') + 1] == 'newsys'
     assert '-password' in cmd
     assert cmd[cmd.index('-password') + 1] == 'NewPass123'
     assert '-pwd' in cmd
@@ -585,7 +591,7 @@ def test_orapki_create_entry(monkeypatch):
             credential_secret="sk-abc123",
         )
         _orapki_responses = {
-            'list_credentials': (0, LIST_CREDENTIALS_EMPTY, ''),
+            'list_entries': (0, '', ''),
             'create_entry': (0, '', ''),
         }
         _commands_run = []
@@ -610,7 +616,7 @@ def test_orapki_modify_entry(monkeypatch):
             credential_secret="new-secret-value",
         )
         _orapki_responses = {
-            'list_credentials': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'list_entries': (0, LIST_CREDENTIALS_OUTPUT, ''),
             'modify_entry': (0, '', ''),
         }
         _commands_run = []
@@ -634,7 +640,7 @@ def test_orapki_delete_entry(monkeypatch):
             credential_alias="primary_db",
         )
         _orapki_responses = {
-            'list_credentials': (0, LIST_CREDENTIALS_OUTPUT, ''),
+            'list_entries': (0, LIST_CREDENTIALS_OUTPUT, ''),
             'delete_entry': (0, '', ''),
         }
         _commands_run = []


### PR DESCRIPTION
Summary                                                                                                                                      
  
  - Add new oracle_orapki module wrapping the orapki CLI for managing Oracle PKI wallets, certificates (trusted/user/root), and credentials    
  - Idempotent operations for wallet creation, cert add/remove/export, and credential upsert with auto-login convergence
  - Extensive hardening: secret redaction in error output, DGMGRL-style input validation, cert selector exclusivity enforcement, and proper    
  check_mode conventions                                                                                                                       
                                                                                                                                               
  Changes                                                                                                                                      
                                                            
  - New module plugins/modules/oracle_orapki.py with support for wallet, certificate, and credential operations                                
  - Wallet display parsing with SSO-only wallet detection
  - Credential lookup by alias or connect string with case-insensitive matching                                                                
  - Cert export idempotency via temp-file comparison                                                                                           
  - Check mode accuracy: validate required params before early returns, no side effects in check mode                                          
  - Test stubs for cert/wallet display operations                                                                                              
                                                                                                                                               
  Test plan                                                                                                                                    
                                                            
  - Run module with check_mode: true for wallet creation with missing password — should fail                                                   
  - Run cert export on existing file — should report changed: false when content matches
  - Verify credential upsert idempotency with existing credentials                                                                             
  - Verify secrets are redacted in error messages on command failure          