### PR TITLE
Fix open upstream issue regressions

### DIFF
--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -416,7 +416,10 @@ def run_dgmgrl(module, commands, output_format='text'):
         if dgmgrl_as:
             connect_string += ' AS %s' % dgmgrl_as.upper()
     elif not dgmgrl_user and not dgmgrl_password and dgmgrl_connect_id:
-        connect_string = '/@%s' % (dgmgrl_connect_id)
+        if dgmgrl_connect_id.startswith('/'):
+            connect_string = dgmgrl_connect_id
+        else:
+            connect_string = '/@%s' % dgmgrl_connect_id
     else:
         # OS authentication
         connect_string = '/ AS %s' % dgmgrl_as.upper()
@@ -433,7 +436,6 @@ def run_dgmgrl(module, commands, output_format='text'):
     script = ';\n'.join(script_lines) + ';\n'
 
     rc, stdout, stderr = module.run_command(cmd, data=script)
-    module.warn(script)
     return rc, stdout, stderr
 
 
@@ -482,8 +484,14 @@ def parse_show_configuration(stdout):
 def dgmgrl_show_configuration(module, output_format):
     """Run SHOW CONFIGURATION and return parsed result."""
     rc, stdout, stderr = run_dgmgrl(module, ['SHOW CONFIGURATION VERBOSE'], output_format)
-    if 'ORA-16532' in stdout or 'not yet created' in stdout.lower():
+    output = '\n'.join([part for part in (stdout, stderr) if part])
+    if 'ORA-16532' in output or 'not yet created' in output.lower():
         return {'status': 'NOT_CONFIGURED', 'name': '', 'databases': []}
+    if rc != 0:
+        module.fail_json(
+            msg='DGMGRL SHOW CONFIGURATION failed: %s' % output.strip(),
+            changed=False,
+        )
 
     if output_format == 'json':
         try:

--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -724,7 +724,7 @@ def main():
             new_password=dict(required=False, no_log=True),
             auto_login=dict(default='none',
                            choices=['none', 'auto_login', 'local_auto_login']),
-            change_password=dict(default=False, type='bool'),
+            change_password=dict(default=False, type='bool', no_log=False),
             backup=dict(default=True, type='bool'),
             backup_location=dict(required=False),
             backup_tag=dict(required=False),

--- a/tests/integration/targets/test_oracle_acl/tasks/create_delete.yml
+++ b/tests/integration/targets/test_oracle_acl/tasks/create_delete.yml
@@ -26,6 +26,21 @@
     state: present
   failed_when: "false"
 
+- name: "setup: remove stale ACL entries"
+  oracle_acl:
+    <<: *con_param
+    host: "{{ item.host }}"
+    principal: "U_ACL_TEST"
+    privilege: "{{ item.priv }}"
+    lower_port: "{{ item.lower_port | default(omit) }}"
+    upper_port: "{{ item.upper_port | default(omit) }}"
+    state: absent
+  loop:
+    - {host: "*.example.com", priv: "connect"}
+    - {host: "mail.example.com", priv: "resolve"}
+    - {host: "smtp.example.com", priv: "connect", lower_port: 25, upper_port: 25}
+  failed_when: "false"
+
 # ── Grant connect ACE ─────────────────────────────────────────────────────────
 
 - name: "check mode: would add ACE?"
@@ -139,10 +154,12 @@
     host: "{{ item.host }}"
     principal: "U_ACL_TEST"
     privilege: "{{ item.priv }}"
+    lower_port: "{{ item.lower_port | default(omit) }}"
+    upper_port: "{{ item.upper_port | default(omit) }}"
     state: absent
   loop:
     - {host: "mail.example.com", priv: "resolve"}
-    - {host: "smtp.example.com", priv: "connect"}
+    - {host: "smtp.example.com", priv: "connect", lower_port: 25, upper_port: 25}
   failed_when: "false"
 
 - name: "cleanup: drop ACL test user"

--- a/tests/integration/targets/test_oracle_tde/tasks/setup_keystore.yml
+++ b/tests/integration/targets/test_oracle_tde/tasks/setup_keystore.yml
@@ -12,14 +12,12 @@
       mode: "{{ mode }}"
       keystore_location: "{{ oracle_wallet_location }}"
 
-# - name: make sure wallet directory exists {{ oracle_wallet_location }}
-#   file:
-#     path: "{{ oracle_wallet_location }}"
-#     state: directory
-#     #owner: "{{ oracle_os_user }}"
-#     #group: "{{ oracle_os_group }}"
-#     #recurse: yes
-#     mode: '0700'
+- name: make sure wallet directory exists {{ oracle_wallet_location }}
+  file:
+    path: "{{ oracle_wallet_location }}"
+    state: directory
+    mode: '0700'
+  when: running_on_server | bool
 
 - name: "create keystore (if not exists)"
   oracle_wallet:

--- a/tests/unit/test_module_argument_specs.py
+++ b/tests/unit/test_module_argument_specs.py
@@ -44,6 +44,14 @@ def test_oracle_role_auth_conf_is_no_log():
     assert exc.value.args[0]["argument_spec"]["auth_conf"]["no_log"] is True
 
 
+def test_oracle_wallet_change_password_is_not_secret():
+    mod = load_module_from_path(module_path("plugins", "modules", "oracle_wallet.py"), "oracle_wallet_spec")
+    _capture_ansible_spec(mod)
+    with pytest.raises(SpecCaptured) as exc:
+        mod.main()
+    assert exc.value.args[0]["argument_spec"]["change_password"].get("no_log") is False
+
+
 def test_oracle_awr_validation_fails_before_connection():
     mod = load_module_from_path(module_path("plugins", "modules", "oracle_awr.py"), "oracle_awr_validation")
 

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -128,6 +128,57 @@ def test_dg_broker_status_not_configured(monkeypatch):
     assert result["configuration"]["status"] == "NOT_CONFIGURED"
 
 
+def test_dg_broker_status_fails_on_dgmgrl_error(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle")
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (
+                1,
+                '',
+                'DGM-16901: Unable to initialize environment\n'
+                'DGM-17378: You may need to set ORACLE_HOME to your Oracle software directory\n',
+            ),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "Unable to initialize environment" in exc.value.args[0]["msg"]
+
+
+def test_dg_broker_wallet_connect_identifier_is_not_double_prefixed(monkeypatch):
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            dgmgrl_connect_identifier="/@EMEA_AT_EMEA",
+        )
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (0, SHOW_CONFIG_OUTPUT, ''),
+            'SHOW': (0, '', ''),
+        }
+        _run_command_calls = []
+        _warnings = []
+
+        def warn(self, msg):
+            type(self)._warnings.append(msg)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson):
+        mod.main()
+    scripts = [kwargs.get('data', '') for _args, kwargs in Mod._run_command_calls]
+    assert any('CONNECT /@EMEA_AT_EMEA;' in script for script in scripts)
+    assert not any('CONNECT /@/@EMEA_AT_EMEA;' in script for script in scripts)
+    assert Mod._warnings == []
+
+
 # ===========================================================================
 # Tests: Broker mode - create configuration
 # ===========================================================================


### PR DESCRIPTION
## Summary
- fail oracle_dataguard status when DGMGRL returns an error instead of returning an empty successful status
- preserve explicit /@ wallet DGMGRL connect identifiers and stop warning with the generated script
- clean stale ACL integration-test entries before rerun-sensitive check-mode assertions
- create the TDE wallet directory during on-server setup and mark change_password as non-secret

## Root cause
The current upstream devel branch partially addressed issue #50, but status still ignored nonzero DGMGRL return codes and /@ connect identifiers could be double-prefixed. The ACL and TDE integration failures came from stale test environment state and missing wallet directory setup, plus Ansible's no_log heuristic for change_password.

## Validation
- PYTEST_ADDOPTS=--no-cov python3 -m pytest tests/unit/test_oracle_dataguard.py tests/unit/test_oracle_acl.py tests/unit/test_oracle_wallet.py tests/unit/test_module_argument_specs.py
- git diff --check
- YAML parse check for the edited ACL and TDE integration task files

Fixes #45
Fixes #46
Fixes #50