### PR TITLE
fix: CDB test guards, RAC params on modify path, oracle_parameter view, pbkdf2 dep   

### DIFF
--- a/plugins/modules/oracle_crs_service.py
+++ b/plugins/modules/oracle_crs_service.py
@@ -136,6 +136,23 @@ options:
       - "-stopoption <stop_options>     Options to stop service (e.g. TRANSACTIONAL or IMMEDIATE)"
     choices: ['TRANSACTIONAL', 'IMMEDIATE']
     required: false
+  preferred:
+    description:
+      - "-preferred <node_list> Comma-separated list of preferred nodes for administrator-managed RAC services"
+    required: false
+  available:
+    description:
+      - "-available <node_list> Comma-separated list of available nodes for administrator-managed RAC services"
+    required: false
+  serverpool:
+    description:
+      - "-serverpool <pool_name> Server pool name for policy-managed RAC services"
+    required: false
+  cardinality:
+    description:
+      - "-cardinality (UNIFORM | SINGLETON) Cardinality for policy-managed RAC services"
+    choices: ['UNIFORM', 'SINGLETON']
+    required: false
 notes:
   - Should be executed with privileges of Oracle CRS installation owner
 author: Ivan Brezina
@@ -312,6 +329,10 @@ class oracle_crs_service:
         srvctl = [self.srvctl]
         if (not self.curent_resource) and state in ['present', 'started', 'stopped', 'restarted']:
             srvctl.extend(['add', 'service', '-s', resource_name, '-d', database_name])
+            for rac_param in ['serverpool', 'preferred', 'available', 'cardinality']:
+                val = self.module.params.get(rac_param)
+                if val:
+                    srvctl.extend(['-' + rac_param, val])
             apply = True
         elif self.curent_resource and state in ['present', 'started', 'stopped', 'restarted']:
             srvctl.extend(['modify', 'service', '-s', resource_name, '-d', database_name])
@@ -436,6 +457,11 @@ def main():
         drain_timeout=dict(required=False),
         # <stop_options> Options to stop service (e.g. TRANSACTIONAL or IMMEDIATE)
         stopoption=dict(required=False, choices=['TRANSACTIONAL', 'IMMEDIATE']),
+        # RAC placement options (required for srvctl add service on RAC)
+        preferred=dict(required=False),
+        available=dict(required=False),
+        serverpool=dict(required=False),
+        cardinality=dict(required=False, choices=['UNIFORM', 'SINGLETON']),
     )
     # global is Python keyword, use this hack to use 'global' as ansible module parameter
     argument_spec.update({'global': dict(required=False, type='bool')})

--- a/plugins/modules/oracle_crs_service.py
+++ b/plugins/modules/oracle_crs_service.py
@@ -297,6 +297,10 @@ class oracle_crs_service:
                 wanted_set.add((pname, param))
             elif param:
                 wanted_set.add((pname, param.upper()))
+        for rac_param in ['serverpool', 'preferred', 'available', 'cardinality']:
+            val = self.module.params.get(rac_param)
+            if val:
+                wanted_set.add((rac_param, val.upper()))
 
         current_set = set()
         # current_set.add(("db", self.curent_resource.get('???', None)))
@@ -323,16 +327,16 @@ class oracle_crs_service:
         current_set.add(("tablefamilyid", self.curent_resource.get('TABLE_FAMILY_ID', None)))
         current_set.add(("drain_timeout", self.curent_resource.get('DRAIN_TIMEOUT', None)))
         current_set.add(("stopoption", self.curent_resource.get('STOP_OPTION', '').upper())) # CRS stores is as lowercase
+        current_set.add(("serverpool", self.curent_resource.get('SERVER_POOL', None)))
+        current_set.add(("cardinality", self.curent_resource.get('CARDINALITY', None)))
+        current_set.add(("preferred", self.curent_resource.get('PREFERRED', None)))
+        current_set.add(("available", self.curent_resource.get('AVAILABLE', None)))
 
         apply = False
         changes = wanted_set.difference(current_set)
         srvctl = [self.srvctl]
         if (not self.curent_resource) and state in ['present', 'started', 'stopped', 'restarted']:
             srvctl.extend(['add', 'service', '-s', resource_name, '-d', database_name])
-            for rac_param in ['serverpool', 'preferred', 'available', 'cardinality']:
-                val = self.module.params.get(rac_param)
-                if val:
-                    srvctl.extend(['-' + rac_param, val])
             apply = True
         elif self.curent_resource and state in ['present', 'started', 'stopped', 'restarted']:
             srvctl.extend(['modify', 'service', '-s', resource_name, '-d', database_name])

--- a/plugins/modules/oracle_crs_service.py
+++ b/plugins/modules/oracle_crs_service.py
@@ -300,7 +300,7 @@ class oracle_crs_service:
         for rac_param in ['serverpool', 'preferred', 'available', 'cardinality']:
             val = self.module.params.get(rac_param)
             if val:
-                wanted_set.add((rac_param, val.upper()))
+                wanted_set.add((rac_param, val))
 
         current_set = set()
         # current_set.add(("db", self.curent_resource.get('???', None)))

--- a/plugins/modules/oracle_parameter.py
+++ b/plugins/modules/oracle_parameter.py
@@ -98,13 +98,13 @@ def check_parameter_exists(conn, parameter_name):
         # 'display_value': '19.0.0'}
     else:
         sql = """
-        select lower(name) as name, 
-        value as CURRENT_VALUE, 
-        ISMODIFIED,-- was modified since startup
+        select lower(name) as name,
+        value as CURRENT_VALUE,
+        ISMODIFIED,
         ISDEFAULT,
         DEFAULT_VALUE,
-        DISPLAY_VALUE  
-        from v$parameter where name = lower(:parameter_name)
+        DISPLAY_VALUE
+        from v$system_parameter where name = lower(:parameter_name)
         """
         p = conn.execute_select_to_dict(sql, {"parameter_name": parameter_name}, fetchone=True)
 

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,1 +1,2 @@
 oracledb
+pbkdf2

--- a/tests/integration/targets/test_oracle_profile/tasks/main.yml
+++ b/tests/integration/targets/test_oracle_profile/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Role tasks with env
+  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
   block:
     - include_tasks: "simple.yml"
     - include_tasks: "issue_4.yml"

--- a/tests/integration/targets/test_oracle_profile/tasks/main.yml
+++ b/tests/integration/targets/test_oracle_profile/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Role tasks with env
-  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
+  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name | length > 0)
   block:
     - include_tasks: "simple.yml"
     - include_tasks: "issue_4.yml"

--- a/tests/integration/targets/test_oracle_role/tasks/main.yml
+++ b/tests/integration/targets/test_oracle_role/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Role tasks with env
+  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
   block:
     - include_tasks: "create_delete.yml"
     - include_tasks: "parameter.yml"

--- a/tests/integration/targets/test_oracle_role/tasks/main.yml
+++ b/tests/integration/targets/test_oracle_role/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Role tasks with env
-  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
+  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name | length > 0)
   block:
     - include_tasks: "create_delete.yml"
     - include_tasks: "parameter.yml"

--- a/tests/integration/targets/test_oracle_sql/tasks/main.yml
+++ b/tests/integration/targets/test_oracle_sql/tasks/main.yml
@@ -4,6 +4,7 @@
   block:
     - include_tasks: "select.yml"
     - include_tasks: "ddl.yml"
+      when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
     - include_tasks: "plsql_block.yml"
     - include_tasks: "sql_file.yml"
     - include_tasks: "special_cases.yml"

--- a/tests/integration/targets/test_oracle_sql/tasks/main.yml
+++ b/tests/integration/targets/test_oracle_sql/tasks/main.yml
@@ -4,7 +4,7 @@
   block:
     - include_tasks: "select.yml"
     - include_tasks: "ddl.yml"
-      when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
+      when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name | length > 0)
     - include_tasks: "plsql_block.yml"
     - include_tasks: "sql_file.yml"
     - include_tasks: "special_cases.yml"

--- a/tests/integration/targets/test_oracle_user/tasks/main.yml
+++ b/tests/integration/targets/test_oracle_user/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Role tasks with env
+  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
   block:
     - include_tasks: "change_state.yml"
     - include_tasks: "check_mode.yml"

--- a/tests/integration/targets/test_oracle_user/tasks/main.yml
+++ b/tests/integration/targets/test_oracle_user/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Role tasks with env
-  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
+  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name | length > 0)
   block:
     - include_tasks: "change_state.yml"
     - include_tasks: "check_mode.yml"


### PR DESCRIPTION
 ## Summary

  Fixes issues #2, #15, #19, #20, #21, #22, #31.                                                                                                   
  
  ### Bug fixes                                                                                                                                    
                                                                           
  **oracle_parameter: use `v$system_parameter` instead of `v$parameter`** (closes #2)

  `v$parameter` reflects the current session's view of parameters;
  `v$system_parameter` is the authoritative system-level value. Using the wrong
  view caused false "no change" results when a parameter had been modified at the                                                                  
  system level but not yet visible in the session.
                                                                                                                                                   
  **oracle_crs_service: wire RAC placement params into the diff/modify path** (closes #15)                                                         
  
  `preferred`, `available`, `serverpool`, and `cardinality` were only appended to                                                                  
  the `srvctl add service` command. On an existing service (the modify path) they
  were never added to `wanted_set` or `current_set`, so changes were silently
  ignored and `srvctl modify` was never called when only RAC params changed.                                                                       
  
  Changes:                                                                                                                                         
  - Add the four params to `wanted_set` (raw values — node names are       
    case-sensitive and CRS stores them in original case)
  - Add the four canonical CRS attribute names (`SERVER_POOL`, `CARDINALITY`,                                                                      
    `PREFERRED`, `AVAILABLE`) to `current_set`
  - Remove the old add-branch explicit loop; the unified diff loop now handles                                                                     
    both add and modify paths without duplicating flags                    
                                                                                                                                                   
  ### Integration test fixes
                                                                                                                                                   
  **Boolean type error in `when` clauses** (closes #19, #20, #21, #22)     

  Four test roles used `oracle_pdb_service_name` (a string) as the final operand                                                                   
  of a `when` clause:
                                                                                                                                                   
  ```yaml                                                                  
  when: not (running_on_cdb | default(false)) or (oracle_pdb_service_name is defined and oracle_pdb_service_name)
                                                                                                                                                   
  Ansible now rejects when clauses whose result is a non-boolean truthy value.
  With running_on_cdb: true and oracle_pdb_service_name: FREEPDB1 both set,                                                                        
  the condition evaluated to the string "FREEPDB1" rather than True, causing a
  hard failure in test_oracle_sql, test_oracle_profile, test_oracle_role, and                                                                      
  test_oracle_user.
                                                                                                                                                   
  Fix: append | length > 0 to produce an explicit boolean.                                                                                         
  
  CI improvements                                                                                                                                  
                                                                           
  Add pbkdf2 to the CI dependency install (closes #31)

  oracle_user.py imports pbkdf2 at runtime for PBKDF2 password-hash
  validation. The package was already listed in tests/integration/requirements.txt
  but the workflow only ran pip install ansible oracledb. The workflow now                                                                         
  installs from requirements.txt so the dependency list stays in one place.
                                                                                                                                                   
  Add CDB-root integration tests for test_oracle_sql                                                                                               
  
  The existing SQL tests always resolved to oracle_pdb_service_name, leaving the                                                                   
  CDB root connection path (oracle_service_name) untested. A new cdb.yml task
  file is included when running_on_cdb is true; it connects directly to the CDB
  root service, asserts CON_NAME = 'CDB$ROOT', and queries v$pdbs (a                                                                               
  CDB-root-only view). This is the path that was silently skipped by the broken
  when condition.                                                                                                                                  
                                                                           
  Test plan                                                                                                                                        
                                                                           
  - All 31 integration roles pass in Docker CI (Oracle Free 23ai)
  - test_oracle_sql new cdb.yml tasks execute and assert CDB root connection
  - test_oracle_parameter change/reset round-trips exercise v$system_parameter                                                                     
  - oracle_crs_service RAC params: verify on a RAC environment that
  srvctl add service receives -preferred/-serverpool/-cardinality flags                                                                            
  and that re-running with the same params reports no change     