### PR TITLE
Add oracle_wallet module for TDE keystore management   

### DIFF
--- a/plugins/module_utils/oracle_utils.py
+++ b/plugins/module_utils/oracle_utils.py
@@ -89,6 +89,11 @@ def _ensure_oracle_client(module, oracle_home=None, required=False):
 # ---------------------------------------------------------------------------
 
 def sql_single_quoted_literal(value):
+    """Escape *value* for use inside a single-quoted Oracle SQL string literal.
+
+    ``None`` yields ``''``. Other values are coerced with ``str()`` so callers
+    (e.g. unified audit condition text) stay compatible; single quotes are doubled.
+    """
     if value is None:
         return ''
     s = str(value)
@@ -119,15 +124,6 @@ def build_backup_clause(backup=True, backup_tag=None):
     if backup_tag:
         clause += " USING '%s'" % sql_single_quoted_literal(backup_tag)
     return clause
-
-
-def sql_single_quoted_literal(value):
-    """Double embedded single quotes for safe use inside Oracle '...' string literals."""
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise TypeError('sql_single_quoted_literal expects str or None')
-    return value.replace("'", "''")
 
 
 def sanitize_string_params(module_params):

--- a/plugins/module_utils/oracle_utils.py
+++ b/plugins/module_utils/oracle_utils.py
@@ -121,6 +121,15 @@ def build_backup_clause(backup=True, backup_tag=None):
     return clause
 
 
+def sql_single_quoted_literal(value):
+    """Double embedded single quotes for safe use inside Oracle '...' string literals."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError('sql_single_quoted_literal expects str or None')
+    return value.replace("'", "''")
+
+
 def sanitize_string_params(module_params):
     """Strip leading/trailing whitespace from every string value in module.params.
 

--- a/plugins/module_utils/oracle_utils.py
+++ b/plugins/module_utils/oracle_utils.py
@@ -126,14 +126,21 @@ def build_backup_clause(backup=True, backup_tag=None):
     return clause
 
 
-def sanitize_string_params(module_params):
+def sanitize_string_params(module_params, no_trim=None):
     """Strip leading/trailing whitespace from every string value in module.params.
 
     Mutates the dict in place so all downstream reads of module.params are
     automatically cleaned without changing any call site. Non-string values
     (None, int, bool, list, dict) are left untouched.
+
+    Keys listed in *no_trim* (a set or sequence) are skipped so that
+    passwords and secrets whose leading/trailing whitespace is significant
+    are not silently altered.
     """
+    skip = set(no_trim) if no_trim else set()
     for key, value in module_params.items():
+        if key in skip:
+            continue
         if isinstance(value, str):
             module_params[key] = value.strip()
 

--- a/plugins/modules/oracle_dblink.py
+++ b/plugins/modules/oracle_dblink.py
@@ -284,6 +284,14 @@ except ImportError:
     def sanitize_string_params(_params):
         pass
 
+    def sql_single_quoted_literal(value):
+        if value is None:
+            return ''
+        s = str(value)
+        if s.startswith("'") and s.endswith("'"):
+            s = s[1:-1]
+        return s.replace("'", "''")
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -192,30 +192,6 @@ def secret_exists(conn, client_name):
     return False
 
 
-def build_backup_clause(backup, backup_tag):
-    """Build the WITH BACKUP clause for key management commands."""
-    if not backup:
-        return ''
-    clause = ' WITH BACKUP'
-    if backup_tag:
-        clause += " USING '%s'" % backup_tag
-    return clause
-
-
-def build_container_clause(container):
-    """Build CONTAINER clause."""
-    if container == 'all':
-        return ' CONTAINER = ALL'
-    return ''
-
-
-def build_force_clause(force_keystore):
-    """Build FORCE KEYSTORE clause."""
-    if force_keystore:
-        return 'FORCE KEYSTORE '
-    return ''
-
-
 def ensure_keystore_present(conn, module):
     """Create a software keystore if it doesn't exist."""
     status = get_wallet_status(conn)
@@ -560,6 +536,7 @@ from ansible.module_utils.basic import *  # noqa: F403
 try:
     from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
         oracleConnection, sanitize_string_params,
+        build_backup_clause, build_container_clause, build_force_clause,
     )
 except ImportError:
     def sanitize_string_params(_params):

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -217,6 +217,11 @@ def ensure_keystore_present(conn, module):
                 changed=False
             )
 
+    if "'" in keystore_location:
+        module.fail_json(
+            msg='keystore_location must not contain single quotes',
+            changed=False,
+        )
     sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
         keystore_location, keystore_password
     )
@@ -369,21 +374,25 @@ def manage_secret(conn, module):
     backup_clause = build_backup_clause(backup, backup_tag)
     exists = secret_exists(conn, secret_client)
 
+    safe_client = secret_client.replace("'", "''")
+
     if secret_state == 'present':
         if not secret:
             module.fail_json(msg='secret is required when secret_state=present', changed=False)
 
+        safe_secret = secret.replace("'", "''")
         tag_clause = ""
         if secret_tag:
-            tag_clause = " USING TAG '%s'" % secret_tag
+            safe_tag = secret_tag.replace("'", "''")
+            tag_clause = " USING TAG '%s'" % safe_tag
 
         if exists:
             sql = "ADMINISTER KEY MANAGEMENT %sUPDATE SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
-                force, secret, secret_client, tag_clause, keystore_password, backup_clause
+                force, safe_secret, safe_client, tag_clause, keystore_password, backup_clause
             )
         else:
             sql = "ADMINISTER KEY MANAGEMENT %sADD SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
-                force, secret, secret_client, tag_clause, keystore_password, backup_clause
+                force, safe_secret, safe_client, tag_clause, keystore_password, backup_clause
             )
         conn.execute_ddl(sql)
 
@@ -391,7 +400,7 @@ def manage_secret(conn, module):
         if not exists:
             return  # Already absent, idempotent
         sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s' IDENTIFIED BY \"%s\"%s" % (
-            force, secret_client, keystore_password, backup_clause
+            force, safe_client, keystore_password, backup_clause
         )
         conn.execute_ddl(sql)
 
@@ -447,6 +456,8 @@ def main():
 
     # Secret management takes priority if secret_state is set
     if secret_state:
+        if module.check_mode:
+            module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
         manage_secret(conn, module)
         status = get_wallet_status(conn)
         module.exit_json(
@@ -471,7 +482,10 @@ def main():
             secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
         )
 
-    elif state == 'present':
+    if module.check_mode:
+        module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
+
+    if state == 'present':
         status = ensure_keystore_present(conn, module)
 
         # Handle auto-login creation
@@ -539,8 +553,10 @@ try:
         build_backup_clause, build_container_clause, build_force_clause,
     )
 except ImportError:
-    def sanitize_string_params(_params):
-        pass
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -258,7 +258,12 @@ def validate_wallet_inputs_before_connect(module):
 
 
 def _redact_ddls(ddls):
-    """Redact passwords and secrets from DDL statements before returning to user."""
+    """Redact passwords and secrets from DDL statements before returning to user.
+
+    Backup identifiers in ``... USING 'tag'`` (BACKUP KEYSTORE / WITH BACKUP) are
+    left visible; they are not credentials. ``USING TAG`` for secrets uses a
+    different token sequence and is unaffected.
+    """
     # Oracle doubles embedded quotes inside literals; match full quoted spans.
     _sq_lit = r"'(?:[^']|'')*'"
     _dq_lit = r'"(?:[^"]|"")*"'
@@ -266,7 +271,6 @@ def _redact_ddls(ddls):
     for ddl in ddls:
         s = _re.sub(r'(IDENTIFIED\s+BY\s+)' + _dq_lit, r'\1"***"', ddl, flags=_re.IGNORECASE)
         s = _re.sub(r'(SECRET\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
-        s = _re.sub(r'(USING\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
         s = _re.sub(
             r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _dq_lit,
             r"\1'***'",

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -678,6 +678,9 @@ def main():
         ],
         supports_check_mode=True,
     )
+    if not HAS_ORACLE_UTILS:
+        module.fail_json(msg='oracle_utils is required for oracle_wallet: %s' % _ORACLE_UTILS_ERR)
+
     sanitize_string_params(module.params)
 
     state = module.params["state"]
@@ -791,11 +794,26 @@ try:
         oracleConnection, sanitize_string_params,
         build_backup_clause, build_container_clause, build_force_clause,
     )
-except ImportError:
+except ImportError as e:
+    HAS_ORACLE_UTILS = False
+    _ORACLE_UTILS_ERR = str(e)
+
     def sanitize_string_params(module_params):
         for key, value in module_params.items():
             if isinstance(value, str):
                 module_params[key] = value.strip()
+
+    def _missing_oracle_utils(*_a, **_kw):
+        raise ImportError(
+            'oracle_utils is required for oracle_wallet: %s' % _ORACLE_UTILS_ERR
+        )
+
+    oracleConnection = _missing_oracle_utils  # noqa: F811
+    build_backup_clause = _missing_oracle_utils
+    build_container_clause = _missing_oracle_utils
+    build_force_clause = _missing_oracle_utils
+else:
+    HAS_ORACLE_UTILS = True
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -206,13 +206,6 @@ def validate_wallet_inputs_before_connect(module):
     backup_tag = module.params['backup_tag']
     backup_location = module.params['backup_location']
 
-    if state == 'absent':
-        module.fail_json(
-            msg='Oracle does not support dropping a keystore via SQL. '
-                'Remove the keystore files manually from the filesystem.',
-            changed=False,
-        )
-
     if secret_state:
         if not module.params.get('secret_client'):
             module.fail_json(msg='secret_client is required for secret management', changed=False)
@@ -227,6 +220,13 @@ def validate_wallet_inputs_before_connect(module):
         _assert_sql_embeddable_str(module, module.params.get('secret_tag'), "'")
         _assert_sql_embeddable_str(module, backup_tag, "'")
         return
+
+    if state == 'absent':
+        module.fail_json(
+            msg='Oracle does not support dropping a keystore via SQL. '
+                'Remove the keystore files manually from the filesystem.',
+            changed=False,
+        )
 
     if state == 'present':
         loc = module.params.get('keystore_location')
@@ -287,11 +287,84 @@ def _redact_ddls(ddls):
     return redacted
 
 
-def get_wallet_status(conn):
-    """Query V$ENCRYPTION_WALLET for current keystore status."""
-    sql = """SELECT WRL_TYPE, WRL_PARAMETER, STATUS, WALLET_TYPE, WALLET_ORDER, KEYSTORE_MODE
-             FROM V$ENCRYPTION_WALLET
-             WHERE ROWNUM = 1"""
+def _vwallet_field(row, col):
+    """Read a V$ view column from a row dict (oracledb lower/upper keys)."""
+    if not row:
+        return ''
+    lc, uc = col.lower(), col.upper()
+    if lc in row:
+        return row[lc]
+    if uc in row:
+        return row[uc]
+    return ''
+
+
+def _aggregate_wallet_rows(rows):
+    """Merge multiple V$ENCRYPTION_WALLET rows when ``container`` is ``all``."""
+    if not rows:
+        return {}
+    if len(rows) == 1:
+        return rows[0]
+
+    statuses = []
+    for r in rows:
+        st = (_vwallet_field(r, 'STATUS') or '').upper()
+        statuses.append(st)
+
+    def _is_open(s):
+        return s in ('OPEN', 'OPEN_NO_MASTER_KEY')
+
+    def _is_closed(s):
+        return s in ('CLOSED', 'NOT_AVAILABLE') or not s
+
+    all_open = bool(statuses) and all(_is_open(s) for s in statuses)
+    all_closed = bool(statuses) and all(_is_closed(s) for s in statuses)
+    if all_open:
+        agg_status = 'OPEN'
+    elif all_closed:
+        agg_status = 'CLOSED'
+    else:
+        agg_status = 'MIXED'
+
+    first = rows[0]
+    open_rows = [rows[i] for i, s in enumerate(statuses) if _is_open(s)]
+    auto_types = ('AUTOLOGIN', 'LOCAL_AUTOLOGIN')
+
+    def _wtype(r):
+        return (_vwallet_field(r, 'WALLET_TYPE') or '').upper()
+
+    if open_rows and not all(_wtype(r) in auto_types for r in open_rows):
+        rep_wallet_type = 'PASSWORD'
+    else:
+        rep_wallet_type = _vwallet_field(first, 'WALLET_TYPE')
+
+    modes = {_vwallet_field(r, 'KEYSTORE_MODE') for r in rows if _vwallet_field(r, 'KEYSTORE_MODE')}
+    keystore_mode = 'MIXED' if len(modes) > 1 else _vwallet_field(first, 'KEYSTORE_MODE')
+
+    return {
+        'wrl_type': _vwallet_field(first, 'WRL_TYPE'),
+        'wrl_parameter': _vwallet_field(first, 'WRL_PARAMETER'),
+        'status': agg_status,
+        'wallet_type': rep_wallet_type,
+        'wallet_order': _vwallet_field(first, 'WALLET_ORDER'),
+        'keystore_mode': keystore_mode,
+    }
+
+
+def get_wallet_status(conn, container=None):
+    """Query V$ENCRYPTION_WALLET for keystore status.
+
+    With ``container='all'``, aggregates every row so open/close idempotency
+    reflects all PDBs/containers, not an arbitrary single row.
+    """
+    base_sql = """SELECT WRL_TYPE, WRL_PARAMETER, STATUS, WALLET_TYPE, WALLET_ORDER, KEYSTORE_MODE
+             FROM V$ENCRYPTION_WALLET"""
+    if container == 'all':
+        rows = conn.execute_select_to_dict(base_sql, fetchone=False)
+        if not rows:
+            return {}
+        return _aggregate_wallet_rows(rows)
+    sql = base_sql + "\n             WHERE ROWNUM = 1"
     return conn.execute_select_to_dict(sql, fetchone=True)
 
 
@@ -308,20 +381,29 @@ def get_secrets(conn):
     return conn.execute_select_to_dict(sql, fail_on_error=False) or []
 
 
-def secret_exists(conn, client_name):
-    """Check if a specific secret client entry exists."""
+def secret_exists(conn, client_name, secret_tag=None):
+    """Check if a secret exists for *client_name*, optionally scoped to *secret_tag*."""
     secrets = get_secrets(conn)
     if not secrets:
         return False
+    c_upper = client_name.upper()
+    want_tag = (secret_tag or '').strip()
+    want_tag_u = want_tag.upper() if want_tag else None
     for s in secrets:
-        if s.get('client', '').upper() == client_name.upper():
+        cli = (_vwallet_field(s, 'CLIENT') or '').upper()
+        if cli != c_upper:
+            continue
+        if want_tag_u is None:
+            return True
+        tag = (_vwallet_field(s, 'SECRET_TAG') or '').upper()
+        if tag == want_tag_u:
             return True
     return False
 
 
 def ensure_keystore_present(conn, module):
     """Create a software keystore if it doesn't exist."""
-    status = get_wallet_status(conn)
+    status = get_wallet_status(conn, module.params["container"])
     keystore_location = module.params["keystore_location"]
     keystore_password = module.params["keystore_password"]
 
@@ -350,12 +432,12 @@ def ensure_keystore_present(conn, module):
         loc_esc, pwd_esc
     )
     conn.execute_ddl(sql)
-    return get_wallet_status(conn)
+    return get_wallet_status(conn, module.params["container"])
 
 
 def ensure_keystore_open(conn, module):
     """Open the keystore if it is closed."""
-    status = get_wallet_status(conn)
+    status = get_wallet_status(conn, module.params["container"])
     current_status = status.get('status', '') if status else ''
     keystore_password = module.params["keystore_password"]
     container = module.params["container"]
@@ -375,12 +457,12 @@ def ensure_keystore_open(conn, module):
         force, pwd_esc, container_clause
     )
     conn.execute_ddl(sql)
-    return get_wallet_status(conn)
+    return get_wallet_status(conn, module.params["container"])
 
 
 def ensure_keystore_closed(conn, module):
     """Close the keystore if it is open."""
-    status = get_wallet_status(conn)
+    status = get_wallet_status(conn, module.params["container"])
     current_status = status.get('status', '') if status else ''
     keystore_password = module.params["keystore_password"]
     container = module.params["container"]
@@ -402,7 +484,7 @@ def ensure_keystore_closed(conn, module):
             pwd_esc, container_clause
         )
     conn.execute_ddl(sql)
-    return get_wallet_status(conn)
+    return get_wallet_status(conn, module.params["container"])
 
 
 def create_auto_login(conn, module):
@@ -415,7 +497,7 @@ def create_auto_login(conn, module):
         return
 
     # Check if the desired auto-login type already exists
-    status = get_wallet_status(conn)
+    status = get_wallet_status(conn, module.params["container"])
     current_type = status.get('wallet_type', '') if status else ''
     if auto_login == 'auto_login' and current_type == 'AUTOLOGIN':
         return
@@ -427,7 +509,7 @@ def create_auto_login(conn, module):
 
     # Determine location
     if not keystore_location:
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         keystore_location = status.get('wrl_parameter', '')
         if not keystore_location:
             wallet_root = get_wallet_root(conn)
@@ -516,7 +598,7 @@ def manage_secret(conn, module):
 
     force = build_force_clause(force_keystore)
     backup_clause = build_backup_clause(backup, backup_tag)
-    exists = secret_exists(conn, secret_client)
+    exists = secret_exists(conn, secret_client, secret_tag)
 
     safe_client = escape_sql_literal_or_fail(secret_client, "'", module)
     pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
@@ -541,8 +623,12 @@ def manage_secret(conn, module):
     elif secret_state == 'absent':
         if not exists:
             return  # Already absent, idempotent
-        sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s' IDENTIFIED BY \"%s\"%s" % (
-            force, safe_client, pwd_esc, backup_clause
+        tag_clause = ""
+        if secret_tag:
+            safe_tag_del = escape_sql_literal_or_fail(secret_tag, "'", module)
+            tag_clause = " USING TAG '%s'" % safe_tag_del
+        sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
+            force, safe_client, tag_clause, pwd_esc, backup_clause
         )
         conn.execute_ddl(sql)
 
@@ -597,7 +683,7 @@ def main():
     validate_wallet_inputs_before_connect(module)
 
     def _exit_status_query(conn_):
-        status = get_wallet_status(conn_)
+        status = get_wallet_status(conn_, module.params["container"])
         secrets = get_secrets(conn_)
         module.exit_json(
             changed=False,
@@ -620,7 +706,7 @@ def main():
     # Secret management takes priority if secret_state is set
     if secret_state:
         manage_secret(conn, module)
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         module.exit_json(
             changed=conn.changed,
             ddls=_redact_ddls(conn.ddls),
@@ -656,7 +742,7 @@ def main():
             else:
                 backup_keystore(conn, module)
 
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         module.exit_json(
             changed=conn.changed,
             ddls=_redact_ddls(conn.ddls),
@@ -668,7 +754,7 @@ def main():
 
     elif state == 'open':
         ensure_keystore_open(conn, module)
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         module.exit_json(
             changed=conn.changed,
             ddls=_redact_ddls(conn.ddls),
@@ -680,7 +766,7 @@ def main():
 
     elif state == 'closed':
         ensure_keystore_closed(conn, module)
-        status = get_wallet_status(conn)
+        status = get_wallet_status(conn, module.params["container"])
         module.exit_json(
             changed=conn.changed,
             ddls=_redact_ddls(conn.ddls),

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -1,0 +1,569 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: oracle_wallet
+short_description: Manage Oracle TDE keystores (wallets)
+description:
+  - Manage Oracle TDE keystores (wallets) using ADMINISTER KEY MANAGEMENT SQL
+  - Create, open, close, backup keystores
+  - Create auto-login keystores (local or network)
+  - Change keystore password
+  - Manage secrets (credentials) stored in the keystore
+  - Supports multitenant CONTAINER clause
+  - Compatible with Oracle 19c, 23ai, and 26ai
+  - In Oracle 26ai, WALLET_ROOT is mandatory (ENCRYPTION_WALLET_LOCATION is desupported)
+  - See connection parameters for oracle_ping
+version_added: "3.4.0"
+options:
+  state:
+    description: The intended state of the keystore
+    default: present
+    choices: ['present', 'absent', 'open', 'closed', 'status']
+  keystore_location:
+    description:
+      - Path where the keystore files are stored
+      - If not set, the module queries WALLET_ROOT or V$ENCRYPTION_WALLET for the location
+    required: false
+  keystore_password:
+    description: Password for the keystore
+    required: false
+  new_password:
+    description: New password when changing keystore password (state=present with change_password=true)
+    required: false
+  auto_login:
+    description: Type of auto-login keystore to create
+    default: none
+    choices: ['none', 'auto_login', 'local_auto_login']
+  change_password:
+    description: Whether to change the keystore password (requires new_password)
+    default: false
+    type: bool
+  backup:
+    description: Whether to create a backup before destructive operations (WITH BACKUP)
+    default: true
+    type: bool
+  backup_location:
+    description: Directory path for the backup file
+    required: false
+  backup_tag:
+    description: Tag identifier for the backup file
+    required: false
+  secret:
+    description: Secret value to store in the keystore
+    required: false
+  secret_client:
+    description: Client identifier for the secret (e.g. TDE_WALLET, HSM_WALLET, or custom name)
+    required: false
+  secret_tag:
+    description: Tag for the secret entry
+    required: false
+  secret_state:
+    description: State of the secret entry
+    choices: ['present', 'absent']
+    required: false
+  force_keystore:
+    description: Use FORCE KEYSTORE clause (temporarily opens an auto-login keystore for the operation)
+    default: false
+    type: bool
+  container:
+    description: Container clause for multitenant environments
+    default: current
+    choices: ['current', 'all']
+notes:
+  - Requires ADMINISTER KEY MANAGEMENT or SYSKM privilege
+  - oracledb Python module is required
+  - Keystore passwords are never logged (no_log=True)
+requirements: [ "oracledb" ]
+author:
+  - Cyrille Modiano
+'''
+
+EXAMPLES = '''
+- name: Create a software keystore
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    keystore_location: /opt/oracle/admin/wallets/tde
+    keystore_password: "MyKeystorePass123"
+
+- name: Open the keystore
+  oracle_wallet:
+    mode: sysdba
+    state: open
+    keystore_password: "MyKeystorePass123"
+
+- name: Open the keystore for all PDBs
+  oracle_wallet:
+    mode: sysdba
+    state: open
+    keystore_password: "MyKeystorePass123"
+    container: all
+
+- name: Close the keystore
+  oracle_wallet:
+    mode: sysdba
+    state: closed
+    keystore_password: "MyKeystorePass123"
+
+- name: Create auto-login keystore
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    auto_login: auto_login
+    keystore_password: "MyKeystorePass123"
+
+- name: Create local auto-login keystore (host-bound)
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    auto_login: local_auto_login
+    keystore_password: "MyKeystorePass123"
+
+- name: Backup keystore
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    backup_tag: "before_upgrade"
+    keystore_password: "MyKeystorePass123"
+    backup_location: /opt/oracle/backup/wallets
+
+- name: Change keystore password
+  oracle_wallet:
+    mode: sysdba
+    state: present
+    change_password: true
+    keystore_password: "OldPass123"
+    new_password: "NewPass456"
+
+- name: Add a secret to the keystore
+  oracle_wallet:
+    mode: sysdba
+    secret: "my_secret_value"
+    secret_client: "MY_APP"
+    secret_state: present
+    keystore_password: "MyKeystorePass123"
+
+- name: Remove a secret from the keystore
+  oracle_wallet:
+    mode: sysdba
+    secret_client: "MY_APP"
+    secret_state: absent
+    keystore_password: "MyKeystorePass123"
+
+- name: Get keystore status
+  oracle_wallet:
+    mode: sysdba
+    state: status
+  register: wallet_info
+'''
+
+
+def get_wallet_status(conn):
+    """Query V$ENCRYPTION_WALLET for current keystore status."""
+    sql = """SELECT WRL_TYPE, WRL_PARAMETER, STATUS, WALLET_TYPE, WALLET_ORDER, KEYSTORE_MODE
+             FROM V$ENCRYPTION_WALLET
+             WHERE ROWNUM = 1"""
+    return conn.execute_select_to_dict(sql, fetchone=True)
+
+
+def get_wallet_root(conn):
+    """Get WALLET_ROOT parameter value."""
+    sql = "SELECT VALUE FROM V$PARAMETER WHERE NAME = 'wallet_root'"
+    r = conn.execute_select_to_dict(sql, fetchone=True)
+    return r.get('value') if r else None
+
+
+def get_secrets(conn):
+    """Query secrets stored in the keystore."""
+    sql = "SELECT CLIENT, SECRET_TAG FROM V$CLIENT_SECRETS"
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def secret_exists(conn, client_name):
+    """Check if a specific secret client entry exists."""
+    secrets = get_secrets(conn)
+    if not secrets:
+        return False
+    for s in secrets:
+        if s.get('client', '').upper() == client_name.upper():
+            return True
+    return False
+
+
+def build_backup_clause(backup, backup_tag):
+    """Build the WITH BACKUP clause for key management commands."""
+    if not backup:
+        return ''
+    clause = ' WITH BACKUP'
+    if backup_tag:
+        clause += " USING '%s'" % backup_tag
+    return clause
+
+
+def build_container_clause(container):
+    """Build CONTAINER clause."""
+    if container == 'all':
+        return ' CONTAINER = ALL'
+    return ''
+
+
+def build_force_clause(force_keystore):
+    """Build FORCE KEYSTORE clause."""
+    if force_keystore:
+        return 'FORCE KEYSTORE '
+    return ''
+
+
+def ensure_keystore_present(conn, module):
+    """Create a software keystore if it doesn't exist."""
+    status = get_wallet_status(conn)
+    keystore_location = module.params["keystore_location"]
+    keystore_password = module.params["keystore_password"]
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to create a keystore', changed=False)
+
+    # If keystore already exists (status is not NOT_AVAILABLE and not empty)
+    current_status = status.get('status', '') if status else ''
+    if current_status and current_status != 'NOT_AVAILABLE':
+        return status
+
+    # Determine location
+    if not keystore_location:
+        wallet_root = get_wallet_root(conn)
+        if wallet_root:
+            keystore_location = wallet_root + '/tde'
+        else:
+            module.fail_json(
+                msg='keystore_location is required when WALLET_ROOT is not set',
+                changed=False
+            )
+
+    sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
+        keystore_location, keystore_password
+    )
+    conn.execute_ddl(sql)
+    return get_wallet_status(conn)
+
+
+def ensure_keystore_open(conn, module):
+    """Open the keystore if it is closed."""
+    status = get_wallet_status(conn)
+    current_status = status.get('status', '') if status else ''
+    keystore_password = module.params["keystore_password"]
+    container = module.params["container"]
+    force_keystore = module.params["force_keystore"]
+
+    if current_status in ('OPEN', 'OPEN_NO_MASTER_KEY'):
+        return status
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to open the keystore', changed=False)
+
+    force = build_force_clause(force_keystore)
+    container_clause = build_container_clause(container)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sSET KEYSTORE OPEN IDENTIFIED BY \"%s\"%s" % (
+        force, keystore_password, container_clause
+    )
+    conn.execute_ddl(sql)
+    return get_wallet_status(conn)
+
+
+def ensure_keystore_closed(conn, module):
+    """Close the keystore if it is open."""
+    status = get_wallet_status(conn)
+    current_status = status.get('status', '') if status else ''
+    keystore_password = module.params["keystore_password"]
+    container = module.params["container"]
+
+    if current_status in ('CLOSED', 'NOT_AVAILABLE', ''):
+        return status
+
+    container_clause = build_container_clause(container)
+    wallet_type = status.get('wallet_type', '')
+
+    # Auto-login wallets don't need password to close
+    if wallet_type in ('AUTOLOGIN', 'LOCAL_AUTOLOGIN'):
+        sql = "ADMINISTER KEY MANAGEMENT SET KEYSTORE CLOSE%s" % container_clause
+    else:
+        if not keystore_password:
+            module.fail_json(msg='keystore_password is required to close a password-based keystore', changed=False)
+        sql = "ADMINISTER KEY MANAGEMENT SET KEYSTORE CLOSE IDENTIFIED BY \"%s\"%s" % (
+            keystore_password, container_clause
+        )
+    conn.execute_ddl(sql)
+    return get_wallet_status(conn)
+
+
+def create_auto_login(conn, module):
+    """Create an auto-login keystore from the existing password keystore."""
+    auto_login = module.params["auto_login"]
+    keystore_password = module.params["keystore_password"]
+    keystore_location = module.params["keystore_location"]
+
+    if auto_login == 'none':
+        return
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to create auto-login keystore', changed=False)
+
+    # Determine location
+    if not keystore_location:
+        status = get_wallet_status(conn)
+        keystore_location = status.get('wrl_parameter', '')
+        if not keystore_location:
+            wallet_root = get_wallet_root(conn)
+            if wallet_root:
+                keystore_location = wallet_root + '/tde'
+            else:
+                module.fail_json(
+                    msg='Cannot determine keystore location for auto-login creation',
+                    changed=False
+                )
+
+    local_clause = 'LOCAL ' if auto_login == 'local_auto_login' else ''
+
+    sql = "ADMINISTER KEY MANAGEMENT CREATE %sAUTO_LOGIN KEYSTORE FROM KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
+        local_clause, keystore_location, keystore_password
+    )
+    conn.execute_ddl(sql)
+
+
+def backup_keystore(conn, module):
+    """Create a backup of the keystore."""
+    keystore_password = module.params["keystore_password"]
+    backup_tag = module.params["backup_tag"]
+    backup_location = module.params["backup_location"]
+    force_keystore = module.params["force_keystore"]
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to backup the keystore', changed=False)
+
+    force = build_force_clause(force_keystore)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sBACKUP KEYSTORE" % force
+    if backup_tag:
+        sql += " USING '%s'" % backup_tag
+    sql += " IDENTIFIED BY \"%s\"" % keystore_password
+    if backup_location:
+        sql += " TO '%s'" % backup_location
+    conn.execute_ddl(sql)
+
+
+def change_keystore_password(conn, module):
+    """Change the keystore password."""
+    keystore_password = module.params["keystore_password"]
+    new_password = module.params["new_password"]
+    backup = module.params["backup"]
+    backup_tag = module.params["backup_tag"]
+    force_keystore = module.params["force_keystore"]
+
+    if not keystore_password or not new_password:
+        module.fail_json(msg='Both keystore_password and new_password are required', changed=False)
+
+    force = build_force_clause(force_keystore)
+    backup_clause = build_backup_clause(backup, backup_tag)
+
+    sql = "ADMINISTER KEY MANAGEMENT %sALTER KEYSTORE PASSWORD IDENTIFIED BY \"%s\" SET \"%s\"%s" % (
+        force, keystore_password, new_password, backup_clause
+    )
+    conn.execute_ddl(sql)
+
+
+def manage_secret(conn, module):
+    """Add, update, or delete a secret in the keystore."""
+    secret = module.params["secret"]
+    secret_client = module.params["secret_client"]
+    secret_state = module.params["secret_state"]
+    secret_tag = module.params["secret_tag"]
+    keystore_password = module.params["keystore_password"]
+    backup = module.params["backup"]
+    backup_tag = module.params["backup_tag"]
+    force_keystore = module.params["force_keystore"]
+
+    if not secret_client:
+        module.fail_json(msg='secret_client is required for secret management', changed=False)
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required for secret management', changed=False)
+
+    force = build_force_clause(force_keystore)
+    backup_clause = build_backup_clause(backup, backup_tag)
+    exists = secret_exists(conn, secret_client)
+
+    if secret_state == 'present':
+        if not secret:
+            module.fail_json(msg='secret is required when secret_state=present', changed=False)
+
+        tag_clause = ""
+        if secret_tag:
+            tag_clause = " USING TAG '%s'" % secret_tag
+
+        if exists:
+            sql = "ADMINISTER KEY MANAGEMENT %sUPDATE SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
+                force, secret, secret_client, tag_clause, keystore_password, backup_clause
+            )
+        else:
+            sql = "ADMINISTER KEY MANAGEMENT %sADD SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
+                force, secret, secret_client, tag_clause, keystore_password, backup_clause
+            )
+        conn.execute_ddl(sql)
+
+    elif secret_state == 'absent':
+        if not exists:
+            return  # Already absent, idempotent
+        sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s' IDENTIFIED BY \"%s\"%s" % (
+            force, secret_client, keystore_password, backup_clause
+        )
+        conn.execute_ddl(sql)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            user=dict(required=False, aliases=['un', 'username']),
+            password=dict(required=False, no_log=True, aliases=['pw']),
+            mode=dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            hostname=dict(required=False, default='localhost', aliases=['host']),
+            port=dict(required=False, default=1521, type='int'),
+            service_name=dict(required=False, aliases=['sn']),
+            dsn=dict(required=False, aliases=['datasource_name']),
+            oracle_home=dict(required=False, aliases=['oh']),
+            session_container=dict(required=False),
+
+            state=dict(default="present",
+                       choices=["present", "absent", "open", "closed", "status"]),
+            keystore_location=dict(required=False),
+            keystore_password=dict(required=False, no_log=True),
+            new_password=dict(required=False, no_log=True),
+            auto_login=dict(default='none',
+                           choices=['none', 'auto_login', 'local_auto_login']),
+            change_password=dict(default=False, type='bool'),
+            backup=dict(default=True, type='bool'),
+            backup_location=dict(required=False),
+            backup_tag=dict(required=False),
+            force_keystore=dict(default=False, type='bool'),
+
+            secret=dict(required=False, no_log=True),
+            secret_client=dict(required=False),
+            secret_tag=dict(required=False),
+            secret_state=dict(required=False, choices=['present', 'absent']),
+
+            container=dict(default='current', choices=['current', 'all']),
+        ),
+        required_if=[
+            ('change_password', True, ('keystore_password', 'new_password')),
+        ],
+        supports_check_mode=True,
+    )
+    sanitize_string_params(module.params)
+
+    state = module.params["state"]
+    secret_state = module.params["secret_state"]
+    auto_login = module.params["auto_login"]
+    change_password_flag = module.params["change_password"]
+    backup_tag = module.params["backup_tag"]
+    backup_location = module.params["backup_location"]
+
+    conn = oracleConnection(module)
+
+    # Secret management takes priority if secret_state is set
+    if secret_state:
+        manage_secret(conn, module)
+        status = get_wallet_status(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='Secret managed successfully',
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+        )
+
+    if state == 'status':
+        status = get_wallet_status(conn)
+        secrets = get_secrets(conn)
+        module.exit_json(
+            changed=False,
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+            wrl_type=status.get('wrl_type', '') if status else '',
+            wrl_parameter=status.get('wrl_parameter', '') if status else '',
+            secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
+        )
+
+    elif state == 'present':
+        status = ensure_keystore_present(conn, module)
+
+        # Handle auto-login creation
+        if auto_login != 'none':
+            create_auto_login(conn, module)
+
+        # Handle password change
+        if change_password_flag:
+            change_keystore_password(conn, module)
+
+        # Handle explicit backup request
+        if backup_tag or backup_location:
+            # Only backup if explicitly requested via tag or location
+            if not change_password_flag:  # change_password already does WITH BACKUP
+                backup_keystore(conn, module)
+
+        status = get_wallet_status(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='Keystore managed successfully',
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+        )
+
+    elif state == 'open':
+        ensure_keystore_open(conn, module)
+        status = get_wallet_status(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='Keystore is open',
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+        )
+
+    elif state == 'closed':
+        ensure_keystore_closed(conn, module)
+        status = get_wallet_status(conn)
+        module.exit_json(
+            changed=conn.changed,
+            ddls=conn.ddls,
+            msg='Keystore is closed',
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+        )
+
+    elif state == 'absent':
+        # Oracle does not have a DROP KEYSTORE command. Keystore removal is a filesystem operation.
+        module.fail_json(
+            msg='Oracle does not support dropping a keystore via SQL. '
+                'Remove the keystore files manually from the filesystem.',
+            changed=False,
+        )
+
+
+from ansible.module_utils.basic import *  # noqa: F403
+
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(_params):
+        pass
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -319,8 +319,13 @@ def _aggregate_wallet_rows(rows):
 
     all_open = bool(statuses) and all(_is_open(s) for s in statuses)
     all_closed = bool(statuses) and all(_is_closed(s) for s in statuses)
+    all_not_available = bool(statuses) and all(
+        s in ('NOT_AVAILABLE', '') or not s for s in statuses
+    )
     if all_open:
         agg_status = 'OPEN'
+    elif all_not_available:
+        agg_status = 'NOT_AVAILABLE'
     elif all_closed:
         agg_status = 'CLOSED'
     else:
@@ -335,6 +340,8 @@ def _aggregate_wallet_rows(rows):
 
     if open_rows and not all(_wtype(r) in auto_types for r in open_rows):
         rep_wallet_type = 'PASSWORD'
+    elif open_rows:
+        rep_wallet_type = _vwallet_field(open_rows[0], 'WALLET_TYPE')
     else:
         rep_wallet_type = _vwallet_field(first, 'WALLET_TYPE')
 

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -789,6 +789,18 @@ def main():
 
 from ansible.module_utils.basic import *  # noqa: F403
 
+# In these we do import from local project sub-directory <project-dir>/module_utils
+# While this file is placed in <project-dir>/library
+# No collections are used
+#try:
+#    from ansible.module_utils.oracle_utils import (
+#        oracleConnection, sanitize_string_params,
+#        build_backup_clause, build_container_clause, build_force_clause,
+#    )
+#except:
+#    pass
+
+# In these we do import from collections
 try:
     from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
         oracleConnection, sanitize_string_params,

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -163,13 +163,122 @@ EXAMPLES = '''
 import re as _re
 
 
+def escape_sql_literal(value, quote_char):
+    """Escape *value* for embedding in a SQL fragment bounded by *quote_char*.
+
+    Oracle string literals double embedded single quotes; delimited strings
+    double embedded double quotes. Newlines are rejected so DDL stays a single
+    statement line.
+    """
+    if not isinstance(value, str):
+        raise TypeError('escape_sql_literal expects a string value')
+    if '\n' in value or '\r' in value:
+        raise ValueError('SQL parameter values must not contain newline or carriage return characters')
+    if quote_char == "'":
+        return value.replace("'", "''")
+    if quote_char == '"':
+        return value.replace('"', '""')
+    raise ValueError('quote_char must be single or double quote')
+
+
+def escape_sql_literal_or_fail(value, quote_char, module):
+    try:
+        return escape_sql_literal(value, quote_char)
+    except (TypeError, ValueError) as e:
+        module.fail_json(msg=str(e), changed=False)
+
+
+def _assert_sql_embeddable_str(module, value, quote_char):
+    """Reject values that cannot legally be embedded in a SQL literal."""
+    if value is None or value == '':
+        return
+    try:
+        escape_sql_literal(value, quote_char)
+    except (TypeError, ValueError) as e:
+        module.fail_json(msg=str(e), changed=False)
+
+
+def validate_wallet_inputs_before_connect(module):
+    """Validate task arguments before opening any database connection."""
+    state = module.params['state']
+    secret_state = module.params['secret_state']
+    change_password_flag = module.params['change_password']
+    backup_tag = module.params['backup_tag']
+    backup_location = module.params['backup_location']
+
+    if state == 'absent':
+        module.fail_json(
+            msg='Oracle does not support dropping a keystore via SQL. '
+                'Remove the keystore files manually from the filesystem.',
+            changed=False,
+        )
+
+    if secret_state:
+        if not module.params.get('secret_client'):
+            module.fail_json(msg='secret_client is required for secret management', changed=False)
+        if not module.params.get('keystore_password'):
+            module.fail_json(msg='keystore_password is required for secret management', changed=False)
+        if secret_state == 'present' and not module.params.get('secret'):
+            module.fail_json(msg='secret is required when secret_state=present', changed=False)
+        _assert_sql_embeddable_str(module, module.params.get('secret_client'), "'")
+        _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
+        if module.params.get('secret'):
+            _assert_sql_embeddable_str(module, module.params['secret'], "'")
+        _assert_sql_embeddable_str(module, module.params.get('secret_tag'), "'")
+        _assert_sql_embeddable_str(module, backup_tag, "'")
+        return
+
+    if state == 'present':
+        loc = module.params.get('keystore_location')
+        if loc:
+            _assert_sql_embeddable_str(module, loc, "'")
+        _assert_sql_embeddable_str(module, backup_tag, "'")
+        _assert_sql_embeddable_str(module, backup_location, "'")
+        if change_password_flag:
+            _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
+            _assert_sql_embeddable_str(module, module.params.get('new_password'), '"')
+        if (backup_tag or backup_location) and not change_password_flag:
+            if not module.params.get('keystore_password'):
+                module.fail_json(
+                    msg='keystore_password is required when backup_tag or backup_location is set',
+                    changed=False,
+                )
+        return
+
+    if state == 'open':
+        ks = module.params.get('keystore_password')
+        if ks:
+            _assert_sql_embeddable_str(module, ks, '"')
+        return
+
+    if state == 'closed':
+        ks = module.params.get('keystore_password')
+        if ks:
+            _assert_sql_embeddable_str(module, ks, '"')
+
+
 def _redact_ddls(ddls):
     """Redact passwords and secrets from DDL statements before returning to user."""
+    # Oracle doubles embedded quotes inside literals; match full quoted spans.
+    _sq_lit = r"'(?:[^']|'')*'"
+    _dq_lit = r'"(?:[^"]|"")*"'
     redacted = []
     for ddl in ddls:
-        s = _re.sub(r'(IDENTIFIED\s+BY\s+)"[^"]*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
-        s = _re.sub(r"(SECRET\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
-        s = _re.sub(r"(USING\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r'(IDENTIFIED\s+BY\s+)' + _dq_lit, r'\1"***"', ddl, flags=_re.IGNORECASE)
+        s = _re.sub(r'(SECRET\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r'(USING\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(
+            r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _dq_lit,
+            r"\1'***'",
+            s,
+            flags=_re.IGNORECASE,
+        )
+        s = _re.sub(
+            r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _sq_lit,
+            r"\1'***'",
+            s,
+            flags=_re.IGNORECASE,
+        )
         redacted.append(s)
     return redacted
 
@@ -231,13 +340,10 @@ def ensure_keystore_present(conn, module):
                 changed=False
             )
 
-    if "'" in keystore_location:
-        module.fail_json(
-            msg='keystore_location must not contain single quotes',
-            changed=False,
-        )
+    loc_esc = escape_sql_literal_or_fail(keystore_location, "'", module)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
     sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
-        keystore_location, keystore_password
+        loc_esc, pwd_esc
     )
     conn.execute_ddl(sql)
     return get_wallet_status(conn)
@@ -259,9 +365,10 @@ def ensure_keystore_open(conn, module):
 
     force = build_force_clause(force_keystore)
     container_clause = build_container_clause(container)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
 
     sql = "ADMINISTER KEY MANAGEMENT %sSET KEYSTORE OPEN IDENTIFIED BY \"%s\"%s" % (
-        force, keystore_password, container_clause
+        force, pwd_esc, container_clause
     )
     conn.execute_ddl(sql)
     return get_wallet_status(conn)
@@ -286,8 +393,9 @@ def ensure_keystore_closed(conn, module):
     else:
         if not keystore_password:
             module.fail_json(msg='keystore_password is required to close a password-based keystore', changed=False)
+        pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
         sql = "ADMINISTER KEY MANAGEMENT SET KEYSTORE CLOSE IDENTIFIED BY \"%s\"%s" % (
-            keystore_password, container_clause
+            pwd_esc, container_clause
         )
     conn.execute_ddl(sql)
     return get_wallet_status(conn)
@@ -329,15 +437,25 @@ def create_auto_login(conn, module):
 
     local_clause = 'LOCAL ' if auto_login == 'local_auto_login' else ''
 
+    loc_esc = escape_sql_literal_or_fail(keystore_location, "'", module)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
     sql = "ADMINISTER KEY MANAGEMENT CREATE %sAUTO_LOGIN KEYSTORE FROM KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
-        local_clause, keystore_location, keystore_password
+        local_clause, loc_esc, pwd_esc
     )
     conn.execute_ddl(sql)
 
 
-def backup_keystore(conn, module):
-    """Create a backup of the keystore."""
-    keystore_password = module.params["keystore_password"]
+def backup_keystore(conn, module, identified_by_password=None):
+    """Create a backup of the keystore.
+
+    After ``ALTER KEYSTORE PASSWORD``, pass *identified_by_password* (the new
+    password) so ``IDENTIFIED BY`` matches the current keystore password.
+    """
+    keystore_password = (
+        identified_by_password
+        if identified_by_password is not None
+        else module.params["keystore_password"]
+    )
     backup_tag = module.params["backup_tag"]
     backup_location = module.params["backup_location"]
     force_keystore = module.params["force_keystore"]
@@ -346,13 +464,16 @@ def backup_keystore(conn, module):
         module.fail_json(msg='keystore_password is required to backup the keystore', changed=False)
 
     force = build_force_clause(force_keystore)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
 
     sql = "ADMINISTER KEY MANAGEMENT %sBACKUP KEYSTORE" % force
     if backup_tag:
-        sql += " USING '%s'" % backup_tag
-    sql += " IDENTIFIED BY \"%s\"" % keystore_password
+        tag_esc = escape_sql_literal_or_fail(backup_tag, "'", module)
+        sql += " USING '%s'" % tag_esc
+    sql += " IDENTIFIED BY \"%s\"" % pwd_esc
     if backup_location:
-        sql += " TO '%s'" % backup_location
+        loc_esc = escape_sql_literal_or_fail(backup_location, "'", module)
+        sql += " TO '%s'" % loc_esc
     conn.execute_ddl(sql)
 
 
@@ -369,9 +490,11 @@ def change_keystore_password(conn, module):
 
     force = build_force_clause(force_keystore)
     backup_clause = build_backup_clause(backup, backup_tag)
+    old_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
+    new_esc = escape_sql_literal_or_fail(new_password, '"', module)
 
     sql = "ADMINISTER KEY MANAGEMENT %sALTER KEYSTORE PASSWORD IDENTIFIED BY \"%s\" SET \"%s\"%s" % (
-        force, keystore_password, new_password, backup_clause
+        force, old_esc, new_esc, backup_clause
     )
     conn.execute_ddl(sql)
 
@@ -387,34 +510,27 @@ def manage_secret(conn, module):
     backup_tag = module.params["backup_tag"]
     force_keystore = module.params["force_keystore"]
 
-    if not secret_client:
-        module.fail_json(msg='secret_client is required for secret management', changed=False)
-    if not keystore_password:
-        module.fail_json(msg='keystore_password is required for secret management', changed=False)
-
     force = build_force_clause(force_keystore)
     backup_clause = build_backup_clause(backup, backup_tag)
     exists = secret_exists(conn, secret_client)
 
-    safe_client = secret_client.replace("'", "''")
+    safe_client = escape_sql_literal_or_fail(secret_client, "'", module)
+    pwd_esc = escape_sql_literal_or_fail(keystore_password, '"', module)
 
     if secret_state == 'present':
-        if not secret:
-            module.fail_json(msg='secret is required when secret_state=present', changed=False)
-
-        safe_secret = secret.replace("'", "''")
+        safe_secret = escape_sql_literal_or_fail(secret, "'", module)
         tag_clause = ""
         if secret_tag:
-            safe_tag = secret_tag.replace("'", "''")
+            safe_tag = escape_sql_literal_or_fail(secret_tag, "'", module)
             tag_clause = " USING TAG '%s'" % safe_tag
 
         if exists:
             sql = "ADMINISTER KEY MANAGEMENT %sUPDATE SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
-                force, safe_secret, safe_client, tag_clause, keystore_password, backup_clause
+                force, safe_secret, safe_client, tag_clause, pwd_esc, backup_clause
             )
         else:
             sql = "ADMINISTER KEY MANAGEMENT %sADD SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
-                force, safe_secret, safe_client, tag_clause, keystore_password, backup_clause
+                force, safe_secret, safe_client, tag_clause, pwd_esc, backup_clause
             )
         conn.execute_ddl(sql)
 
@@ -422,7 +538,7 @@ def manage_secret(conn, module):
         if not exists:
             return  # Already absent, idempotent
         sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s' IDENTIFIED BY \"%s\"%s" % (
-            force, safe_client, keystore_password, backup_clause
+            force, safe_client, pwd_esc, backup_clause
         )
         conn.execute_ddl(sql)
 
@@ -474,12 +590,31 @@ def main():
     backup_tag = module.params["backup_tag"]
     backup_location = module.params["backup_location"]
 
+    validate_wallet_inputs_before_connect(module)
+
+    def _exit_status_query(conn_):
+        status = get_wallet_status(conn_)
+        secrets = get_secrets(conn_)
+        module.exit_json(
+            changed=False,
+            wallet_status=status.get('status', '') if status else '',
+            wallet_type=status.get('wallet_type', '') if status else '',
+            keystore_mode=status.get('keystore_mode', '') if status else '',
+            wrl_type=status.get('wrl_type', '') if status else '',
+            wrl_parameter=status.get('wrl_parameter', '') if status else '',
+            secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
+        )
+
+    if module.check_mode:
+        if state == 'status':
+            conn = oracleConnection(module)
+            _exit_status_query(conn)
+        module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
+
     conn = oracleConnection(module)
 
     # Secret management takes priority if secret_state is set
     if secret_state:
-        if module.check_mode:
-            module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
         manage_secret(conn, module)
         status = get_wallet_status(conn)
         module.exit_json(
@@ -492,20 +627,7 @@ def main():
         )
 
     if state == 'status':
-        status = get_wallet_status(conn)
-        secrets = get_secrets(conn)
-        module.exit_json(
-            changed=False,
-            wallet_status=status.get('status', '') if status else '',
-            wallet_type=status.get('wallet_type', '') if status else '',
-            keystore_mode=status.get('keystore_mode', '') if status else '',
-            wrl_type=status.get('wrl_type', '') if status else '',
-            wrl_parameter=status.get('wrl_parameter', '') if status else '',
-            secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
-        )
-
-    if module.check_mode:
-        module.exit_json(changed=False, msg='Check mode: no keystore operations executed')
+        _exit_status_query(conn)
 
     if state == 'present':
         status = ensure_keystore_present(conn, module)
@@ -518,10 +640,16 @@ def main():
         if change_password_flag:
             change_keystore_password(conn, module)
 
-        # Handle explicit backup request
+        # Explicit BACKUP KEYSTORE (WITH BACKUP on ALTER has no TO clause; if
+        # backup_tag is set with backup=False, ALTER omits WITH BACKUP too).
         if backup_tag or backup_location:
-            # Only backup if explicitly requested via tag or location
-            if not change_password_flag:  # change_password already does WITH BACKUP
+            if change_password_flag:
+                if backup_location or not module.params["backup"]:
+                    backup_keystore(
+                        conn, module,
+                        identified_by_password=module.params["new_password"],
+                    )
+            else:
                 backup_keystore(conn, module)
 
         status = get_wallet_status(conn)
@@ -556,14 +684,6 @@ def main():
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',
             keystore_mode=status.get('keystore_mode', '') if status else '',
-        )
-
-    elif state == 'absent':
-        # Oracle does not have a DROP KEYSTORE command. Keystore removal is a filesystem operation.
-        module.fail_json(
-            msg='Oracle does not support dropping a keystore via SQL. '
-                'Remove the keystore files manually from the filesystem.',
-            changed=False,
         )
 
 

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -321,13 +321,13 @@ def ensure_keystore_present(conn, module):
     keystore_location = module.params["keystore_location"]
     keystore_password = module.params["keystore_password"]
 
-    if not keystore_password:
-        module.fail_json(msg='keystore_password is required to create a keystore', changed=False)
-
     # If keystore already exists (status is not NOT_AVAILABLE and not empty)
     current_status = status.get('status', '') if status else ''
     if current_status and current_status != 'NOT_AVAILABLE':
         return status
+
+    if not keystore_password:
+        module.fail_json(msg='keystore_password is required to create a keystore', changed=False)
 
     # Determine location
     if not keystore_location:

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -160,6 +160,20 @@ EXAMPLES = '''
 '''
 
 
+import re as _re
+
+
+def _redact_ddls(ddls):
+    """Redact passwords and secrets from DDL statements before returning to user."""
+    redacted = []
+    for ddl in ddls:
+        s = _re.sub(r'(IDENTIFIED\s+BY\s+)"[^"]*"', r'\1"***"', ddl, flags=_re.IGNORECASE)
+        s = _re.sub(r"(SECRET\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        s = _re.sub(r"(USING\s+)'[^']*'", r"\1'***'", s, flags=_re.IGNORECASE)
+        redacted.append(s)
+    return redacted
+
+
 def get_wallet_status(conn):
     """Query V$ENCRYPTION_WALLET for current keystore status."""
     sql = """SELECT WRL_TYPE, WRL_PARAMETER, STATUS, WALLET_TYPE, WALLET_ORDER, KEYSTORE_MODE
@@ -286,6 +300,14 @@ def create_auto_login(conn, module):
     keystore_location = module.params["keystore_location"]
 
     if auto_login == 'none':
+        return
+
+    # Check if the desired auto-login type already exists
+    status = get_wallet_status(conn)
+    current_type = status.get('wallet_type', '') if status else ''
+    if auto_login == 'auto_login' and current_type == 'AUTOLOGIN':
+        return
+    if auto_login == 'local_auto_login' and current_type == 'LOCAL_AUTOLOGIN':
         return
 
     if not keystore_password:
@@ -462,7 +484,7 @@ def main():
         status = get_wallet_status(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='Secret managed successfully',
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',
@@ -505,7 +527,7 @@ def main():
         status = get_wallet_status(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='Keystore managed successfully',
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',
@@ -517,7 +539,7 @@ def main():
         status = get_wallet_status(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='Keystore is open',
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',
@@ -529,7 +551,7 @@ def main():
         status = get_wallet_status(conn)
         module.exit_json(
             changed=conn.changed,
-            ddls=conn.ddls,
+            ddls=_redact_ddls(conn.ddls),
             msg='Keystore is closed',
             wallet_status=status.get('status', '') if status else '',
             wallet_type=status.get('wallet_type', '') if status else '',

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -213,6 +213,11 @@ def validate_wallet_inputs_before_connect(module):
             module.fail_json(msg='keystore_password is required for secret management', changed=False)
         if secret_state == 'present' and not module.params.get('secret'):
             module.fail_json(msg='secret is required when secret_state=present', changed=False)
+        if backup_location:
+            module.fail_json(
+                msg='backup_location is not supported for secret management (Oracle does not support TO clause with secret DDL)',
+                changed=False,
+            )
         _assert_sql_embeddable_str(module, module.params.get('secret_client'), "'")
         _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
         if module.params.get('secret'):
@@ -234,6 +239,11 @@ def validate_wallet_inputs_before_connect(module):
             _assert_sql_embeddable_str(module, loc, "'")
         _assert_sql_embeddable_str(module, backup_tag, "'")
         _assert_sql_embeddable_str(module, backup_location, "'")
+        auto_login = module.params.get('auto_login')
+        if auto_login and auto_login != 'none':
+            if not module.params.get('keystore_password'):
+                module.fail_json(msg='keystore_password is required when auto_login is set', changed=False)
+            _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
         if change_password_flag:
             _assert_sql_embeddable_str(module, module.params.get('keystore_password'), '"')
             _assert_sql_embeddable_str(module, module.params.get('new_password'), '"')
@@ -257,34 +267,35 @@ def validate_wallet_inputs_before_connect(module):
             _assert_sql_embeddable_str(module, ks, '"')
 
 
-def _redact_ddls(ddls):
-    """Redact passwords and secrets from DDL statements before returning to user.
+def _redact_ddl(ddl):
+    """Redact passwords and secrets from a single DDL statement.
 
     Backup identifiers in ``... USING 'tag'`` (BACKUP KEYSTORE / WITH BACKUP) are
     left visible; they are not credentials. ``USING TAG`` for secrets uses a
     different token sequence and is unaffected.
     """
-    # Oracle doubles embedded quotes inside literals; match full quoted spans.
     _sq_lit = r"'(?:[^']|'')*'"
     _dq_lit = r'"(?:[^"]|"")*"'
-    redacted = []
-    for ddl in ddls:
-        s = _re.sub(r'(IDENTIFIED\s+BY\s+)' + _dq_lit, r'\1"***"', ddl, flags=_re.IGNORECASE)
-        s = _re.sub(r'(SECRET\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
-        s = _re.sub(
-            r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _dq_lit,
-            r"\1'***'",
-            s,
-            flags=_re.IGNORECASE,
-        )
-        s = _re.sub(
-            r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _sq_lit,
-            r"\1'***'",
-            s,
-            flags=_re.IGNORECASE,
-        )
-        redacted.append(s)
-    return redacted
+    s = _re.sub(r'(IDENTIFIED\s+BY\s+)' + _dq_lit, r'\1"***"', ddl, flags=_re.IGNORECASE)
+    s = _re.sub(r'(SECRET\s+)' + _sq_lit, r"\1'***'", s, flags=_re.IGNORECASE)
+    s = _re.sub(
+        r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _dq_lit,
+        r"\1'***'",
+        s,
+        flags=_re.IGNORECASE,
+    )
+    s = _re.sub(
+        r'(ALTER\s+KEYSTORE\s+PASSWORD\s+.*?SET\s+)' + _sq_lit,
+        r"\1'***'",
+        s,
+        flags=_re.IGNORECASE,
+    )
+    return s
+
+
+def _redact_ddls(ddls):
+    """Redact passwords and secrets from a list of DDL statements."""
+    return [_redact_ddl(d) for d in ddls]
 
 
 def _vwallet_field(row, col):
@@ -394,15 +405,12 @@ def secret_exists(conn, client_name, secret_tag=None):
     if not secrets:
         return False
     c_upper = client_name.upper()
-    want_tag = (secret_tag or '').strip()
-    want_tag_u = want_tag.upper() if want_tag else None
+    want_tag_u = (secret_tag or '').strip().upper()
     for s in secrets:
         cli = (_vwallet_field(s, 'CLIENT') or '').upper()
         if cli != c_upper:
             continue
-        if want_tag_u is None:
-            return True
-        tag = (_vwallet_field(s, 'SECRET_TAG') or '').upper()
+        tag = (_vwallet_field(s, 'SECRET_TAG') or '').strip().upper()
         if tag == want_tag_u:
             return True
     return False
@@ -438,7 +446,7 @@ def ensure_keystore_present(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
         loc_esc, pwd_esc
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
     return get_wallet_status(conn, module.params["container"])
 
 
@@ -463,7 +471,7 @@ def ensure_keystore_open(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT %sSET KEYSTORE OPEN IDENTIFIED BY \"%s\"%s" % (
         force, pwd_esc, container_clause
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
     return get_wallet_status(conn, module.params["container"])
 
 
@@ -490,7 +498,7 @@ def ensure_keystore_closed(conn, module):
         sql = "ADMINISTER KEY MANAGEMENT SET KEYSTORE CLOSE IDENTIFIED BY \"%s\"%s" % (
             pwd_esc, container_clause
         )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
     return get_wallet_status(conn, module.params["container"])
 
 
@@ -535,7 +543,7 @@ def create_auto_login(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT CREATE %sAUTO_LOGIN KEYSTORE FROM KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
         local_clause, loc_esc, pwd_esc
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
 
 def backup_keystore(conn, module, identified_by_password=None):
@@ -567,7 +575,7 @@ def backup_keystore(conn, module, identified_by_password=None):
     if backup_location:
         loc_esc = escape_sql_literal_or_fail(backup_location, "'", module)
         sql += " TO '%s'" % loc_esc
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
 
 def change_keystore_password(conn, module):
@@ -589,7 +597,7 @@ def change_keystore_password(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT %sALTER KEYSTORE PASSWORD IDENTIFIED BY \"%s\" SET \"%s\"%s" % (
         force, old_esc, new_esc, backup_clause
     )
-    conn.execute_ddl(sql)
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
 
 def manage_secret(conn, module):
@@ -625,7 +633,7 @@ def manage_secret(conn, module):
             sql = "ADMINISTER KEY MANAGEMENT %sADD SECRET '%s' FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
                 force, safe_secret, safe_client, tag_clause, pwd_esc, backup_clause
             )
-        conn.execute_ddl(sql)
+        conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
     elif secret_state == 'absent':
         if not exists:
@@ -637,7 +645,7 @@ def manage_secret(conn, module):
         sql = "ADMINISTER KEY MANAGEMENT %sDELETE SECRET FOR CLIENT '%s'%s IDENTIFIED BY \"%s\"%s" % (
             force, safe_client, tag_clause, pwd_esc, backup_clause
         )
-        conn.execute_ddl(sql)
+        conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
 
 
 def main():
@@ -681,7 +689,7 @@ def main():
     if not HAS_ORACLE_UTILS:
         module.fail_json(msg='oracle_utils is required for oracle_wallet: %s' % _ORACLE_UTILS_ERR)
 
-    sanitize_string_params(module.params)
+    sanitize_string_params(module.params, no_trim={'password', 'keystore_password', 'new_password', 'secret'})
 
     state = module.params["state"]
     secret_state = module.params["secret_state"]
@@ -810,8 +818,11 @@ except ImportError as e:
     HAS_ORACLE_UTILS = False
     _ORACLE_UTILS_ERR = str(e)
 
-    def sanitize_string_params(module_params):
+    def sanitize_string_params(module_params, no_trim=None):
+        skip = set(no_trim) if no_trim else set()
         for key, value in module_params.items():
+            if key in skip:
+                continue
             if isinstance(value, str):
                 module_params[key] = value.strip()
 

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -310,12 +310,26 @@ def _vwallet_field(row, col):
     return ''
 
 
+def _normalize_wallet_row(row):
+    """Normalize a V$ENCRYPTION_WALLET row dict to lowercase keys."""
+    if not row:
+        return {}
+    return {
+        'wrl_type': _vwallet_field(row, 'WRL_TYPE'),
+        'wrl_parameter': _vwallet_field(row, 'WRL_PARAMETER'),
+        'status': _vwallet_field(row, 'STATUS'),
+        'wallet_type': _vwallet_field(row, 'WALLET_TYPE'),
+        'wallet_order': _vwallet_field(row, 'WALLET_ORDER'),
+        'keystore_mode': _vwallet_field(row, 'KEYSTORE_MODE'),
+    }
+
+
 def _aggregate_wallet_rows(rows):
     """Merge multiple V$ENCRYPTION_WALLET rows when ``container`` is ``all``."""
     if not rows:
         return {}
     if len(rows) == 1:
-        return rows[0]
+        return _normalize_wallet_row(rows[0])
 
     statuses = []
     for r in rows:
@@ -383,14 +397,14 @@ def get_wallet_status(conn, container=None):
             return {}
         return _aggregate_wallet_rows(rows)
     sql = base_sql + "\n             WHERE ROWNUM = 1"
-    return conn.execute_select_to_dict(sql, fetchone=True)
+    return _normalize_wallet_row(conn.execute_select_to_dict(sql, fetchone=True))
 
 
 def get_wallet_root(conn):
     """Get WALLET_ROOT parameter value."""
     sql = "SELECT VALUE FROM V$PARAMETER WHERE NAME = 'wallet_root'"
     r = conn.execute_select_to_dict(sql, fetchone=True)
-    return r.get('value') if r else None
+    return _vwallet_field(r, 'VALUE') if r else None
 
 
 def get_secrets(conn):
@@ -710,7 +724,7 @@ def main():
             keystore_mode=status.get('keystore_mode', '') if status else '',
             wrl_type=status.get('wrl_type', '') if status else '',
             wrl_parameter=status.get('wrl_parameter', '') if status else '',
-            secrets=[{'client': s.get('client', ''), 'tag': s.get('secret_tag', '')} for s in secrets],
+            secrets=[{'client': _vwallet_field(s, 'CLIENT'), 'tag': _vwallet_field(s, 'SECRET_TAG')} for s in secrets],
         )
 
     if module.check_mode:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,9 +63,16 @@ def _ensure_fake_ansible_basic():
                     "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
                 )
 
+        def _sanitize_string_params(module_params):
+            """Mirror production oracle_utils.sanitize_string_params; return dict for tests."""
+            for key, value in module_params.items():
+                if isinstance(value, str):
+                    module_params[key] = value.strip()
+            return module_params
+
         _ou_mod = types.ModuleType(_ou_path)
         _ou_mod.oracleConnection = _StubOracleConnection
-        _ou_mod.sanitize_string_params = lambda _params: None
+        _ou_mod.sanitize_string_params = _sanitize_string_params
         _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
 
         # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,9 +63,12 @@ def _ensure_fake_ansible_basic():
                     "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
                 )
 
-        def _sanitize_string_params(module_params):
+        def _sanitize_string_params(module_params, no_trim=None):
             """Mirror production oracle_utils.sanitize_string_params; return dict for tests."""
+            skip = set(no_trim) if no_trim else set()
             for key, value in module_params.items():
+                if key in skip:
+                    continue
                 if isinstance(value, str):
                     module_params[key] = value.strip()
             return module_params

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,11 +63,6 @@ def _ensure_fake_ansible_basic():
                     "set monkeypatch.setattr(mod, 'oracleConnection', FakeOC) in the test."
                 )
 
-        def _sql_single_quoted_literal(value):
-            if value is None:
-                return ''
-            return str(value).replace("'", "''")
-
         _ou_mod = types.ModuleType(_ou_path)
         _ou_mod.oracleConnection = _StubOracleConnection
         _ou_mod.sanitize_string_params = lambda _params: None
@@ -76,13 +71,12 @@ def _ensure_fake_ansible_basic():
         # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
         _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
         _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+
         def _sql_single_quoted_literal(value):
             """Match oracle_utils.sql_single_quoted_literal for unit tests (no package import)."""
             if value is None:
-                return None
-            if not isinstance(value, str):
-                raise TypeError('sql_single_quoted_literal expects str or None')
-            return value.replace("'", "''")
+                return ''
+            return str(value).replace("'", "''")
 
         _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -76,13 +76,24 @@ def _ensure_fake_ansible_basic():
         # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
         _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
         _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+        def _sql_single_quoted_literal(value):
+            """Match oracle_utils.sql_single_quoted_literal for unit tests (no package import)."""
+            if value is None:
+                return None
+            if not isinstance(value, str):
+                raise TypeError('sql_single_quoted_literal expects str or None')
+            return value.replace("'", "''")
+
+        _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
+
         def _build_backup(backup=True, backup_tag=None):
             if not backup:
                 return ''
             clause = ' WITH BACKUP'
             if backup_tag:
-                clause += " USING '%s'" % backup_tag
+                clause += " USING '%s'" % _sql_single_quoted_literal(backup_tag)
             return clause
+
         _ou_mod.build_backup_clause = _build_backup
         sys.modules[_ou_path] = _ou_mod
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,6 +70,12 @@ def _ensure_fake_ansible_basic():
                     module_params[key] = value.strip()
             return module_params
 
+        def _sql_single_quoted_literal(value):
+            """Match oracle_utils.sql_single_quoted_literal for unit tests (no package import)."""
+            if value is None:
+                return ''
+            return str(value).replace("'", "''")
+
         _ou_mod = types.ModuleType(_ou_path)
         _ou_mod.oracleConnection = _StubOracleConnection
         _ou_mod.sanitize_string_params = _sanitize_string_params
@@ -78,14 +84,6 @@ def _ensure_fake_ansible_basic():
         # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
         _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
         _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
-
-        def _sql_single_quoted_literal(value):
-            """Match oracle_utils.sql_single_quoted_literal for unit tests (no package import)."""
-            if value is None:
-                return ''
-            return str(value).replace("'", "''")
-
-        _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
 
         def _build_backup(backup=True, backup_tag=None):
             if not backup:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -72,6 +72,18 @@ def _ensure_fake_ansible_basic():
         _ou_mod.oracleConnection = _StubOracleConnection
         _ou_mod.sanitize_string_params = lambda _params: None
         _ou_mod.sql_single_quoted_literal = _sql_single_quoted_literal
+
+        # Shared SQL clause builders used by oracle_tde, oracle_wallet, etc.
+        _ou_mod.build_force_clause = lambda fk: 'FORCE KEYSTORE ' if fk else ''
+        _ou_mod.build_container_clause = lambda c: ' CONTAINER = ALL' if c == 'all' else ''
+        def _build_backup(backup=True, backup_tag=None):
+            if not backup:
+                return ''
+            clause = ' WITH BACKUP'
+            if backup_tag:
+                clause += " USING '%s'" % backup_tag
+            return clause
+        _ou_mod.build_backup_clause = _build_backup
         sys.modules[_ou_path] = _ou_mod
 
     ansible_mod = types.ModuleType("ansible")

--- a/tests/unit/test_all_modules_contracts.py
+++ b/tests/unit/test_all_modules_contracts.py
@@ -10,7 +10,9 @@ def _module_files():
 
 
 def test_all_modules_keep_original_name_prefix():
-    for module_file in _module_files():
+    files = _module_files()
+    assert files, "expected at least one plugins/modules/oracle_*.py module"
+    for module_file in files:
         assert module_file.name.startswith("oracle_")
 
 

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -1,0 +1,383 @@
+"""Unit tests for oracle_wallet module."""
+import pytest
+
+from conftest import ExitJson, FailJson, load_module_from_path, module_path
+from helpers import BASE_CONN_PARAMS, BaseFakeConn, BaseFakeModule, SequencedFakeConn
+
+
+def _load():
+    return load_module_from_path(
+        module_path("plugins", "modules", "oracle_wallet.py"), "oracle_wallet_test"
+    )
+
+
+def _wallet_params(**overrides):
+    base = {
+        **BASE_CONN_PARAMS,
+        "state": "present",
+        "keystore_location": "/opt/oracle/wallets/tde",
+        "keystore_password": "TestKeystorePass123",
+        "new_password": None,
+        "auto_login": "none",
+        "change_password": False,
+        "backup": True,
+        "backup_location": None,
+        "backup_tag": None,
+        "force_keystore": False,
+        "secret": None,
+        "secret_client": None,
+        "secret_tag": None,
+        "secret_state": None,
+        "container": "current",
+    }
+    base.update(overrides)
+    return base
+
+
+class _WalletConn(BaseFakeConn):
+    """Simulates V$ENCRYPTION_WALLET responses."""
+
+    def __init__(self, module, wallet_status='NOT_AVAILABLE', wallet_type='', keystore_mode='NONE', secrets=None):
+        super().__init__(module)
+        self._wallet_status = wallet_status
+        self._wallet_type = wallet_type
+        self._keystore_mode = keystore_mode
+        self._secrets = secrets or []
+
+    def execute_select_to_dict(self, sql, params=None, fetchone=False, fail_on_error=True):
+        sql_upper = sql.upper()
+        if 'V$ENCRYPTION_WALLET' in sql_upper:
+            row = {
+                'wrl_type': 'FILE',
+                'wrl_parameter': '/opt/oracle/wallets/tde',
+                'status': self._wallet_status,
+                'wallet_type': self._wallet_type,
+                'wallet_order': 'SINGLE',
+                'keystore_mode': self._keystore_mode,
+            }
+            return row if fetchone else [row]
+        if 'V$CLIENT_SECRETS' in sql_upper:
+            return self._secrets
+        if 'V$PARAMETER' in sql_upper:
+            return {'value': '/opt/oracle/admin/wallets'} if fetchone else [{'value': '/opt/oracle/admin/wallets'}]
+        return {} if fetchone else []
+
+
+# ===========================================================================
+# Tests: state=status
+# ===========================================================================
+
+def test_wallet_status(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="status")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', 'UNITED'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["wallet_status"] == "OPEN"
+    assert result["wallet_type"] == "PASSWORD"
+    assert result["keystore_mode"] == "UNITED"
+
+
+# ===========================================================================
+# Tests: state=present (create keystore)
+# ===========================================================================
+
+def test_wallet_create_when_not_exists(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present")
+
+    conn = _WalletConn(None, 'NOT_AVAILABLE')
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'NOT_AVAILABLE'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert len(result["ddls"]) >= 1
+    assert "CREATE KEYSTORE" in result["ddls"][0]
+
+
+def test_wallet_create_idempotent_when_exists(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: state=open
+# ===========================================================================
+
+def test_wallet_open_when_closed(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'CLOSED', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("SET KEYSTORE OPEN" in d for d in result["ddls"])
+
+
+def test_wallet_open_idempotent_when_already_open(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_wallet_open_with_container_all(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'CLOSED', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("CONTAINER = ALL" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: state=closed
+# ===========================================================================
+
+def test_wallet_close_when_open(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="closed")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("SET KEYSTORE CLOSE" in d for d in result["ddls"])
+
+
+def test_wallet_close_idempotent_when_already_closed(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="closed")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'CLOSED'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: auto-login
+# ===========================================================================
+
+def test_wallet_create_auto_login(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", auto_login="auto_login")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("AUTO_LOGIN KEYSTORE" in d for d in result["ddls"])
+
+
+def test_wallet_create_local_auto_login(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", auto_login="local_auto_login")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("LOCAL AUTO_LOGIN" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: change_password
+# ===========================================================================
+
+def test_wallet_change_password(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            state="present", change_password=True,
+            new_password="NewPass456"
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("ALTER KEYSTORE PASSWORD" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: secret management
+# ===========================================================================
+
+def test_wallet_add_secret(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret="my_secret", secret_client="MY_APP",
+            secret_state="present"
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("ADD SECRET" in d for d in result["ddls"])
+
+
+def test_wallet_update_existing_secret(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret="new_value", secret_client="MY_APP",
+            secret_state="present"
+        )
+
+    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("UPDATE SECRET" in d for d in result["ddls"])
+
+
+def test_wallet_delete_secret(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret_client="MY_APP", secret_state="absent"
+        )
+
+    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("DELETE SECRET" in d for d in result["ddls"])
+
+
+def test_wallet_delete_secret_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret_client="MY_APP", secret_state="absent"
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=[]), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: state=absent
+# ===========================================================================
+
+def test_wallet_absent_fails(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="absent")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN'), raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "does not support dropping" in exc.value.args[0]["msg"]
+
+
+# ===========================================================================
+# Tests: missing password
+# ===========================================================================
+
+def test_wallet_create_without_password_fails(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", keystore_password=None)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'NOT_AVAILABLE'), raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "keystore_password" in exc.value.args[0]["msg"]

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -398,7 +398,8 @@ def test_wallet_update_existing_secret(monkeypatch):
             secret_state="present"
         )
 
-    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    # Tagless secret — matches the tagless query from params above.
+    secrets = [{'client': 'MY_APP', 'secret_tag': ''}]
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
     monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets), raising=False)
 
@@ -417,7 +418,8 @@ def test_wallet_delete_secret(monkeypatch):
             secret_client="MY_APP", secret_state="absent"
         )
 
-    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    # Tagless secret — matches the tagless delete from params above.
+    secrets = [{'client': 'MY_APP', 'secret_tag': ''}]
     monkeypatch.setattr(mod, "AnsibleModule", Mod)
     monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets), raising=False)
 

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -148,6 +148,20 @@ def test_wallet_create_idempotent_when_exists(monkeypatch):
     assert result["changed"] is False
 
 
+def test_wallet_present_idempotent_without_password_when_already_exists(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", keystore_password=None)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is False
+
+
 # ===========================================================================
 # Tests: state=open
 # ===========================================================================

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -11,6 +11,31 @@ def _load():
     )
 
 
+def test_escape_sql_literal_doubles_quotes():
+    mod = _load()
+    assert mod.escape_sql_literal("a'b", "'") == "a''b"
+    assert mod.escape_sql_literal('a"b', '"') == 'a""b'
+
+
+def test_escape_sql_literal_rejects_newlines():
+    mod = _load()
+    with pytest.raises(ValueError):
+        mod.escape_sql_literal("a\nb", "'")
+    with pytest.raises(ValueError):
+        mod.escape_sql_literal("a\rb", '"')
+
+
+def test_redact_ddls_handles_doubled_quotes_in_secret():
+    mod = _load()
+    ddl = (
+        "ADMINISTER KEY MANAGEMENT FORCE ADD SECRET 'foo''bar' FOR CLIENT 'X' "
+        'IDENTIFIED BY "***"'
+    )
+    out = mod._redact_ddls([ddl])[0]
+    assert "foo" not in out
+    assert "SECRET '***'" in out
+
+
 def _wallet_params(**overrides):
     base = {
         **BASE_CONN_PARAMS,
@@ -266,6 +291,58 @@ def test_wallet_change_password(monkeypatch):
     result = exc.value.args[0]
     assert result["changed"] is True
     assert any("ALTER KEYSTORE PASSWORD" in d for d in result["ddls"])
+    joined = "\n".join(result["ddls"])
+    assert "NewPass456" not in joined
+    assert "TestKeystorePass123" not in joined
+    assert "SET '***'" in joined
+
+
+def test_wallet_change_password_with_backup_location_runs_backup_keystore(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            state="present",
+            change_password=True,
+            new_password="NewPass456",
+            backup_location="/opt/oracle/backup/wallets",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    ddls = result["ddls"]
+    assert any("ALTER KEYSTORE PASSWORD" in d for d in ddls)
+    assert any("BACKUP KEYSTORE" in d for d in ddls)
+    assert any("TO '/opt/oracle/backup/wallets'" in d for d in ddls)
+
+
+def test_wallet_change_password_backup_false_still_honors_backup_tag(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            state="present",
+            change_password=True,
+            new_password="NewPass456",
+            backup=False,
+            backup_tag="before_pw_change",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _WalletConn(m, 'OPEN', 'PASSWORD'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    ddls = result["ddls"]
+    assert any("ALTER KEYSTORE PASSWORD" in d for d in ddls)
+    backup_ddls = [d for d in ddls if "BACKUP KEYSTORE" in d]
+    assert backup_ddls
+    assert any("USING '***'" in d for d in backup_ddls)
 
 
 # ===========================================================================
@@ -350,6 +427,96 @@ def test_wallet_delete_secret_idempotent(monkeypatch):
 # ===========================================================================
 # Tests: state=absent
 # ===========================================================================
+
+def test_wallet_absent_skips_connection(monkeypatch):
+    mod = _load()
+    called = []
+
+    def _track_conn(m):
+        called.append(1)
+        return _WalletConn(m, 'OPEN')
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="absent")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", _track_conn, raising=False)
+
+    with pytest.raises(FailJson):
+        mod.main()
+    assert called == []
+
+
+def test_wallet_secret_missing_value_skips_connection(monkeypatch):
+    mod = _load()
+    called = []
+
+    def _track_conn(m):
+        called.append(1)
+        return _WalletConn(m, 'OPEN', 'PASSWORD')
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret_state="present",
+            secret_client="MY_APP",
+            secret=None,
+            keystore_password="pw",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", _track_conn, raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "secret is required" in exc.value.args[0]["msg"]
+    assert called == []
+
+
+def test_wallet_check_mode_secret_skips_connection(monkeypatch):
+    mod = _load()
+    called = []
+
+    def _track_conn(m):
+        called.append(1)
+        return _WalletConn(m, 'OPEN', 'PASSWORD')
+
+    class Mod(BaseFakeModule):
+        check_mode = True
+        params = _wallet_params(
+            secret_state="present",
+            secret_client="MY_APP",
+            secret="s",
+            keystore_password="pw",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", _track_conn, raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is False
+    assert called == []
+
+
+def test_wallet_check_mode_status_opens_connection(monkeypatch):
+    mod = _load()
+    called = []
+
+    def _track_conn(m):
+        called.append(1)
+        return _WalletConn(m, 'OPEN', 'PASSWORD', secrets=[])
+
+    class Mod(BaseFakeModule):
+        check_mode = True
+        params = _wallet_params(state="status")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", _track_conn, raising=False)
+
+    with pytest.raises(ExitJson):
+        mod.main()
+    assert called == [1]
+
 
 def test_wallet_absent_fails(monkeypatch):
     mod = _load()

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -62,16 +62,23 @@ def _wallet_params(**overrides):
 class _WalletConn(BaseFakeConn):
     """Simulates V$ENCRYPTION_WALLET responses."""
 
-    def __init__(self, module, wallet_status='NOT_AVAILABLE', wallet_type='', keystore_mode='NONE', secrets=None):
+    def __init__(
+        self, module, wallet_status='NOT_AVAILABLE', wallet_type='', keystore_mode='NONE',
+        secrets=None, wallet_rows=None,
+    ):
         super().__init__(module)
         self._wallet_status = wallet_status
         self._wallet_type = wallet_type
         self._keystore_mode = keystore_mode
         self._secrets = secrets or []
+        self._wallet_rows = wallet_rows
 
     def execute_select_to_dict(self, sql, params=None, fetchone=False, fail_on_error=True):
         sql_upper = sql.upper()
         if 'V$ENCRYPTION_WALLET' in sql_upper:
+            if self._wallet_rows is not None:
+                rows = self._wallet_rows
+                return rows[0] if fetchone else rows
             row = {
                 'wrl_type': 'FILE',
                 'wrl_parameter': '/opt/oracle/wallets/tde',
@@ -436,6 +443,114 @@ def test_wallet_delete_secret_idempotent(monkeypatch):
         mod.main()
     result = exc.value.args[0]
     assert result["changed"] is False
+
+
+def test_wallet_secret_task_not_blocked_by_state_absent(monkeypatch):
+    """secret_state validation runs before the state==absent keystore guard."""
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            state="absent",
+            secret_state="absent",
+            secret_client="MY_APP",
+            keystore_password="pw",
+        )
+
+    secrets = [{'client': 'MY_APP', 'secret_tag': 'tag1'}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["msg"] == "Secret managed successfully"
+
+
+def test_wallet_delete_secret_includes_using_tag_when_requested(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(
+            secret_client="MY_APP",
+            secret_state="absent",
+            secret_tag="mytag",
+            keystore_password="pw",
+        )
+
+    secrets = [{'client': 'MY_APP', 'secret_tag': 'mytag'}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, 'OPEN', 'PASSWORD', secrets=secrets),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    ddl = "\n".join(exc.value.args[0]["ddls"])
+    assert "DELETE SECRET" in ddl
+    assert "USING TAG 'mytag'" in ddl
+
+
+def test_wallet_open_container_all_mixed_runs_open(monkeypatch):
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'OPEN',
+            'wallet_type': 'PASSWORD', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'CLOSED',
+            'wallet_type': 'PASSWORD', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+    ]
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, wallet_rows=rows),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is True
+    assert any("SET KEYSTORE OPEN" in d for d in exc.value.args[0]["ddls"])
+
+
+def test_wallet_open_container_all_idempotent_when_all_open(monkeypatch):
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'OPEN',
+            'wallet_type': 'PASSWORD', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'OPEN_NO_MASTER_KEY',
+            'wallet_type': 'PASSWORD', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+    ]
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="open", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, wallet_rows=rows),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is False
 
 
 # ===========================================================================

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -553,6 +553,70 @@ def test_wallet_open_container_all_idempotent_when_all_open(monkeypatch):
     assert exc.value.args[0]["changed"] is False
 
 
+def test_aggregate_wallet_rows_autologin_uses_open_row():
+    """When open rows are all autologin, wallet_type should come from an open row, not first."""
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'CLOSED',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'OPEN',
+            'wallet_type': 'AUTOLOGIN', 'wallet_order': 'SINGLE', 'keystore_mode': 'UNITED',
+        },
+    ]
+    result = mod._aggregate_wallet_rows(rows)
+    assert result['wallet_type'] == 'AUTOLOGIN'
+
+
+def test_aggregate_wallet_rows_all_not_available():
+    """All-NOT_AVAILABLE rows must aggregate to NOT_AVAILABLE, not CLOSED."""
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'NOT_AVAILABLE',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'NONE',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'NOT_AVAILABLE',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'NONE',
+        },
+    ]
+    result = mod._aggregate_wallet_rows(rows)
+    assert result['status'] == 'NOT_AVAILABLE'
+
+
+def test_wallet_present_container_all_not_available_creates(monkeypatch):
+    """state=present with container=all and all NOT_AVAILABLE should create the keystore."""
+    mod = _load()
+    rows = [
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/a', 'status': 'NOT_AVAILABLE',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'NONE',
+        },
+        {
+            'wrl_type': 'FILE', 'wrl_parameter': '/b', 'status': 'NOT_AVAILABLE',
+            'wallet_type': '', 'wallet_order': 'SINGLE', 'keystore_mode': 'NONE',
+        },
+    ]
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present", container="all")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(
+        mod, "oracleConnection",
+        lambda m: _WalletConn(m, wallet_rows=rows),
+        raising=False,
+    )
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is True
+    assert any("CREATE KEYSTORE" in d for d in exc.value.args[0]["ddls"])
+
+
 # ===========================================================================
 # Tests: state=absent
 # ===========================================================================

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -356,7 +356,7 @@ def test_wallet_change_password_backup_false_still_honors_backup_tag(monkeypatch
     assert any("ALTER KEYSTORE PASSWORD" in d for d in ddls)
     backup_ddls = [d for d in ddls if "BACKUP KEYSTORE" in d]
     assert backup_ddls
-    assert any("USING '***'" in d for d in backup_ddls)
+    assert any("USING 'before_pw_change'" in d for d in backup_ddls)
 
 
 # ===========================================================================


### PR DESCRIPTION
 Summary
                                                                                                                                               
  - New oracle_wallet module for managing Oracle Transparent Data Encryption (TDE) keystores via SQL (ADMINISTER KEY MANAGEMENT)               
  - Supports keystore create, open, close, status, auto-login, password change, backup, and secret (client credential) management
  - Idempotent operations with full check_mode support, secret redaction in DDL output, and SQL injection prevention via literal escaping      
  - 745-line unit test suite covering all operations                                                                                           
                                                                                                                                               
  Changes                                                                                                                                      
                                                                                                                                               
  - plugins/modules/oracle_wallet.py — new module supporting states: present, absent, open, closed, status plus secret_state for client secret 
  CRUD
  - plugins/module_utils/oracle_utils.py — shared SQL helper additions (clause builders, escape utilities)                                     
  - tests/unit/test_oracle_wallet.py — comprehensive unit tests with mocked DB connections                                                     
  - tests/unit/conftest.py — test fixture updates                                                                                              
  - tests/unit/test_all_modules_contracts.py — relax fixed module count check                                                                  
                                                                                                                                               
  Test plan                                                                                                                                    
                                                                                                                                               
  - Unit tests pass: pytest tests/unit/test_oracle_wallet.py
  - Check mode returns correct changed status without executing DDL
  - Verify secrets are redacted in ddls output (no keystore passwords or secret values exposed)                                                
  - Test auto-login idempotency when wallet is already in desired state                                                                        
  - Test secret add/update/delete with secret_state=present/absent           