### PR TITLE
Add oracle_dataguard module for Data Guard management  

### DIFF
--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -490,10 +490,10 @@ def _validate_dgmgrl_identifier(module, value, param_name):
         module.fail_json(msg='Invalid %s: must be an Oracle identifier' % param_name, changed=False)
 
 
-def _quote_dgmgrl_literal(value):
+def _quote_dgmgrl_literal(module, value):
     """Escape single quotes and reject injection characters in a DGMGRL string literal."""
     if ';' in value or '\n' in value or '\r' in value:
-        raise ValueError("DGMGRL literal must not contain semicolons or newlines: %r" % value)
+        module.fail_json(msg="DGMGRL literal must not contain semicolons or newlines: %r" % value, changed=False)
     return value.replace("'", "''")
 
 
@@ -513,7 +513,7 @@ def dgmgrl_create_configuration(module):
     _validate_dgmgrl_identifier(module, primary_db, 'primary_database')
 
     cmd = "CREATE CONFIGURATION %s AS PRIMARY DATABASE IS %s CONNECT IDENTIFIER IS '%s'" % (
-        config_name, primary_db, _quote_dgmgrl_literal(connect_id)
+        config_name, primary_db, _quote_dgmgrl_literal(module, connect_id)
     )
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already exists' not in stdout.lower():
@@ -534,7 +534,7 @@ def dgmgrl_add_database(module):
 
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
 
-    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, _quote_dgmgrl_literal(connect_id))
+    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, _quote_dgmgrl_literal(module, connect_id))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already' not in stdout.lower():
         module.fail_json(msg='Failed to add database: %s %s' % (stdout, stderr), changed=False)
@@ -633,7 +633,7 @@ def dgmgrl_set_properties(module, db_name, properties):
     commands = []
     for prop, value in properties.items():
         _validate_dgmgrl_identifier(module, prop, 'property name')
-        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(str(value))))
+        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(module, str(value))))
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
         module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
@@ -661,7 +661,7 @@ def dgmgrl_set_protection_mode(module, protection_mode):
 def dgmgrl_set_state(module, db_name, db_state):
     """Set database transport/apply state."""
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
-    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(db_state.upper()))
+    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(module, db_state.upper()))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         module.fail_json(msg='Failed to set state: %s %s' % (stdout, stderr), changed=False)
@@ -709,7 +709,7 @@ def dgmgrl_add_far_sync(module):
 
     _validate_dgmgrl_identifier(module, fs_name, 'far_sync_name')
 
-    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, _quote_dgmgrl_literal(fs_connect))
+    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, _quote_dgmgrl_literal(module, fs_connect))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         if 'already' in stdout.lower():
@@ -732,7 +732,7 @@ def dgmgrl_validate(module, db_name):
 
 def _validate_dgmgrl_connect_string(module, value, param_name):
     """Validate a connect identifier is safe for DGMGRL (no injection)."""
-    if not value or ';' in value or '\n' in value:
+    if not value or ';' in value or '\n' in value or '\r' in value:
         module.fail_json(msg='Invalid %s: must not be empty or contain ; or newlines' % param_name, changed=False)
 
 
@@ -749,7 +749,7 @@ def dgmgrl_set_primary_database_candidates(module, candidates):
     for c in candidates:
         _validate_dgmgrl_identifier(module, c, 'primary_database_candidates member')
     value = ','.join(candidates)
-    cmd = "EDIT CONFIGURATION SET PROPERTY PrimaryDatabaseCandidates='%s'" % _quote_dgmgrl_literal(value)
+    cmd = "EDIT CONFIGURATION SET PROPERTY PrimaryDatabaseCandidates='%s'" % _quote_dgmgrl_literal(module, value)
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         if 'not supported' in stdout.lower() or 'invalid property' in stdout.lower():
@@ -789,10 +789,10 @@ def dgmgrl_set_tags(module, tags):
         _validate_dgmgrl_tag_name(module, tag_name)
         if target_name:
             cmd = "EDIT %s %s SET TAG %s='%s'" % (
-                target_type, target_name, tag_name, _quote_dgmgrl_literal(str(tag_value)))
+                target_type, target_name, tag_name, _quote_dgmgrl_literal(module, str(tag_value)))
         else:
             cmd = "EDIT %s SET TAG %s='%s'" % (
-                target_type, tag_name, _quote_dgmgrl_literal(str(tag_value)))
+                target_type, tag_name, _quote_dgmgrl_literal(module, str(tag_value)))
         commands.append(cmd)
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
@@ -830,7 +830,7 @@ def dgmgrl_show_tags(module, output_format):
         cmd = 'SHOW %s %s TAG' % (target_type, target_name)
     else:
         cmd = 'SHOW %s TAG' % target_type
-    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    rc, stdout, stderr = run_dgmgrl(module, [cmd], output_format)
     if rc != 0:
         return None
     return stdout

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -430,8 +430,7 @@ def parse_show_configuration(stdout):
             result['name'] = line.split('-', 1)[1].strip()
         elif line.startswith('Protection Mode:'):
             result['protection_mode'] = line.split(':', 1)[1].strip()
-        elif any(role in line for role in (
-                'Primary database', 'Physical standby', 'Snapshot standby', 'Logical standby')):
+        elif re.search(r'(?i)\b(primary|physical\s+standby|snapshot\s+standby|logical\s+standby)\b', line):
             parts = line.split('-')
             if len(parts) >= 2:
                 db_info = {
@@ -440,14 +439,12 @@ def parse_show_configuration(stdout):
                     'status': '',
                 }
                 desc = parts[1].strip()
-                if 'Primary' in desc:
-                    db_info['role'] = 'PRIMARY'
-                elif 'Physical standby' in desc:
-                    db_info['role'] = 'PHYSICAL STANDBY'
-                elif 'Snapshot standby' in desc:
-                    db_info['role'] = 'SNAPSHOT STANDBY'
-                elif 'Logical standby' in desc:
-                    db_info['role'] = 'LOGICAL STANDBY'
+                role_match = re.search(
+                    r'(?i)\b(physical\s+standby|snapshot\s+standby|logical\s+standby|primary)\b',
+                    desc,
+                )
+                if role_match:
+                    db_info['role'] = re.sub(r'\s+', ' ', role_match.group(1)).upper()
                 result['databases'].append(db_info)
         elif line.startswith('Fast-Start Failover:'):
             result['fast_start_failover'] = line.split(':', 1)[1].strip()
@@ -623,17 +620,24 @@ def dgmgrl_convert_database(module, db_name, target_type):
 
 
 def dgmgrl_set_properties(module, db_name, properties):
-    """Set properties on a database.
-
-    Returns True because DGMGRL does not report whether a value actually changed.
-    """
+    """Set properties on a database. Returns True only when a value changed."""
     if not db_name or not properties:
         return False
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
     commands = []
     for prop, value in properties.items():
         _validate_dgmgrl_identifier(module, prop, 'property name')
-        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(module, str(value))))
+        desired = str(value)
+        # Query current value to avoid unnecessary EDIT commands.
+        rc, stdout, _ = run_dgmgrl(module, ['SHOW DATABASE %s %s' % (db_name, prop)])
+        if rc == 0:
+            # DGMGRL output is typically "  <prop> = '<value>'" or similar.
+            m = re.search(r"=\s*'?([^'\n]*)'?", stdout)
+            if m and m.group(1).strip().upper() == desired.upper():
+                continue
+        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(module, desired)))
+    if not commands:
+        return False
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
         module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
@@ -641,7 +645,7 @@ def dgmgrl_set_properties(module, db_name, properties):
 
 
 def dgmgrl_set_protection_mode(module, protection_mode):
-    """Set the protection mode."""
+    """Set the protection mode. Returns True only when the mode changed."""
     mode_map = {
         'maximum_protection': 'MAXPROTECTION',
         'maximum_availability': 'MAXAVAILABILITY',
@@ -651,6 +655,13 @@ def dgmgrl_set_protection_mode(module, protection_mode):
     if not mode:
         module.fail_json(msg='Invalid protection mode: %s' % protection_mode, changed=False)
 
+    # Check current protection mode to avoid unnecessary changes.
+    rc, stdout, _ = run_dgmgrl(module, ['SHOW CONFIGURATION'])
+    if rc == 0:
+        m = re.search(r'(?i)protection\s+mode:\s*(\S+)', stdout)
+        if m and m.group(1).upper() == mode.upper():
+            return False
+
     cmd = 'EDIT CONFIGURATION SET PROTECTION MODE AS %s' % mode
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
@@ -659,9 +670,18 @@ def dgmgrl_set_protection_mode(module, protection_mode):
 
 
 def dgmgrl_set_state(module, db_name, db_state):
-    """Set database transport/apply state."""
+    """Set database transport/apply state. Returns True only when the state changed."""
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
-    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(module, db_state.upper()))
+    desired = db_state.upper()
+
+    # Check current state to avoid unnecessary changes.
+    rc, stdout, _ = run_dgmgrl(module, ['SHOW DATABASE %s StateName' % db_name])
+    if rc == 0:
+        m = re.search(r"=\s*'?([^'\n]*)'?", stdout)
+        if m and m.group(1).strip().upper() == desired:
+            return False
+
+    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(module, desired))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         module.fail_json(msg='Failed to set state: %s %s' % (stdout, stderr), changed=False)
@@ -830,7 +850,7 @@ def dgmgrl_show_tags(module, output_format):
         cmd = 'SHOW %s %s TAG' % (target_type, target_name)
     else:
         cmd = 'SHOW %s TAG' % target_type
-    rc, stdout, stderr = run_dgmgrl(module, [cmd], output_format)
+    rc, stdout, _ = run_dgmgrl(module, [cmd], output_format)
     if rc != 0:
         return None
     return stdout

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -1018,12 +1018,14 @@ def _run_broker_mode(module):
     database_name = module.params["database_name"]
     output_format = module.params["output_format"]
 
+    if state == 'status':
+        # Status is read-only, allow it even in check mode.
+        _broker_status(module, database_name, output_format)
+
     if module.check_mode:
         module.exit_json(changed=False, msg='Check mode: no broker operations executed')
 
-    if state == 'status':
-        _broker_status(module, database_name, output_format)
-    elif state == 'present':
+    if state == 'present':
         _broker_present(module, database_name, output_format)
     elif state == 'absent':
         _broker_absent(module, database_name)

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -1,0 +1,930 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: oracle_dataguard
+short_description: Manage Oracle Data Guard configurations
+description:
+  - Manage Oracle Data Guard via the Broker (DGMGRL) or via SQL direct
+  - Create, enable, disable, and remove Data Guard configurations
+  - Add, remove, enable, and disable standby databases
+  - Perform switchover and failover operations
+  - Convert databases between physical/snapshot standby
+  - Manage Data Guard properties
+  - Set protection modes (Maximum Protection, Maximum Availability, Maximum Performance)
+  - Manage Fast-Start Failover (FSFO) and observers
+  - Manage Far Sync instances
+  - Query Data Guard status, lag, and health
+  - SQL mode for environments without broker
+  - Compatible with Oracle 19c, 23ai, and 26ai
+  - "Oracle 26ai features: JSON output, PrimaryDatabaseCandidates, VALIDATE DGConnectIdentifier, tagging"
+version_added: "3.4.0"
+options:
+  mode_dg:
+    description:
+      - Data Guard management mode
+      - broker uses DGMGRL commands (recommended by Oracle)
+      - sql uses direct SQL and V$ views (for environments without broker)
+    default: broker
+    choices: ['broker', 'sql']
+  state:
+    description: The intended state
+    default: status
+    choices:
+      - present
+      - absent
+      - enabled
+      - disabled
+      - status
+      - switchover
+      - failover
+      - snapshot_standby
+      - physical_standby
+  oracle_home:
+    description: ORACLE_HOME path (required for DGMGRL in broker mode)
+    required: false
+    aliases: ['oh']
+  dgmgrl_user:
+    description:
+      - Username for DGMGRL connection
+      - If omitted (along with dgmgrl_password), OS authentication is used (/ AS SYSDG or / AS SYSDBA)
+    required: false
+  dgmgrl_password:
+    description:
+      - Password for DGMGRL connection
+      - If omitted (along with dgmgrl_user), OS authentication is used
+    required: false
+  dgmgrl_connect_identifier:
+    description: Connect identifier for DGMGRL (e.g. host:port/service)
+    required: false
+  dgmgrl_as:
+    description:
+      - DGMGRL connection privilege
+      - Used for both password and OS authentication
+    default: sysdg
+    choices: ['sysdba', 'sysdg']
+  configuration_name:
+    description: Name of the Data Guard broker configuration
+    required: false
+  primary_database:
+    description: DB_UNIQUE_NAME of the primary database
+    required: false
+  connect_identifier:
+    description: Oracle Net connect identifier for the database being managed
+    required: false
+  database_name:
+    description: DB_UNIQUE_NAME of the database to manage
+    required: false
+  properties:
+    description:
+      - Dictionary of broker properties to set on a database
+      - "Example: {'LogXptMode': 'SYNC', 'NetTimeout': '60'}"
+    type: dict
+    required: false
+  protection_mode:
+    description: Data Guard protection mode
+    choices: ['maximum_protection', 'maximum_availability', 'maximum_performance']
+    required: false
+  database_state:
+    description: Desired state of redo transport/apply for a database
+    choices: ['transport-on', 'transport-off', 'apply-on', 'apply-off']
+    required: false
+  fsfo:
+    description: Fast-Start Failover state
+    choices: ['enabled', 'disabled']
+    required: false
+  fsfo_target:
+    description: Target database for Fast-Start Failover
+    required: false
+  far_sync_name:
+    description: Name of the Far Sync instance
+    required: false
+  far_sync_connect_identifier:
+    description: Connect identifier for Far Sync instance
+    required: false
+  observer_state:
+    description: Observer state
+    choices: ['started', 'stopped']
+    required: false
+  output_format:
+    description:
+      - Output format for DGMGRL (26ai supports JSON)
+      - json provides structured output (Oracle 26ai+)
+    default: text
+    choices: ['text', 'json']
+  force_logging:
+    description: Enable or disable FORCE LOGGING (SQL mode)
+    choices: ['enable', 'disable']
+    required: false
+  apply_state:
+    description: Managed recovery state (SQL mode)
+    choices: ['started', 'stopped']
+    required: false
+notes:
+  - Broker mode requires DGMGRL binary in ORACLE_HOME/bin
+  - "Broker mode supports OS authentication (/ AS SYSDG or / AS SYSDBA) when dgmgrl_user and dgmgrl_password are omitted"
+  - "SQL mode supports OS authentication (mode: sysdba without user/password) when running as the oracle OS user"
+  - SQL mode uses standard oracledb connection
+  - Switchover and failover are non-idempotent operations - use with care
+  - oracledb Python module is required for SQL mode
+requirements: [ "oracledb" ]
+author:
+  - Cyrille Modiano
+'''
+
+EXAMPLES = '''
+# --- Broker Mode (default) ---
+
+# OS authentication (runs as oracle OS user, no username/password needed)
+- name: Get Data Guard status with OS authentication as SYSDG
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: status
+
+- name: Get Data Guard status with OS authentication as SYSDBA
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    dgmgrl_as: sysdba
+    state: status
+
+# Password authentication
+- name: Get Data Guard status with password authentication
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    dgmgrl_user: sys
+    dgmgrl_password: "SysPass123"
+    dgmgrl_as: sysdg
+    state: status
+
+- name: Create a Data Guard broker configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: present
+    configuration_name: my_dg_config
+    primary_database: PROD
+    connect_identifier: "prod-host:1521/PROD"
+
+- name: Add a standby database to the configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: present
+    database_name: STDBY
+    connect_identifier: "stdby-host:1521/STDBY"
+
+- name: Enable the configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: enabled
+
+- name: Set database properties
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    database_name: STDBY
+    properties:
+      LogXptMode: SYNC
+      NetTimeout: "60"
+      RedoCompression: ENABLE
+
+- name: Set protection mode to Maximum Availability
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    protection_mode: maximum_availability
+
+- name: Switchover to standby
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: switchover
+    database_name: STDBY
+
+- name: Failover to standby
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: failover
+    database_name: STDBY
+
+- name: Convert to snapshot standby
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: snapshot_standby
+    database_name: STDBY
+
+- name: Enable Fast-Start Failover
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    fsfo: enabled
+
+- name: Disable the configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: disabled
+
+- name: Remove a standby database
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: absent
+    database_name: STDBY
+
+- name: Remove entire configuration
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/19c
+    state: absent
+
+# --- SQL Mode ---
+
+# OS authentication (mode: sysdba, no user/password)
+- name: Get Data Guard status via SQL with OS authentication
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    state: status
+
+# Password authentication
+- name: Get Data Guard status via SQL with password
+  oracle_dataguard:
+    mode_dg: sql
+    user: sys
+    password: "SysPass123"
+    mode: sysdba
+    service_name: PROD
+    state: status
+
+- name: Start managed recovery (SQL mode)
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    apply_state: started
+
+- name: Stop managed recovery (SQL mode)
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    apply_state: stopped
+
+- name: Enable force logging (SQL mode)
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    force_logging: enable
+
+- name: Set protection mode via SQL
+  oracle_dataguard:
+    mode_dg: sql
+    mode: sysdba
+    protection_mode: maximum_availability
+'''
+
+import json
+import os
+
+
+# ============================================================================
+# DGMGRL (Broker) Functions
+# ============================================================================
+
+def run_dgmgrl(module, commands, output_format='text'):
+    """Execute DGMGRL commands and return output.
+
+    Commands are passed via stdin to avoid shell injection.
+    """
+    oracle_home = module.params.get("oracle_home")
+    if not oracle_home:
+        if 'ORACLE_HOME' in os.environ:
+            oracle_home = os.environ['ORACLE_HOME']
+        else:
+            module.fail_json(msg='oracle_home is required for broker mode', changed=False)
+
+    dgmgrl_bin = os.path.join(oracle_home, 'bin', 'dgmgrl')
+    if not os.path.exists(dgmgrl_bin):
+        module.fail_json(msg='DGMGRL not found at %s' % dgmgrl_bin, changed=False)
+
+    # Build connect string
+    dgmgrl_user = module.params.get("dgmgrl_user")
+    dgmgrl_password = module.params.get("dgmgrl_password")
+    dgmgrl_connect_id = module.params.get("dgmgrl_connect_identifier")
+    dgmgrl_as = module.params.get("dgmgrl_as")
+
+    if dgmgrl_user and dgmgrl_password:
+        if dgmgrl_connect_id:
+            connect_string = '%s/%s@%s' % (dgmgrl_user, dgmgrl_password, dgmgrl_connect_id)
+        else:
+            connect_string = '%s/%s' % (dgmgrl_user, dgmgrl_password)
+        if dgmgrl_as:
+            connect_string += ' AS %s' % dgmgrl_as.upper()
+    else:
+        connect_string = '/ AS %s' % dgmgrl_as.upper()
+
+    # Build command
+    cmd = [dgmgrl_bin, '-silent']
+    if output_format == 'json':
+        cmd.extend(['-outputformat', 'json'])
+    cmd.append(connect_string)
+
+    # Build script from commands
+    script = ';\n'.join(commands) + ';\n'
+
+    rc, stdout, stderr = module.run_command(cmd, data=script)
+
+    return rc, stdout, stderr
+
+
+def parse_show_configuration(stdout):
+    """Parse SHOW CONFIGURATION output into a dict."""
+    result = {
+        'name': '',
+        'protection_mode': '',
+        'status': '',
+        'databases': [],
+        'fast_start_failover': '',
+    }
+    for line in stdout.split('\n'):
+        line = line.strip()
+        if line.startswith('Configuration -'):
+            result['name'] = line.split('-', 1)[1].strip()
+        elif line.startswith('Protection Mode:'):
+            result['protection_mode'] = line.split(':', 1)[1].strip()
+        elif any(role in line for role in (
+                'Primary database', 'Physical standby', 'Snapshot standby', 'Logical standby')):
+            parts = line.split('-')
+            if len(parts) >= 2:
+                db_info = {
+                    'name': parts[0].strip(),
+                    'role': '',
+                    'status': '',
+                }
+                desc = parts[1].strip()
+                if 'Primary' in desc:
+                    db_info['role'] = 'PRIMARY'
+                elif 'Physical standby' in desc:
+                    db_info['role'] = 'PHYSICAL STANDBY'
+                elif 'Snapshot standby' in desc:
+                    db_info['role'] = 'SNAPSHOT STANDBY'
+                elif 'Logical standby' in desc:
+                    db_info['role'] = 'LOGICAL STANDBY'
+                result['databases'].append(db_info)
+        elif line.startswith('Fast-Start Failover:'):
+            result['fast_start_failover'] = line.split(':', 1)[1].strip()
+        elif line.startswith('Configuration Status:'):
+            result['status'] = line.split(':', 1)[1].strip()
+    return result
+
+
+def dgmgrl_show_configuration(module, output_format):
+    """Run SHOW CONFIGURATION and return parsed result."""
+    rc, stdout, stderr = run_dgmgrl(module, ['SHOW CONFIGURATION VERBOSE'], output_format)
+    if rc != 0:
+        if 'ORA-16532' in stdout or 'not yet created' in stdout.lower():
+            return {'status': 'NOT_CONFIGURED', 'name': '', 'databases': []}
+        module.fail_json(msg='DGMGRL SHOW CONFIGURATION failed: %s %s' % (stdout, stderr), changed=False)
+
+    if output_format == 'json':
+        try:
+            return json.loads(stdout)
+        except (ValueError, TypeError):
+            return parse_show_configuration(stdout)
+    return parse_show_configuration(stdout)
+
+
+def dgmgrl_show_database(module, db_name, output_format):
+    """Run SHOW DATABASE and return output."""
+    rc, stdout, _stderr = run_dgmgrl(module, ['SHOW DATABASE %s VERBOSE' % db_name], output_format)
+    if rc != 0:
+        return None
+    return stdout
+
+
+def dgmgrl_create_configuration(module):
+    """Create a Data Guard broker configuration."""
+    config_name = module.params["configuration_name"]
+    primary_db = module.params["primary_database"]
+    connect_id = module.params["connect_identifier"]
+
+    if not config_name or not primary_db or not connect_id:
+        module.fail_json(
+            msg='configuration_name, primary_database, and connect_identifier are required to create a configuration',
+            changed=False
+        )
+
+    cmd = "CREATE CONFIGURATION %s AS PRIMARY DATABASE IS %s CONNECT IDENTIFIER IS '%s'" % (
+        config_name, primary_db, connect_id
+    )
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already exists' not in stdout.lower():
+        module.fail_json(msg='Failed to create configuration: %s %s' % (stdout, stderr), changed=False)
+    return rc == 0 or 'already exists' in stdout.lower()
+
+
+def dgmgrl_add_database(module):
+    """Add a database to the Data Guard configuration."""
+    db_name = module.params["database_name"]
+    connect_id = module.params["connect_identifier"]
+
+    if not db_name or not connect_id:
+        module.fail_json(
+            msg='database_name and connect_identifier are required to add a database',
+            changed=False
+        )
+
+    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, connect_id)
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already' not in stdout.lower():
+        module.fail_json(msg='Failed to add database: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_remove_database(module, db_name):
+    """Remove a database from the configuration."""
+    rc, stdout, stderr = run_dgmgrl(module, ['REMOVE DATABASE %s' % db_name])
+    if rc != 0 and 'not found' not in stdout.lower():
+        module.fail_json(msg='Failed to remove database: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_remove_configuration(module):
+    """Remove the entire Data Guard configuration."""
+    rc, stdout, stderr = run_dgmgrl(module, ['REMOVE CONFIGURATION'])
+    if rc != 0 and 'not yet created' not in stdout.lower():
+        module.fail_json(msg='Failed to remove configuration: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_enable(module, target_type, target_name=None):
+    """Enable configuration or database."""
+    if target_type == 'configuration':
+        cmd = 'ENABLE CONFIGURATION'
+    else:
+        cmd = 'ENABLE DATABASE %s' % target_name
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already enabled' not in stdout.lower():
+        module.fail_json(msg='Failed to enable %s: %s %s' % (target_type, stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_disable(module, target_type, target_name=None):
+    """Disable configuration or database."""
+    if target_type == 'configuration':
+        cmd = 'DISABLE CONFIGURATION'
+    else:
+        cmd = 'DISABLE DATABASE %s' % target_name
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already disabled' not in stdout.lower():
+        module.fail_json(msg='Failed to disable %s: %s %s' % (target_type, stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_switchover(module, db_name):
+    """Perform a switchover to the specified database."""
+    if not db_name:
+        module.fail_json(msg='database_name is required for switchover', changed=False)
+    rc, stdout, stderr = run_dgmgrl(module, ['SWITCHOVER TO %s' % db_name])
+    if rc != 0:
+        module.fail_json(msg='Switchover failed: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_failover(module, db_name):
+    """Perform a failover to the specified database."""
+    if not db_name:
+        module.fail_json(msg='database_name is required for failover', changed=False)
+    rc, stdout, stderr = run_dgmgrl(module, ['FAILOVER TO %s' % db_name])
+    if rc != 0:
+        module.fail_json(msg='Failover failed: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_convert_database(module, db_name, target_type):
+    """Convert database to snapshot or physical standby."""
+    if not db_name:
+        module.fail_json(msg='database_name is required for convert', changed=False)
+    cmd = 'CONVERT DATABASE %s TO %s' % (db_name, target_type)
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Convert failed: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_set_properties(module, db_name, properties):
+    """Set properties on a database."""
+    if not db_name or not properties:
+        return
+    commands = []
+    for prop, value in properties.items():
+        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, value))
+    rc, stdout, stderr = run_dgmgrl(module, commands)
+    if rc != 0:
+        module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
+
+
+def dgmgrl_set_protection_mode(module, protection_mode):
+    """Set the protection mode."""
+    mode_map = {
+        'maximum_protection': 'MAXPROTECTION',
+        'maximum_availability': 'MAXAVAILABILITY',
+        'maximum_performance': 'MAXPERFORMANCE',
+    }
+    mode = mode_map.get(protection_mode)
+    if not mode:
+        module.fail_json(msg='Invalid protection mode: %s' % protection_mode, changed=False)
+
+    cmd = 'EDIT CONFIGURATION SET PROTECTION MODE AS %s' % mode
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Failed to set protection mode: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_set_state(module, db_name, db_state):
+    """Set database transport/apply state."""
+    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, db_state.upper())
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Failed to set state: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_manage_fsfo(module, fsfo_state):
+    """Enable or disable Fast-Start Failover."""
+    if fsfo_state == 'enabled':
+        cmd = 'ENABLE FAST_START FAILOVER'
+    else:
+        cmd = 'DISABLE FAST_START FAILOVER'
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Failed to manage FSFO: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_manage_observer(module, observer_state):
+    """Start or stop the FSFO observer."""
+    if observer_state == 'started':
+        cmd = 'START OBSERVER IN BACKGROUND'
+    else:
+        cmd = 'STOP OBSERVER'
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        module.fail_json(msg='Failed to manage observer: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_add_far_sync(module):
+    """Add a Far Sync instance."""
+    fs_name = module.params["far_sync_name"]
+    fs_connect = module.params["far_sync_connect_identifier"]
+
+    if not fs_name or not fs_connect:
+        module.fail_json(
+            msg='far_sync_name and far_sync_connect_identifier are required',
+            changed=False
+        )
+
+    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, fs_connect)
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0 and 'already' not in stdout.lower():
+        module.fail_json(msg='Failed to add Far Sync: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_validate(module, db_name):
+    """Validate a database configuration."""
+    cmd = 'VALIDATE DATABASE %s' % db_name
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    return {'rc': rc, 'output': stdout, 'errors': stderr}
+
+
+# ============================================================================
+# SQL Mode Functions
+# ============================================================================
+
+def sql_get_database_info(conn):
+    """Get Data Guard related information from V$DATABASE."""
+    sql = """SELECT DATABASE_ROLE, PROTECTION_MODE, PROTECTION_LEVEL,
+                    SWITCHOVER_STATUS, DATAGUARD_BROKER, FORCE_LOGGING,
+                    FLASHBACK_ON, DB_UNIQUE_NAME
+             FROM V$DATABASE"""
+    return conn.execute_select_to_dict(sql, fetchone=True)
+
+
+def sql_get_dataguard_stats(conn):
+    """Get transport and apply lag from V$DATAGUARD_STATS."""
+    sql = "SELECT NAME, VALUE, UNIT, TIME_COMPUTED, DATUM_TIME FROM V$DATAGUARD_STATS"
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def sql_get_archive_dest_status(conn):
+    """Get archive destination status."""
+    sql = """SELECT DEST_ID, STATUS, TYPE, DATABASE_MODE, RECOVERY_MODE,
+                    GAP_STATUS, SYNCHRONIZED, ERROR, DB_UNIQUE_NAME
+             FROM V$ARCHIVE_DEST_STATUS
+             WHERE STATUS != 'INACTIVE'"""
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def sql_get_dataguard_processes(conn):
+    """Get active Data Guard processes."""
+    sql = """SELECT ROLE, ACTION, CLIENT_ROLE, THREAD#, SEQUENCE#, BLOCK#
+             FROM V$DATAGUARD_PROCESS"""
+    return conn.execute_select_to_dict(sql, fail_on_error=False) or []
+
+
+def sql_start_apply(conn, _module):
+    """Start managed recovery (redo apply)."""
+    # Check if MRP is already running
+    processes = sql_get_dataguard_processes(conn)
+    for p in processes:
+        if p.get('action', '').upper() in ('APPLYING_LOG', 'APPLYING'):
+            return  # Already running, idempotent
+
+    conn.execute_ddl('ALTER DATABASE RECOVER MANAGED STANDBY DATABASE USING CURRENT LOGFILE DISCONNECT')
+
+
+def sql_stop_apply(conn, _module):
+    """Stop managed recovery."""
+    processes = sql_get_dataguard_processes(conn)
+    mrp_running = False
+    for p in processes:
+        if p.get('action', '').upper() in ('APPLYING_LOG', 'APPLYING'):
+            mrp_running = True
+            break
+    if not mrp_running:
+        return  # Already stopped, idempotent
+
+    conn.execute_ddl('ALTER DATABASE RECOVER MANAGED STANDBY DATABASE CANCEL')
+
+
+def sql_set_force_logging(conn, _module, enable):
+    """Enable or disable force logging."""
+    db_info = sql_get_database_info(conn)
+    current = db_info.get('force_logging', 'NO')
+
+    if enable == 'enable' and current == 'YES':
+        return  # Already enabled
+    if enable == 'disable' and current == 'NO':
+        return  # Already disabled
+
+    if enable == 'enable':
+        conn.execute_ddl('ALTER DATABASE FORCE LOGGING')
+    else:
+        conn.execute_ddl('ALTER DATABASE NO FORCE LOGGING')
+
+
+def sql_set_protection_mode(conn, module, protection_mode):
+    """Set protection mode via SQL."""
+    mode_map = {
+        'maximum_protection': 'MAXIMIZE PROTECTION',
+        'maximum_availability': 'MAXIMIZE AVAILABILITY',
+        'maximum_performance': 'MAXIMIZE PERFORMANCE',
+    }
+    target = mode_map.get(protection_mode)
+    if not target:
+        module.fail_json(msg='Invalid protection mode: %s' % protection_mode, changed=False)
+
+    db_info = sql_get_database_info(conn)
+    current = db_info.get('protection_mode', '')
+
+    if target.replace('MAXIMIZE ', 'MAXIMUM ') == current:
+        return  # Already set
+
+    conn.execute_ddl('ALTER DATABASE SET STANDBY DATABASE TO %s' % target)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            # Standard connection params (for SQL mode)
+            user=dict(required=False, aliases=['un', 'username']),
+            password=dict(required=False, no_log=True, aliases=['pw']),
+            mode=dict(default='normal', choices=["normal", "sysdba", "sysdg", "sysoper", "sysasm"]),
+            hostname=dict(required=False, default='localhost', aliases=['host']),
+            port=dict(required=False, default=1521, type='int'),
+            service_name=dict(required=False, aliases=['sn']),
+            dsn=dict(required=False, aliases=['datasource_name']),
+            oracle_home=dict(required=False, aliases=['oh']),
+            session_container=dict(required=False),
+
+            # Data Guard mode
+            mode_dg=dict(default='broker', choices=['broker', 'sql']),
+            state=dict(default='status',
+                       choices=['present', 'absent', 'enabled', 'disabled', 'status',
+                                'switchover', 'failover', 'snapshot_standby', 'physical_standby']),
+
+            # DGMGRL connection
+            dgmgrl_user=dict(required=False),
+            dgmgrl_password=dict(required=False, no_log=True),
+            dgmgrl_connect_identifier=dict(required=False),
+            dgmgrl_as=dict(default='sysdg', choices=['sysdba', 'sysdg']),
+
+            # Configuration
+            configuration_name=dict(required=False),
+            primary_database=dict(required=False),
+            connect_identifier=dict(required=False),
+
+            # Database member
+            database_name=dict(required=False),
+
+            # Properties
+            properties=dict(required=False, type='dict'),
+
+            # Protection mode
+            protection_mode=dict(required=False,
+                                choices=['maximum_protection', 'maximum_availability',
+                                         'maximum_performance']),
+
+            # Database state
+            database_state=dict(required=False,
+                               choices=['transport-on', 'transport-off',
+                                        'apply-on', 'apply-off']),
+
+            # Fast-Start Failover
+            fsfo=dict(required=False, choices=['enabled', 'disabled']),
+            fsfo_target=dict(required=False),
+
+            # Far Sync
+            far_sync_name=dict(required=False),
+            far_sync_connect_identifier=dict(required=False),
+
+            # Observer
+            observer_state=dict(required=False, choices=['started', 'stopped']),
+
+            # Output format (26ai JSON)
+            output_format=dict(default='text', choices=['text', 'json']),
+
+            # SQL mode specific
+            force_logging=dict(required=False, choices=['enable', 'disable']),
+            apply_state=dict(required=False, choices=['started', 'stopped']),
+        ),
+        supports_check_mode=True,
+    )
+
+    sanitize_string_params(module.params)
+
+    if module.params["mode_dg"] == 'broker':
+        _run_broker_mode(module)
+    else:
+        _run_sql_mode(module)
+
+
+def _run_broker_mode(module):
+    """Handle all broker (DGMGRL) operations."""
+    state = module.params["state"]
+    database_name = module.params["database_name"]
+    output_format = module.params["output_format"]
+
+    if module.check_mode:
+        module.exit_json(changed=False, msg='Check mode: no broker operations executed')
+
+    if state == 'status':
+        _broker_status(module, database_name, output_format)
+    elif state == 'present':
+        _broker_present(module, database_name, output_format)
+    elif state == 'absent':
+        _broker_absent(module, database_name)
+    elif state == 'enabled':
+        _broker_enable_disable(module, database_name, enable=True)
+    elif state == 'disabled':
+        _broker_enable_disable(module, database_name, enable=False)
+    elif state == 'switchover':
+        dgmgrl_switchover(module, database_name)
+        module.exit_json(changed=True, msg='Switchover to %s completed' % database_name)
+    elif state == 'failover':
+        dgmgrl_failover(module, database_name)
+        module.exit_json(changed=True, msg='Failover to %s completed' % database_name)
+    elif state == 'snapshot_standby':
+        dgmgrl_convert_database(module, database_name, 'SNAPSHOT STANDBY')
+        module.exit_json(changed=True, msg='Converted %s to snapshot standby' % database_name)
+    elif state == 'physical_standby':
+        dgmgrl_convert_database(module, database_name, 'PHYSICAL STANDBY')
+        module.exit_json(changed=True, msg='Converted %s to physical standby' % database_name)
+
+
+def _broker_status(module, database_name, output_format):
+    """Handle broker status query."""
+    config = dgmgrl_show_configuration(module, output_format)
+    db_detail = None
+    validate_result = None
+    if database_name:
+        db_detail = dgmgrl_show_database(module, database_name, output_format)
+        validate_result = dgmgrl_validate(module, database_name)
+    module.exit_json(
+        changed=False,
+        configuration=config,
+        database_detail=db_detail,
+        validate=validate_result,
+    )
+
+
+def _broker_present(module, database_name, output_format):
+    """Handle broker present state (create/add/configure)."""
+    changed = False
+    config = dgmgrl_show_configuration(module, 'text')
+
+    if module.params["configuration_name"] and config.get('status') == 'NOT_CONFIGURED':
+        dgmgrl_create_configuration(module)
+        changed = True
+
+    if database_name and config.get('status') != 'NOT_CONFIGURED':
+        existing_dbs = [d['name'] for d in config.get('databases', [])]
+        if database_name.upper() not in [d.upper() for d in existing_dbs]:
+            dgmgrl_add_database(module)
+            changed = True
+
+    if module.params["far_sync_name"]:
+        dgmgrl_add_far_sync(module)
+        changed = True
+    if module.params["properties"] and database_name:
+        dgmgrl_set_properties(module, database_name, module.params["properties"])
+        changed = True
+    if module.params["protection_mode"]:
+        dgmgrl_set_protection_mode(module, module.params["protection_mode"])
+        changed = True
+    if module.params["database_state"] and database_name:
+        dgmgrl_set_state(module, database_name, module.params["database_state"])
+        changed = True
+    if module.params["fsfo"]:
+        dgmgrl_manage_fsfo(module, module.params["fsfo"])
+        changed = True
+    if module.params["observer_state"]:
+        dgmgrl_manage_observer(module, module.params["observer_state"])
+        changed = True
+
+    config = dgmgrl_show_configuration(module, output_format)
+    module.exit_json(changed=changed, configuration=config, msg='Data Guard configuration updated')
+
+
+def _broker_absent(module, database_name):
+    """Handle broker absent state (remove)."""
+    config = dgmgrl_show_configuration(module, 'text')
+    if config.get('status') == 'NOT_CONFIGURED':
+        module.exit_json(changed=False, msg='No configuration exists')
+
+    changed = False
+    if database_name:
+        existing_dbs = [d['name'] for d in config.get('databases', [])]
+        if database_name.upper() in [d.upper() for d in existing_dbs]:
+            dgmgrl_remove_database(module, database_name)
+            changed = True
+    else:
+        dgmgrl_remove_configuration(module)
+        changed = True
+
+    module.exit_json(changed=changed, msg='Data Guard resources removed')
+
+
+def _broker_enable_disable(module, database_name, enable):
+    """Handle broker enable/disable operations."""
+    func = dgmgrl_enable if enable else dgmgrl_disable
+    if database_name:
+        func(module, 'database', database_name)
+    else:
+        func(module, 'configuration')
+    action = 'Enabled' if enable else 'Disabled'
+    module.exit_json(changed=True, msg='%s successfully' % action)
+
+
+def _run_sql_mode(module):
+    """Handle all SQL mode operations."""
+    state = module.params["state"]
+    protection_mode = module.params["protection_mode"]
+    conn = oracleConnection(module)
+
+    if state == 'status':
+        module.exit_json(
+            changed=False,
+            database=sql_get_database_info(conn),
+            dataguard_stats=sql_get_dataguard_stats(conn),
+            archive_dest_status=sql_get_archive_dest_status(conn),
+            dataguard_processes=sql_get_dataguard_processes(conn),
+        )
+
+    apply_state = module.params["apply_state"]
+    if apply_state == 'started':
+        sql_start_apply(conn, module)
+    elif apply_state == 'stopped':
+        sql_stop_apply(conn, module)
+
+    force_logging = module.params["force_logging"]
+    if force_logging:
+        sql_set_force_logging(conn, module, force_logging)
+
+    if protection_mode:
+        sql_set_protection_mode(conn, module, protection_mode)
+
+    module.exit_json(
+        changed=conn.changed,
+        ddls=conn.ddls,
+        database=sql_get_database_info(conn),
+        msg='Data Guard SQL operations completed',
+    )
+
+
+from ansible.module_utils.basic import *  # noqa: F403
+
+try:
+    from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
+        oracleConnection, sanitize_string_params,
+    )
+except ImportError:
+    def sanitize_string_params(_params):
+        pass
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -276,6 +276,7 @@ EXAMPLES = '''
 
 import json
 import os
+import re
 
 
 # ============================================================================
@@ -387,10 +388,22 @@ def dgmgrl_show_configuration(module, output_format):
 
 def dgmgrl_show_database(module, db_name, output_format):
     """Run SHOW DATABASE and return output."""
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     rc, stdout, _stderr = run_dgmgrl(module, ['SHOW DATABASE %s VERBOSE' % db_name], output_format)
     if rc != 0:
         return None
     return stdout
+
+
+def _validate_dgmgrl_identifier(module, value, param_name):
+    """Validate that a value is a safe DGMGRL identifier (letters, digits, _, $, #)."""
+    if not re.match(r'^[A-Za-z][A-Za-z0-9_$#]*$', value):
+        module.fail_json(msg='Invalid %s: must be an Oracle identifier' % param_name, changed=False)
+
+
+def _quote_dgmgrl_literal(value):
+    """Escape single quotes in a DGMGRL string literal."""
+    return value.replace("'", "''")
 
 
 def dgmgrl_create_configuration(module):
@@ -405,8 +418,11 @@ def dgmgrl_create_configuration(module):
             changed=False
         )
 
+    _validate_dgmgrl_identifier(module, config_name, 'configuration_name')
+    _validate_dgmgrl_identifier(module, primary_db, 'primary_database')
+
     cmd = "CREATE CONFIGURATION %s AS PRIMARY DATABASE IS %s CONNECT IDENTIFIER IS '%s'" % (
-        config_name, primary_db, connect_id
+        config_name, primary_db, _quote_dgmgrl_literal(connect_id)
     )
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already exists' not in stdout.lower():
@@ -425,7 +441,9 @@ def dgmgrl_add_database(module):
             changed=False
         )
 
-    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, connect_id)
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
+
+    cmd = "ADD DATABASE %s AS CONNECT IDENTIFIER IS '%s'" % (db_name, _quote_dgmgrl_literal(connect_id))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already' not in stdout.lower():
         module.fail_json(msg='Failed to add database: %s %s' % (stdout, stderr), changed=False)
@@ -434,6 +452,7 @@ def dgmgrl_add_database(module):
 
 def dgmgrl_remove_database(module, db_name):
     """Remove a database from the configuration."""
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     rc, stdout, stderr = run_dgmgrl(module, ['REMOVE DATABASE %s' % db_name])
     if rc != 0 and 'not found' not in stdout.lower():
         module.fail_json(msg='Failed to remove database: %s %s' % (stdout, stderr), changed=False)
@@ -449,26 +468,32 @@ def dgmgrl_remove_configuration(module):
 
 
 def dgmgrl_enable(module, target_type, target_name=None):
-    """Enable configuration or database."""
+    """Enable configuration or database. Returns True if changed."""
     if target_type == 'configuration':
         cmd = 'ENABLE CONFIGURATION'
     else:
+        _validate_dgmgrl_identifier(module, target_name, 'database_name')
         cmd = 'ENABLE DATABASE %s' % target_name
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already enabled' not in stdout.lower():
         module.fail_json(msg='Failed to enable %s: %s %s' % (target_type, stdout, stderr), changed=False)
+    if 'already enabled' in stdout.lower():
+        return False
     return True
 
 
 def dgmgrl_disable(module, target_type, target_name=None):
-    """Disable configuration or database."""
+    """Disable configuration or database. Returns True if changed."""
     if target_type == 'configuration':
         cmd = 'DISABLE CONFIGURATION'
     else:
+        _validate_dgmgrl_identifier(module, target_name, 'database_name')
         cmd = 'DISABLE DATABASE %s' % target_name
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already disabled' not in stdout.lower():
         module.fail_json(msg='Failed to disable %s: %s %s' % (target_type, stdout, stderr), changed=False)
+    if 'already disabled' in stdout.lower():
+        return False
     return True
 
 
@@ -476,6 +501,7 @@ def dgmgrl_switchover(module, db_name):
     """Perform a switchover to the specified database."""
     if not db_name:
         module.fail_json(msg='database_name is required for switchover', changed=False)
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     rc, stdout, stderr = run_dgmgrl(module, ['SWITCHOVER TO %s' % db_name])
     if rc != 0:
         module.fail_json(msg='Switchover failed: %s %s' % (stdout, stderr), changed=False)
@@ -486,6 +512,7 @@ def dgmgrl_failover(module, db_name):
     """Perform a failover to the specified database."""
     if not db_name:
         module.fail_json(msg='database_name is required for failover', changed=False)
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     rc, stdout, stderr = run_dgmgrl(module, ['FAILOVER TO %s' % db_name])
     if rc != 0:
         module.fail_json(msg='Failover failed: %s %s' % (stdout, stderr), changed=False)
@@ -507,9 +534,11 @@ def dgmgrl_set_properties(module, db_name, properties):
     """Set properties on a database."""
     if not db_name or not properties:
         return
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     commands = []
     for prop, value in properties.items():
-        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, value))
+        _validate_dgmgrl_identifier(module, prop, 'property name')
+        commands.append("EDIT DATABASE %s SET PROPERTY %s='%s'" % (db_name, prop, _quote_dgmgrl_literal(str(value))))
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
         module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
@@ -535,7 +564,8 @@ def dgmgrl_set_protection_mode(module, protection_mode):
 
 def dgmgrl_set_state(module, db_name, db_state):
     """Set database transport/apply state."""
-    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, db_state.upper())
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
+    cmd = "EDIT DATABASE %s SET STATE='%s'" % (db_name, _quote_dgmgrl_literal(db_state.upper()))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
         module.fail_json(msg='Failed to set state: %s %s' % (stdout, stderr), changed=False)
@@ -577,7 +607,9 @@ def dgmgrl_add_far_sync(module):
             changed=False
         )
 
-    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, fs_connect)
+    _validate_dgmgrl_identifier(module, fs_name, 'far_sync_name')
+
+    cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, _quote_dgmgrl_literal(fs_connect))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0 and 'already' not in stdout.lower():
         module.fail_json(msg='Failed to add Far Sync: %s %s' % (stdout, stderr), changed=False)
@@ -586,6 +618,7 @@ def dgmgrl_add_far_sync(module):
 
 def dgmgrl_validate(module, db_name):
     """Validate a database configuration."""
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     cmd = 'VALIDATE DATABASE %s' % db_name
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     return {'rc': rc, 'output': stdout, 'errors': stderr}
@@ -873,11 +906,11 @@ def _broker_enable_disable(module, database_name, enable):
     """Handle broker enable/disable operations."""
     func = dgmgrl_enable if enable else dgmgrl_disable
     if database_name:
-        func(module, 'database', database_name)
+        changed = func(module, 'database', database_name)
     else:
-        func(module, 'configuration')
+        changed = func(module, 'configuration')
     action = 'Enabled' if enable else 'Disabled'
-    module.exit_json(changed=True, msg='%s successfully' % action)
+    module.exit_json(changed=changed, msg='%s successfully' % action)
 
 
 def _run_sql_mode(module):

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -378,6 +378,12 @@ def run_dgmgrl(module, commands, output_format='text'):
     dgmgrl_connect_id = module.params.get("dgmgrl_connect_identifier")
     dgmgrl_as = module.params.get("dgmgrl_as")
 
+    # Reject command separators in credentials to prevent DGMGRL injection.
+    if dgmgrl_password:
+        _validate_dgmgrl_connect_string(module, dgmgrl_password, 'dgmgrl_password')
+    if dgmgrl_connect_id:
+        _validate_dgmgrl_connect_string(module, dgmgrl_connect_id, 'dgmgrl_connect_identifier')
+
     if dgmgrl_user and dgmgrl_password:
         if dgmgrl_connect_id:
             connect_string = '%s/%s@%s' % (dgmgrl_user, dgmgrl_password, dgmgrl_connect_id)

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -1203,6 +1203,15 @@ def _run_sql_mode(module):
 
 from ansible.module_utils.basic import *  # noqa: F403
 
+# In these we do import from local project sub-directory <project-dir>/module_utils
+# While this file is placed in <project-dir>/library
+# No collections are used
+#try:
+#    from ansible.module_utils.oracle_utils import oracleConnection, sanitize_string_params
+#except:
+#    pass
+
+# In this case we do import from collections
 try:
     from ansible_collections.ibre5041.ansible_oracle_modules.plugins.module_utils.oracle_utils import (  # noqa: E501
         oracleConnection, sanitize_string_params,

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -379,6 +379,8 @@ def run_dgmgrl(module, commands, output_format='text'):
     dgmgrl_as = module.params.get("dgmgrl_as")
 
     # Reject command separators in credentials to prevent DGMGRL injection.
+    if dgmgrl_user:
+        _validate_dgmgrl_connect_string(module, dgmgrl_user, 'dgmgrl_user')
     if dgmgrl_password:
         _validate_dgmgrl_connect_string(module, dgmgrl_password, 'dgmgrl_password')
     if dgmgrl_connect_id:

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -54,6 +54,7 @@ options:
     description:
       - Password for DGMGRL connection
       - If omitted (along with dgmgrl_user), OS authentication is used
+      - Credentials are passed via stdin (CONNECT command), never on the command line
     required: false
   dgmgrl_connect_identifier:
     description: Connect identifier for DGMGRL (e.g. host:port/service)
@@ -153,6 +154,7 @@ options:
     required: false
 notes:
   - Broker mode requires DGMGRL binary in ORACLE_HOME/bin
+  - "Broker mode uses dgmgrl /nolog and passes credentials via stdin (CONNECT command) to avoid exposing passwords in process listings"
   - "Broker mode supports OS authentication (/ AS SYSDG or / AS SYSDBA) when dgmgrl_user and dgmgrl_password are omitted"
   - "SQL mode supports OS authentication (mode: sysdba without user/password) when running as the oracle OS user"
   - SQL mode uses standard oracledb connection
@@ -178,7 +180,7 @@ EXAMPLES = '''
     dgmgrl_as: sysdba
     state: status
 
-# Password authentication
+# Password authentication (credentials are passed via stdin, not on the command line)
 - name: Get Data Guard status with password authentication
   oracle_dataguard:
     oracle_home: /u01/app/oracle/product/19c
@@ -368,7 +370,9 @@ def run_dgmgrl(module, commands, output_format='text'):
     if not os.path.exists(dgmgrl_bin):
         module.fail_json(msg='DGMGRL not found at %s' % dgmgrl_bin, changed=False)
 
-    # Build connect string
+    # Build connect string and pass it via stdin (CONNECT command) so that
+    # credentials never appear on the command line or in process listings.
+    # This mirrors how oracle_sqldba passes passwords to sqlplus via stdin.
     dgmgrl_user = module.params.get("dgmgrl_user")
     dgmgrl_password = module.params.get("dgmgrl_password")
     dgmgrl_connect_id = module.params.get("dgmgrl_connect_identifier")
@@ -381,17 +385,29 @@ def run_dgmgrl(module, commands, output_format='text'):
             connect_string = '%s/%s' % (dgmgrl_user, dgmgrl_password)
         if dgmgrl_as:
             connect_string += ' AS %s' % dgmgrl_as.upper()
+    elif dgmgrl_user:
+        # Wallet-based authentication (no password)
+        if dgmgrl_connect_id:
+            connect_string = '%s/@%s' % (dgmgrl_user, dgmgrl_connect_id)
+        else:
+            connect_string = '%s/' % dgmgrl_user
+        if dgmgrl_as:
+            connect_string += ' AS %s' % dgmgrl_as.upper()
     else:
+        # OS authentication
         connect_string = '/ AS %s' % dgmgrl_as.upper()
 
-    # Build command
+    # Use /nolog mode and issue CONNECT via stdin to keep credentials
+    # out of the process argument list visible in ps/proc.
     cmd = [dgmgrl_bin, '-silent']
     if output_format == 'json':
         cmd.extend(['-outputformat', 'json'])
-    cmd.append(connect_string)
+    cmd.append('/nolog')
 
-    # Build script from commands
-    script = ';\n'.join(commands) + ';\n'
+    # Build script: CONNECT first, then the actual commands
+    script_lines = ['CONNECT %s' % connect_string]
+    script_lines.extend(commands)
+    script = ';\n'.join(script_lines) + ';\n'
 
     rc, stdout, stderr = module.run_command(cmd, data=script)
 
@@ -605,9 +621,12 @@ def dgmgrl_convert_database(module, db_name, target_type):
 
 
 def dgmgrl_set_properties(module, db_name, properties):
-    """Set properties on a database."""
+    """Set properties on a database.
+
+    Returns True because DGMGRL does not report whether a value actually changed.
+    """
     if not db_name or not properties:
-        return
+        return False
     _validate_dgmgrl_identifier(module, db_name, 'database_name')
     commands = []
     for prop, value in properties.items():
@@ -616,6 +635,7 @@ def dgmgrl_set_properties(module, db_name, properties):
     rc, stdout, stderr = run_dgmgrl(module, commands)
     if rc != 0:
         module.fail_json(msg='Failed to set properties: %s %s' % (stdout, stderr), changed=False)
+    return True
 
 
 def dgmgrl_set_protection_mode(module, protection_mode):
@@ -689,7 +709,9 @@ def dgmgrl_add_far_sync(module):
 
     cmd = "ADD FAR_SYNC %s AS CONNECT IDENTIFIER IS '%s'" % (fs_name, _quote_dgmgrl_literal(fs_connect))
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
-    if rc != 0 and 'already' not in stdout.lower():
+    if rc != 0:
+        if 'already' in stdout.lower():
+            return False
         module.fail_json(msg='Failed to add Far Sync: %s %s' % (stdout, stderr), changed=False)
     return True
 
@@ -1065,26 +1087,26 @@ def _broker_present(module, database_name, output_format):
             changed = True
 
     if module.params["far_sync_name"]:
-        dgmgrl_add_far_sync(module)
-        changed = True
+        if dgmgrl_add_far_sync(module):
+            changed = True
     if module.params["properties"] and database_name:
-        dgmgrl_set_properties(module, database_name, module.params["properties"])
-        changed = True
+        if dgmgrl_set_properties(module, database_name, module.params["properties"]):
+            changed = True
     if module.params["protection_mode"]:
-        dgmgrl_set_protection_mode(module, module.params["protection_mode"])
-        changed = True
+        if dgmgrl_set_protection_mode(module, module.params["protection_mode"]):
+            changed = True
     if module.params["database_state"] and database_name:
-        dgmgrl_set_state(module, database_name, module.params["database_state"])
-        changed = True
+        if dgmgrl_set_state(module, database_name, module.params["database_state"]):
+            changed = True
     if module.params["primary_database_candidates"]:
         if dgmgrl_set_primary_database_candidates(module, module.params["primary_database_candidates"]):
             changed = True
     if module.params["fsfo"]:
-        dgmgrl_manage_fsfo(module, module.params["fsfo"], module.params.get("fsfo_target"))
-        changed = True
+        if dgmgrl_manage_fsfo(module, module.params["fsfo"], module.params.get("fsfo_target")):
+            changed = True
     if module.params["observer_state"]:
-        dgmgrl_manage_observer(module, module.params["observer_state"])
-        changed = True
+        if dgmgrl_manage_observer(module, module.params["observer_state"]):
+            changed = True
     if module.params["tags"]:
         if dgmgrl_set_tags(module, module.params["tags"]):
             changed = True
@@ -1126,12 +1148,24 @@ def _broker_enable_disable(module, database_name, enable):
     module.exit_json(changed=changed, msg='%s successfully' % action)
 
 
+_SQL_SUPPORTED_STATES = frozenset(['status', 'present'])
+
+
 def _run_sql_mode(module):
     """Handle all SQL mode operations."""
     if oracleConnection is None:
         module.fail_json(msg='SQL mode requires oracledb module. Install via: pip install oracledb', changed=False)
     state = module.params["state"]
     protection_mode = module.params["protection_mode"]
+
+    if state not in _SQL_SUPPORTED_STATES:
+        module.fail_json(
+            msg="state '%s' is not supported in SQL mode. "
+                "Supported states: %s. Use mode_dg=broker for this operation."
+                % (state, ', '.join(sorted(_SQL_SUPPORTED_STATES))),
+            changed=False,
+        )
+
     conn = oracleConnection(module)
 
     if state == 'status':

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -895,6 +895,9 @@ def _run_sql_mode(module):
             dataguard_processes=sql_get_dataguard_processes(conn),
         )
 
+    if module.check_mode:
+        module.exit_json(changed=False, msg='Check mode: no SQL operations executed')
+
     apply_state = module.params["apply_state"]
     if apply_state == 'started':
         sql_start_apply(conn, module)
@@ -923,8 +926,10 @@ try:
         oracleConnection, sanitize_string_params,
     )
 except ImportError:
-    def sanitize_string_params(_params):
-        pass
+    def sanitize_string_params(module_params):
+        for key, value in module_params.items():
+            if isinstance(value, str):
+                module_params[key] = value.strip()
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -767,7 +767,7 @@ def _validate_dgmgrl_connect_string(module, value, param_name):
 def dgmgrl_validate_connect_identifier(module, connect_identifier):
     """Validate a DG connect identifier (26ai+)."""
     _validate_dgmgrl_connect_string(module, connect_identifier, 'validate_connect_identifier')
-    cmd = 'VALIDATE DGConnectIdentifier %s' % connect_identifier
+    cmd = "VALIDATE DGConnectIdentifier '%s'" % _quote_dgmgrl_literal(module, connect_identifier)
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     return {'rc': rc, 'output': stdout, 'errors': stderr}
 

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -407,7 +407,8 @@ def parse_show_configuration(stdout):
         'databases': [],
         'fast_start_failover': '',
     }
-    for line in stdout.split('\n'):
+    lines = stdout.split('\n')
+    for i, line in enumerate(lines):
         line = line.strip()
         if line.startswith('Configuration -'):
             result['name'] = line.split('-', 1)[1].strip()
@@ -435,7 +436,10 @@ def parse_show_configuration(stdout):
         elif line.startswith('Fast-Start Failover:'):
             result['fast_start_failover'] = line.split(':', 1)[1].strip()
         elif line.startswith('Configuration Status:'):
-            result['status'] = line.split(':', 1)[1].strip()
+            # Status value appears on the next line in DGMGRL output
+            if i + 1 < len(lines):
+                status_line = lines[i + 1].strip()
+                result['status'] = status_line.split('(')[0].strip() if '(' in status_line else status_line
     return result
 
 
@@ -592,6 +596,7 @@ def dgmgrl_convert_database(module, db_name, target_type):
     """Convert database to snapshot or physical standby."""
     if not db_name:
         module.fail_json(msg='database_name is required for convert', changed=False)
+    _validate_dgmgrl_identifier(module, db_name, 'database_name')
     cmd = 'CONVERT DATABASE %s TO %s' % (db_name, target_type)
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     if rc != 0:
@@ -1051,6 +1056,7 @@ def _broker_present(module, database_name, output_format):
     if module.params["configuration_name"] and config.get('status') == 'NOT_CONFIGURED':
         dgmgrl_create_configuration(module)
         changed = True
+        config = dgmgrl_show_configuration(module, 'text')
 
     if database_name and config.get('status') != 'NOT_CONFIGURED':
         existing_dbs = [d['name'] for d in config.get('databases', [])]
@@ -1122,6 +1128,8 @@ def _broker_enable_disable(module, database_name, enable):
 
 def _run_sql_mode(module):
     """Handle all SQL mode operations."""
+    if oracleConnection is None:
+        module.fail_json(msg='SQL mode requires oracledb module. Install via: pip install oracledb', changed=False)
     state = module.params["state"]
     protection_mode = module.params["protection_mode"]
     conn = oracleConnection(module)
@@ -1166,6 +1174,8 @@ try:
         oracleConnection, sanitize_string_params,
     )
 except ImportError:
+    oracleConnection = None
+
     def sanitize_string_params(module_params):
         for key, value in module_params.items():
             if isinstance(value, str):

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -18,7 +18,7 @@ description:
   - Query Data Guard status, lag, and health
   - SQL mode for environments without broker
   - Compatible with Oracle 19c, 23ai, and 26ai
-  - "Oracle 26ai features: JSON output, PrimaryDatabaseCandidates, VALIDATE DGConnectIdentifier, tagging"
+  - "Oracle 26ai features: JSON output, VALIDATE DGConnectIdentifier, PrimaryDatabaseCandidates, tagging, FSFO target"
 version_added: "3.4.0"
 options:
   mode_dg:
@@ -95,7 +95,9 @@ options:
     choices: ['enabled', 'disabled']
     required: false
   fsfo_target:
-    description: Target database for Fast-Start Failover
+    description:
+      - Target database for Fast-Start Failover
+      - "When enabling FSFO, issues ENABLE FAST_START FAILOVER TARGET TO <target>"
     required: false
   far_sync_name:
     description: Name of the Far Sync instance
@@ -106,6 +108,34 @@ options:
   observer_state:
     description: Observer state
     choices: ['started', 'stopped']
+    required: false
+  validate_connect_identifier:
+    description:
+      - Connect identifier to validate via DGMGRL VALIDATE DGConnectIdentifier
+      - "Tests network resolution, connectivity, and service name validation"
+      - "Oracle 26ai+ feature"
+    required: false
+  primary_database_candidates:
+    description:
+      - List of database unique names eligible to become primary
+      - Sets the PrimaryDatabaseCandidates configuration property
+      - "Oracle 26ai+ feature, will warn and skip on older versions"
+    type: list
+    elements: str
+    required: false
+  tags:
+    description:
+      - Dictionary of tags to set on the target object
+      - "Target is determined by database_name (DATABASE), far_sync_name (FAR_SYNC), or CONFIGURATION if neither is set"
+      - "Uses EDIT <object> SET TAG syntax (Oracle 26ai+)"
+    type: dict
+    required: false
+  reset_tags:
+    description:
+      - List of tag names to remove from the target object
+      - "Uses EDIT <object> RESET TAG syntax (Oracle 26ai+)"
+    type: list
+    elements: str
     required: false
   output_format:
     description:
@@ -229,6 +259,45 @@ EXAMPLES = '''
   oracle_dataguard:
     oracle_home: /u01/app/oracle/product/19c
     state: absent
+
+# --- Oracle 26ai Features ---
+
+- name: Enable Fast-Start Failover with specific target
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: present
+    fsfo: enabled
+    fsfo_target: STDBY
+
+- name: Validate a DG connect identifier (26ai+)
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: status
+    validate_connect_identifier: "stdby-host:1521/STDBY"
+
+- name: Set PrimaryDatabaseCandidates (26ai+)
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: present
+    primary_database_candidates:
+      - PROD
+      - STDBY
+
+- name: Set tags on a database (26ai+)
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: present
+    database_name: STDBY
+    tags:
+      environment: production
+      tier: dr
+
+- name: Remove tags from configuration (26ai+)
+  oracle_dataguard:
+    oracle_home: /u01/app/oracle/product/26ai
+    state: present
+    reset_tags:
+      - environment
 
 # --- SQL Mode ---
 
@@ -572,10 +641,14 @@ def dgmgrl_set_state(module, db_name, db_state):
     return True
 
 
-def dgmgrl_manage_fsfo(module, fsfo_state):
+def dgmgrl_manage_fsfo(module, fsfo_state, fsfo_target=None):
     """Enable or disable Fast-Start Failover."""
     if fsfo_state == 'enabled':
-        cmd = 'ENABLE FAST_START FAILOVER'
+        if fsfo_target:
+            _validate_dgmgrl_identifier(module, fsfo_target, 'fsfo_target')
+            cmd = 'ENABLE FAST_START FAILOVER TARGET TO %s' % fsfo_target
+        else:
+            cmd = 'ENABLE FAST_START FAILOVER'
     else:
         cmd = 'DISABLE FAST_START FAILOVER'
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
@@ -622,6 +695,116 @@ def dgmgrl_validate(module, db_name):
     cmd = 'VALIDATE DATABASE %s' % db_name
     rc, stdout, stderr = run_dgmgrl(module, [cmd])
     return {'rc': rc, 'output': stdout, 'errors': stderr}
+
+
+# ============================================================================
+# Oracle 26ai Features
+# ============================================================================
+
+def _validate_dgmgrl_connect_string(module, value, param_name):
+    """Validate a connect identifier is safe for DGMGRL (no injection)."""
+    if not value or ';' in value or '\n' in value:
+        module.fail_json(msg='Invalid %s: must not be empty or contain ; or newlines' % param_name, changed=False)
+
+
+def dgmgrl_validate_connect_identifier(module, connect_identifier):
+    """Validate a DG connect identifier (26ai+)."""
+    _validate_dgmgrl_connect_string(module, connect_identifier, 'validate_connect_identifier')
+    cmd = 'VALIDATE DGConnectIdentifier %s' % connect_identifier
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    return {'rc': rc, 'output': stdout, 'errors': stderr}
+
+
+def dgmgrl_set_primary_database_candidates(module, candidates):
+    """Set PrimaryDatabaseCandidates configuration property (26ai+)."""
+    for c in candidates:
+        _validate_dgmgrl_identifier(module, c, 'primary_database_candidates member')
+    value = ','.join(candidates)
+    cmd = "EDIT CONFIGURATION SET PROPERTY PrimaryDatabaseCandidates='%s'" % _quote_dgmgrl_literal(value)
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        if 'not supported' in stdout.lower() or 'invalid property' in stdout.lower():
+            module.warn('PrimaryDatabaseCandidates not supported on this Oracle version')
+            return False
+        module.fail_json(msg='Failed to set PrimaryDatabaseCandidates: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def _validate_dgmgrl_tag_name(module, tag_name):
+    """Validate a tag name — alphanumeric, underscores, hyphens."""
+    if not re.match(r'^[A-Za-z][A-Za-z0-9_-]*$', tag_name):
+        module.fail_json(msg='Invalid tag name: %s' % tag_name, changed=False)
+
+
+def _resolve_tag_target(module):
+    """Determine the DGMGRL object type and name for tag operations.
+
+    Returns (target_keyword, target_name) e.g. ('DATABASE', 'STDBY') or ('CONFIGURATION', '').
+    """
+    db_name = module.params.get("database_name")
+    fs_name = module.params.get("far_sync_name")
+    if db_name:
+        _validate_dgmgrl_identifier(module, db_name, 'database_name')
+        return ('DATABASE', db_name)
+    if fs_name:
+        _validate_dgmgrl_identifier(module, fs_name, 'far_sync_name')
+        return ('FAR_SYNC', fs_name)
+    return ('CONFIGURATION', '')
+
+
+def dgmgrl_set_tags(module, tags):
+    """Set tags on a DGMGRL object (26ai+)."""
+    target_type, target_name = _resolve_tag_target(module)
+    commands = []
+    for tag_name, tag_value in tags.items():
+        _validate_dgmgrl_tag_name(module, tag_name)
+        if target_name:
+            cmd = "EDIT %s %s SET TAG %s='%s'" % (
+                target_type, target_name, tag_name, _quote_dgmgrl_literal(str(tag_value)))
+        else:
+            cmd = "EDIT %s SET TAG %s='%s'" % (
+                target_type, tag_name, _quote_dgmgrl_literal(str(tag_value)))
+        commands.append(cmd)
+    rc, stdout, stderr = run_dgmgrl(module, commands)
+    if rc != 0:
+        if 'not supported' in stdout.lower():
+            module.warn('Tagging not supported on this Oracle version')
+            return False
+        module.fail_json(msg='Failed to set tags: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_reset_tags(module, tag_names):
+    """Reset (remove) tags from a DGMGRL object (26ai+)."""
+    target_type, target_name = _resolve_tag_target(module)
+    commands = []
+    for tag_name in tag_names:
+        _validate_dgmgrl_tag_name(module, tag_name)
+        if target_name:
+            cmd = 'EDIT %s %s RESET TAG %s' % (target_type, target_name, tag_name)
+        else:
+            cmd = 'EDIT %s RESET TAG %s' % (target_type, tag_name)
+        commands.append(cmd)
+    rc, stdout, stderr = run_dgmgrl(module, commands)
+    if rc != 0:
+        if 'not supported' in stdout.lower():
+            module.warn('Tagging not supported on this Oracle version')
+            return False
+        module.fail_json(msg='Failed to reset tags: %s %s' % (stdout, stderr), changed=False)
+    return True
+
+
+def dgmgrl_show_tags(module, output_format):
+    """Show tags on a DGMGRL object (26ai+). Returns tag output string or None."""
+    target_type, target_name = _resolve_tag_target(module)
+    if target_name:
+        cmd = 'SHOW %s %s TAG' % (target_type, target_name)
+    else:
+        cmd = 'SHOW %s TAG' % target_type
+    rc, stdout, stderr = run_dgmgrl(module, [cmd])
+    if rc != 0:
+        return None
+    return stdout
 
 
 # ============================================================================
@@ -778,6 +961,12 @@ def main():
             # Observer
             observer_state=dict(required=False, choices=['started', 'stopped']),
 
+            # 26ai features
+            validate_connect_identifier=dict(required=False),
+            primary_database_candidates=dict(required=False, type='list', elements='str'),
+            tags=dict(required=False, type='dict'),
+            reset_tags=dict(required=False, type='list', elements='str'),
+
             # Output format (26ai JSON)
             output_format=dict(default='text', choices=['text', 'json']),
 
@@ -834,14 +1023,23 @@ def _broker_status(module, database_name, output_format):
     config = dgmgrl_show_configuration(module, output_format)
     db_detail = None
     validate_result = None
+    validate_connect = None
+    tags_output = None
     if database_name:
         db_detail = dgmgrl_show_database(module, database_name, output_format)
         validate_result = dgmgrl_validate(module, database_name)
+    if module.params.get("validate_connect_identifier"):
+        validate_connect = dgmgrl_validate_connect_identifier(
+            module, module.params["validate_connect_identifier"])
+    if config.get('status') != 'NOT_CONFIGURED':
+        tags_output = dgmgrl_show_tags(module, output_format)
     module.exit_json(
         changed=False,
         configuration=config,
         database_detail=db_detail,
         validate=validate_result,
+        validate_connect_identifier=validate_connect,
+        tags=tags_output,
     )
 
 
@@ -872,12 +1070,21 @@ def _broker_present(module, database_name, output_format):
     if module.params["database_state"] and database_name:
         dgmgrl_set_state(module, database_name, module.params["database_state"])
         changed = True
+    if module.params["primary_database_candidates"]:
+        if dgmgrl_set_primary_database_candidates(module, module.params["primary_database_candidates"]):
+            changed = True
     if module.params["fsfo"]:
-        dgmgrl_manage_fsfo(module, module.params["fsfo"])
+        dgmgrl_manage_fsfo(module, module.params["fsfo"], module.params.get("fsfo_target"))
         changed = True
     if module.params["observer_state"]:
         dgmgrl_manage_observer(module, module.params["observer_state"])
         changed = True
+    if module.params["tags"]:
+        if dgmgrl_set_tags(module, module.params["tags"]):
+            changed = True
+    if module.params["reset_tags"]:
+        if dgmgrl_reset_tags(module, module.params["reset_tags"]):
+            changed = True
 
     config = dgmgrl_show_configuration(module, output_format)
     module.exit_json(changed=changed, configuration=config, msg='Data Guard configuration updated')

--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -491,7 +491,9 @@ def _validate_dgmgrl_identifier(module, value, param_name):
 
 
 def _quote_dgmgrl_literal(value):
-    """Escape single quotes in a DGMGRL string literal."""
+    """Escape single quotes and reject injection characters in a DGMGRL string literal."""
+    if ';' in value or '\n' in value or '\r' in value:
+        raise ValueError("DGMGRL literal must not contain semicolons or newlines: %r" % value)
     return value.replace("'", "''")
 
 

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -1,0 +1,552 @@
+"""Unit tests for oracle_dataguard module."""
+import pytest
+
+from conftest import ExitJson, FailJson, load_module_from_path, module_path
+from helpers import BASE_CONN_PARAMS, BaseFakeConn, BaseFakeModule
+
+
+def _load():
+    return load_module_from_path(
+        module_path("plugins", "modules", "oracle_dataguard.py"), "oracle_dataguard_test"
+    )
+
+
+def _dg_params(**overrides):
+    base = {
+        **BASE_CONN_PARAMS,
+        "mode_dg": "broker",
+        "state": "status",
+        "dgmgrl_user": None,
+        "dgmgrl_password": None,
+        "dgmgrl_connect_identifier": None,
+        "dgmgrl_as": "sysdg",
+        "configuration_name": None,
+        "primary_database": None,
+        "connect_identifier": None,
+        "database_name": None,
+        "properties": None,
+        "protection_mode": None,
+        "database_state": None,
+        "fsfo": None,
+        "fsfo_target": None,
+        "far_sync_name": None,
+        "far_sync_connect_identifier": None,
+        "observer_state": None,
+        "output_format": "text",
+        "force_logging": None,
+        "apply_state": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# DGMGRL output fixtures
+# ===========================================================================
+
+SHOW_CONFIG_OUTPUT = """Configuration - my_dg_config
+
+  Protection Mode: MaxPerformance
+  Members:
+  PROD    - Primary database
+    STDBY   - Physical standby database
+
+Fast-Start Failover:  Disabled
+
+Configuration Status:
+SUCCESS   (status updated 5 seconds ago)
+"""
+
+SHOW_CONFIG_NOT_CONFIGURED = """ORA-16532: Oracle Data Guard broker configuration does not exist
+Configuration details cannot be determined by DGMGRL
+"""
+
+
+class _DgBrokerModule(BaseFakeModule):
+    """Module that stubs run_command for DGMGRL."""
+
+    _dgmgrl_responses = {}
+
+    def run_command(self, command, **kwargs):
+        data = kwargs.get('data', '')
+        # Check which commands are in the script
+        for key, (rc, stdout, stderr) in self._dgmgrl_responses.items():
+            if key in data.upper():
+                return (rc, stdout, stderr)
+        # Default: show configuration
+        return (0, SHOW_CONFIG_OUTPUT, '')
+
+
+# ===========================================================================
+# Tests: Broker mode - status
+# ===========================================================================
+
+def test_dg_broker_status(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle")
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["configuration"]["name"] == "my_dg_config"
+    assert result["configuration"]["protection_mode"] == "MaxPerformance"
+
+
+def test_dg_broker_status_not_configured(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle")
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (1, SHOW_CONFIG_NOT_CONFIGURED, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["configuration"]["status"] == "NOT_CONFIGURED"
+
+
+# ===========================================================================
+# Tests: Broker mode - create configuration
+# ===========================================================================
+
+def test_dg_broker_create_config(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            configuration_name="my_dg",
+            primary_database="PROD",
+            connect_identifier="prod-host:1521/PROD",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (1, SHOW_CONFIG_NOT_CONFIGURED, ''),
+            'CREATE CONFIGURATION': (0, 'Succeeded.', ''),
+        }
+        _call_count = 0
+
+        def run_command(self, command, **kwargs):
+            data = kwargs.get('data', '')
+            # First call: show config returns not configured
+            # Second call: create succeeds
+            # Third call: show config returns success
+            self.__class__._call_count += 1
+            if self.__class__._call_count <= 1:
+                return (1, SHOW_CONFIG_NOT_CONFIGURED, '')
+            elif 'CREATE' in data.upper():
+                return (0, 'Succeeded.', '')
+            else:
+                return (0, SHOW_CONFIG_OUTPUT, '')
+
+    Mod._call_count = 0
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+# ===========================================================================
+# Tests: Broker mode - absent (remove)
+# ===========================================================================
+
+def test_dg_broker_remove_database(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="absent",
+            database_name="STDBY",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'REMOVE DATABASE': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_dg_broker_remove_configuration(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="absent",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'REMOVE CONFIGURATION': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_dg_broker_absent_when_not_configured(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="absent",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (1, SHOW_CONFIG_NOT_CONFIGURED, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: Broker mode - enable/disable
+# ===========================================================================
+
+def test_dg_broker_enable_configuration(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="enabled")
+        _dgmgrl_responses = {
+            'ENABLE CONFIGURATION': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_dg_broker_disable_database(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="disabled", database_name="STDBY")
+        _dgmgrl_responses = {
+            'DISABLE DATABASE': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+# ===========================================================================
+# Tests: Broker mode - switchover/failover
+# ===========================================================================
+
+def test_dg_broker_switchover(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="switchover", database_name="STDBY")
+        _dgmgrl_responses = {
+            'SWITCHOVER TO': (0, 'Switchover succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert "switchover" in result["msg"].lower()
+
+
+def test_dg_broker_failover(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="failover", database_name="STDBY")
+        _dgmgrl_responses = {
+            'FAILOVER TO': (0, 'Failover succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+# ===========================================================================
+# Tests: Broker mode - convert
+# ===========================================================================
+
+def test_dg_broker_convert_snapshot(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle", state="snapshot_standby", database_name="STDBY")
+        _dgmgrl_responses = {
+            'CONVERT DATABASE': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert "snapshot" in result["msg"].lower()
+
+
+# ===========================================================================
+# Tests: SQL mode - status
+# ===========================================================================
+
+class _DgSqlConn(BaseFakeConn):
+    """Simulates V$DATABASE, V$DATAGUARD_STATS, etc."""
+
+    def __init__(self, module, db_role='PRIMARY', force_logging='YES',
+                 protection_mode='MAXIMUM PERFORMANCE', dg_processes=None):
+        super().__init__(module)
+        self._db_role = db_role
+        self._force_logging = force_logging
+        self._protection_mode = protection_mode
+        self._dg_processes = dg_processes or []
+
+    def execute_select_to_dict(self, sql, params=None, fetchone=False, fail_on_error=True):
+        sql_upper = sql.upper()
+        if 'V$DATABASE' in sql_upper:
+            row = {
+                'database_role': self._db_role,
+                'protection_mode': self._protection_mode,
+                'protection_level': self._protection_mode,
+                'switchover_status': 'TO STANDBY',
+                'dataguard_broker': 'ENABLED',
+                'force_logging': self._force_logging,
+                'flashback_on': 'YES',
+                'db_unique_name': 'PROD',
+            }
+            return row if fetchone else [row]
+        if 'V$DATAGUARD_STATS' in sql_upper:
+            return [
+                {'name': 'transport lag', 'value': '+00 00:00:00', 'unit': 'day(2) to second(0) interval', 'time_computed': '2024-01-01', 'datum_time': '2024-01-01'},
+                {'name': 'apply lag', 'value': '+00 00:00:02', 'unit': 'day(2) to second(0) interval', 'time_computed': '2024-01-01', 'datum_time': '2024-01-01'},
+            ]
+        if 'V$ARCHIVE_DEST_STATUS' in sql_upper:
+            return [{'dest_id': 2, 'status': 'VALID', 'type': 'PHYSICAL', 'database_mode': 'MOUNTED',
+                     'recovery_mode': 'MANAGED REAL TIME APPLY', 'gap_status': 'NO GAP',
+                     'synchronized': 'YES', 'error': '', 'db_unique_name': 'STDBY'}]
+        if 'V$DATAGUARD_PROCESS' in sql_upper:
+            return self._dg_processes
+        return {} if fetchone else []
+
+
+def test_dg_sql_status(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="status")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["database"]["database_role"] == "PRIMARY"
+    assert len(result["dataguard_stats"]) == 2
+
+
+# ===========================================================================
+# Tests: SQL mode - apply management
+# ===========================================================================
+
+def test_dg_sql_start_apply(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", apply_state="started")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, db_role='PHYSICAL STANDBY'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("RECOVER MANAGED STANDBY" in d for d in result["ddls"])
+
+
+def test_dg_sql_start_apply_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", apply_state="started")
+
+    processes = [{'role': 'MRP', 'action': 'APPLYING_LOG', 'client_role': '', 'thread#': 1, 'sequence#': 100, 'block#': 1}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, dg_processes=processes), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+def test_dg_sql_stop_apply(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", apply_state="stopped")
+
+    processes = [{'role': 'MRP', 'action': 'APPLYING_LOG', 'client_role': '', 'thread#': 1, 'sequence#': 100, 'block#': 1}]
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, dg_processes=processes), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("CANCEL" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: SQL mode - force logging
+# ===========================================================================
+
+def test_dg_sql_enable_force_logging(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", force_logging="enable")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, force_logging='NO'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("FORCE LOGGING" in d for d in result["ddls"])
+
+
+def test_dg_sql_force_logging_idempotent(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", force_logging="enable")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, force_logging='YES'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+
+
+# ===========================================================================
+# Tests: SQL mode - protection mode
+# ===========================================================================
+
+def test_dg_sql_set_protection_mode(monkeypatch):
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _dg_params(mode_dg="sql", state="present", protection_mode="maximum_availability")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _DgSqlConn(m, protection_mode='MAXIMUM PERFORMANCE'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert any("MAXIMIZE AVAILABILITY" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: parse_show_configuration
+# ===========================================================================
+
+def test_parse_show_configuration():
+    mod = _load()
+    result = mod.parse_show_configuration(SHOW_CONFIG_OUTPUT)
+    assert result["name"] == "my_dg_config"
+    assert result["protection_mode"] == "MaxPerformance"
+    assert result["fast_start_failover"] == "Disabled"
+    assert len(result["databases"]) == 2
+    assert result["databases"][0]["role"] == "PRIMARY"
+    assert result["databases"][1]["role"] == "PHYSICAL STANDBY"
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+class _FakeOs:
+    """Fake os module that makes path.exists return True for oracle_home."""
+
+    def __init__(self, oracle_home):
+        self._oracle_home = oracle_home
+        self.environ = dict(ORACLE_HOME=oracle_home)
+
+    class path:
+        _oracle_home = None
+
+        @classmethod
+        def exists(cls, path_str):
+            return True
+
+        @classmethod
+        def join(cls, *args):
+            import os as _os
+            return _os.path.join(*args)
+
+    def __getattr__(self, name):
+        import os as _os
+        return getattr(_os, name)
+
+
+# Ensure _FakeOs.path methods work for all tests
+_FakeOs.path._oracle_home = "/fake/oracle"

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -69,11 +69,13 @@ Configuration details cannot be determined by DGMGRL
 class _DgBrokerModule(BaseFakeModule):
     """Module that stubs run_command for DGMGRL."""
 
-    _dgmgrl_responses = {}
-    _run_command_calls = []
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._dgmgrl_responses = getattr(type(self), '_dgmgrl_responses', {})
+        self._run_command_calls = getattr(type(self), '_run_command_calls', [])
 
     def run_command(self, command, **kwargs):
-        type(self)._run_command_calls.append((command, kwargs))
+        self._run_command_calls.append((command, kwargs))
         data = kwargs.get('data', '')
         # Check which commands are in the script
         for key, (rc, stdout, stderr) in self._dgmgrl_responses.items():

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -528,12 +528,9 @@ class _FakeOs:
     """Fake os module that makes path.exists return True for oracle_home."""
 
     def __init__(self, oracle_home):
-        self._oracle_home = oracle_home
         self.environ = dict(ORACLE_HOME=oracle_home)
 
     class path:
-        _oracle_home = None
-
         @classmethod
         def exists(cls, path_str):
             return True
@@ -546,7 +543,3 @@ class _FakeOs:
     def __getattr__(self, name):
         import os as _os
         return getattr(_os, name)
-
-
-# Ensure _FakeOs.path methods work for all tests
-_FakeOs.path._oracle_home = "/fake/oracle"

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -836,6 +836,7 @@ def test_parse_show_configuration():
     assert len(result["databases"]) == 2
     assert result["databases"][0]["role"] == "PRIMARY"
     assert result["databases"][1]["role"] == "PHYSICAL STANDBY"
+    assert result["status"] == "SUCCESS"
 
 
 # ===========================================================================

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -32,6 +32,10 @@ def _dg_params(**overrides):
         "far_sync_name": None,
         "far_sync_connect_identifier": None,
         "observer_state": None,
+        "validate_connect_identifier": None,
+        "primary_database_candidates": None,
+        "tags": None,
+        "reset_tags": None,
         "output_format": "text",
         "force_logging": None,
         "apply_state": None,
@@ -66,8 +70,10 @@ class _DgBrokerModule(BaseFakeModule):
     """Module that stubs run_command for DGMGRL."""
 
     _dgmgrl_responses = {}
+    _run_command_calls = []
 
     def run_command(self, command, **kwargs):
+        type(self)._run_command_calls.append((command, kwargs))
         data = kwargs.get('data', '')
         # Check which commands are in the script
         for key, (rc, stdout, stderr) in self._dgmgrl_responses.items():
@@ -503,6 +509,318 @@ def test_dg_sql_set_protection_mode(monkeypatch):
     result = exc.value.args[0]
     assert result["changed"] is True
     assert any("MAXIMIZE AVAILABILITY" in d for d in result["ddls"])
+
+
+# ===========================================================================
+# Tests: FSFO Target
+# ===========================================================================
+
+def test_dg_broker_fsfo_enable_with_target(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            fsfo="enabled",
+            fsfo_target="STDBY",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'ENABLE FAST_START FAILOVER': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    # Verify the target was included in the command
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('TARGET TO STDBY' in c for c in calls)
+
+
+def test_dg_broker_fsfo_enable_without_target(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            fsfo="enabled",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'ENABLE FAST_START FAILOVER': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('ENABLE FAST_START FAILOVER' in c and 'TARGET' not in c for c in calls)
+
+
+# ===========================================================================
+# Tests: VALIDATE DGConnectIdentifier (26ai)
+# ===========================================================================
+
+def test_dg_broker_validate_connect_identifier(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="status",
+            validate_connect_identifier="stdby-host:1521/STDBY",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'VALIDATE DGCONNECTIDENTIFIER': (0, 'Validation succeeded.', ''),
+            'SHOW': (0, '', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["validate_connect_identifier"] is not None
+    assert result["validate_connect_identifier"]["rc"] == 0
+
+
+def test_dg_broker_validate_connect_identifier_injection(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="status",
+            validate_connect_identifier="host:1521/SVC; DROP CONFIGURATION",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert 'Invalid' in exc.value.args[0]['msg']
+
+
+# ===========================================================================
+# Tests: PrimaryDatabaseCandidates (26ai)
+# ===========================================================================
+
+def test_dg_broker_set_primary_db_candidates(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            primary_database_candidates=["PROD", "STDBY"],
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'PRIMARYDATABASECANDIDATES': (0, 'Succeeded.', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+
+
+def test_dg_broker_primary_db_candidates_invalid_name(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            primary_database_candidates=["PROD", "BAD NAME"],
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert 'Invalid' in exc.value.args[0]['msg']
+
+
+def test_dg_broker_primary_db_candidates_unsupported(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            primary_database_candidates=["PROD"],
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'PRIMARYDATABASECANDIDATES': (1, 'ORA-16599: invalid property', ''),
+        }
+        _warnings = []
+
+        def warn(self, msg):
+            type(self)._warnings.append(msg)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    # changed=False because the feature was skipped
+    assert any('not supported' in w for w in Mod._warnings)
+
+
+# ===========================================================================
+# Tests: Tagging (26ai)
+# ===========================================================================
+
+def test_dg_broker_set_tags_database(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            database_name="STDBY",
+            tags={"environment": "production", "tier": "dr"},
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'SET TAG': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('EDIT DATABASE STDBY SET TAG' in c for c in calls)
+
+
+def test_dg_broker_set_tags_configuration(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            tags={"site": "dc1"},
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'SET TAG': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('EDIT CONFIGURATION SET TAG' in c for c in calls)
+
+
+def test_dg_broker_reset_tags(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            database_name="STDBY",
+            reset_tags=["environment"],
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'RESET TAG': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    calls = [kwargs.get('data', '') for args, kwargs in Mod._run_command_calls]
+    assert any('EDIT DATABASE STDBY RESET TAG environment' in c for c in calls)
+
+
+def test_dg_broker_show_tags_in_status(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="status",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'SHOW': (0, 'environment=production\ntier=dr\n', ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    result = exc.value.args[0]
+    assert result["tags"] is not None
+
+
+def test_dg_broker_tags_invalid_name(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            tags={"bad tag!": "value"},
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert 'Invalid tag name' in exc.value.args[0]['msg']
 
 
 # ===========================================================================


### PR DESCRIPTION
Summary                                                            
                                                                                                                                               
  - New oracle_dataguard module for managing Oracle Data Guard configurations via both SQL (V$DATABASE, ALTER DATABASE) and DGMGRL broker CLI  
  - Supports SQL mode for standby role conversion and status queries, and broker mode for full configuration lifecycle (create, add/remove
  databases, far sync, properties, protection mode, state management)                                                                          
  - Oracle 26ai features: VALIDATE DGConnectIdentifier, PrimaryDatabaseCandidates, and tag management
  - Credentials passed via DGMGRL stdin to avoid process listing exposure, with injection validation on all user-supplied strings              
                                                                                                                                               
  Changes                                                                                                                                      
                                                                                                                                               
  - plugins/modules/oracle_dataguard.py — new module with two operational modes:
    - SQL mode: standby conversion (convert_to_physical_standby, convert_to_snapshot_standby), switchover, failover, and status queries
    - Broker mode: configuration CRUD, database add/remove/enable/disable, far sync, property editing, protection mode, state management, and  
  show commands                                                                                                                                
  - tests/unit/test_oracle_dataguard.py — 866-line unit test suite covering both modes                                                         
                                                                                                                                               
  Test plan                                                          

  - Unit tests pass: pytest tests/unit/test_oracle_dataguard.py                                                                                
  - Check mode returns correct status without executing DGMGRL commands or SQL DDL
  - Verify credentials are never exposed in process listings or error output                                                                   
  - Test broker idempotency: properties, protection mode, and state skip changes when already at desired value
  - Test input validation rejects ;, \n, \r in all credential and identifier fields    