### PR TITLE
oracle_user: fix idempotency and support IDENTIFIED EXTERNALLY AS

### DIFF
--- a/plugins/modules/oracle_user.py
+++ b/plugins/modules/oracle_user.py
@@ -36,6 +36,14 @@ options:
     required: false
     default: password
     choices: ['password', 'external', 'global', 'none']
+  external_name:
+    description:
+      - The external name (e.g. certificate DN or Kerberos principal) for an
+        externally identified user, i.e. C(IDENTIFIED EXTERNALLY AS '<external_name>').
+      - Only valid with I(authentication_type=external). Omit it to use the bare
+        C(IDENTIFIED EXTERNALLY) form (an existing external name is then cleared).
+    required: false
+    default: None
   profile:
     description: The profile for the user
     required: false
@@ -146,6 +154,7 @@ def check_user_exists(conn, schema):
         , temporary_tablespace
         , profile
         , authentication_type
+        , external_name
         , oracle_maintained
     from dba_users
     where username = upper(:schema_name)"""
@@ -180,6 +189,7 @@ def create_user(conn, module):
     default_temp_tablespace = module.params["default_temp_tablespace"]
     profile = module.params["profile"]
     authentication_type = module.params["authentication_type"]
+    external_name = module.params["external_name"]
     container = module.params["container"]
     container_data = module.params["container_data"]
 
@@ -202,6 +212,8 @@ def create_user(conn, module):
         sql = 'create user %s identified globally ' % schema
     elif authentication_type == 'external':
         sql = 'create user %s identified externally ' % schema
+        if external_name:
+            sql += "as '%s' " % external_name
     elif authentication_type == 'none':
         sql = 'create user %s no authentication ' % schema
 
@@ -232,6 +244,19 @@ def create_user(conn, module):
 
     msg = 'The schema %s has been created successfully' % schema
     module.exit_json(msg=msg, changed=conn.changed, ddls=conn.ddls)
+
+
+# Get the current default CONTAINER_DATA attribute for the user
+def get_container_data_all(conn, schema):
+    """Return ALL_CONTAINERS ('Y'/'N') of the user's default container_data attribute."""
+    sql = """
+    select all_containers
+    from cdb_container_data
+    where username = upper(:schema_name)
+      and default_attr = 'Y'
+      and object_name is null"""
+    r = conn.execute_select_to_dict(sql, {"schema_name": schema}, fetchone=True, fail_on_error=False)
+    return r['all_containers'] if r and 'all_containers' in r else None
 
 
 # Get the current password hash for the user
@@ -298,6 +323,7 @@ def modify_user(conn, module, user):
     schema_password = module.params["schema_password"]
     schema_password_hash = module.params["schema_password_hash"]
     authentication_type = module.params["authentication_type"]
+    external_name = module.params["external_name"]
     container = module.params["container"]
     container_data = module.params["container_data"]
 
@@ -322,9 +348,11 @@ def modify_user(conn, module, user):
             wanted_set.add(('password', schema_password))
         wanted_set.add(('authentication_type', 'PASSWORD'))
     elif authentication_type == 'external':
-        wanted_set.add(('authentication_type', 'IDENTIFIED EXTERNALLY'))
+        wanted_set.add(('authentication_type', 'EXTERNAL'))
+        # external_name is None when omitted → wants the bare form (NULL external name)
+        wanted_set.add(('external_name', external_name))
     elif authentication_type == 'global':
-        wanted_set.add(('authentication_type', 'IDENTIFIED GLOBALLY'))
+        wanted_set.add(('authentication_type', 'GLOBAL'))
     elif authentication_type == 'none':
         wanted_set.add(('authentication_type', 'NONE'))
 
@@ -355,6 +383,7 @@ def modify_user(conn, module, user):
     password_status = get_change(changes, 'password_status')
     schema_password = get_change(changes, 'password')
     schema_password_hash = get_change(changes, 'password_hash')
+    external_name_changed = any(a == 'external_name' for (a, _) in changes)
     if authentication_type == 'PASSWORD' \
             or (password_status and password_status == 'UNEXPIRED') \
             or schema_password \
@@ -374,11 +403,11 @@ def modify_user(conn, module, user):
                 sql += ''' identified by "%s" ''' % schema_password
             else:
                 module.fail_json(msg="Can on un-expire password, without providing password(or hash)", changed=conn.changed, ddls=conn.ddls)
-    elif authentication_type == 'IDENTIFIED EXTERNALLY':
-        sql += ''' identified externally '''
-    elif authentication_type == 'IDENTIFIED GLOBALLY':
-        wanted_set.add(('authentication_type', 'IDENTIFIED EXTERNALLY'))
-    elif authentication_type == 'global':
+    elif authentication_type == 'EXTERNAL' or external_name_changed:
+        sql += ' identified externally'
+        if module.params['external_name']:
+            sql += " as '%s'" % module.params['external_name']
+    elif authentication_type == 'GLOBAL':
         sql += ''' identified globally '''
     elif authentication_type == 'NONE':
         sql += ''' no authentication '''
@@ -408,12 +437,16 @@ def modify_user(conn, module, user):
     if changes:
         conn.execute_ddl(sql)
 
+    container_data_changed = False
     if container_data:
-        alter_sql = 'alter user %s set container_data=%s container=current' % (schema, container)
-        conn.execute_ddl(alter_sql)
+        wanted_all = 'Y' if container == 'all' else 'N'
+        if get_container_data_all(conn, schema) != wanted_all:
+            alter_sql = 'alter user %s set container_data=%s container=current' % (schema, container)
+            conn.execute_ddl(alter_sql)
+            container_data_changed = True
 
     # wanted list is subset of current settings, do not do anything
-    if not changes and not container_data:
+    if not changes and not container_data_changed:
         module.exit_json(msg='The schema (%s) is in the intended state' % schema, changed=conn.changed, ddls=conn.ddls)
 
     module.exit_json(msg='Successfully altered the user (%s) / %s' % (schema, str(changes)), changed=conn.changed, ddls=conn.ddls)
@@ -455,6 +488,7 @@ def main():
             default_temp_tablespace = dict(default=None, aliases=['temporary_tablespace']),
             profile       = dict(default=None),
             authentication_type = dict(default=None, choices=['password', 'external', 'global', 'none']),
+            external_name = dict(default=None),
             container     = dict(default=None, choices=["all", "current"]),
             container_data = dict(default=None)
         ),
@@ -467,6 +501,9 @@ def main():
 
     schema = module.params["schema"]
     state = module.params["state"]
+
+    if module.params["external_name"] and module.params["authentication_type"] != 'external':
+        module.fail_json(msg="external_name is only valid with authentication_type=external", changed=False)
 
     oc = oracleConnection(module)
 

--- a/tests/unit/test_crud_modules.py
+++ b/tests/unit/test_crud_modules.py
@@ -34,6 +34,7 @@ def _user_params(**overrides):
         "authentication_type": "password",
         "container": None,
         "container_data": None,
+        "external_name": None,
     }
     base.update(overrides)
     return base
@@ -65,6 +66,15 @@ def _default_user_row():
         "authentication_type": "PASSWORD",
         "oracle_maintained": "N",
         "password_status": "UNEXPIRED",
+        "external_name": None,
+    }
+
+
+def _external_user_row(external_name=None):
+    return {
+        **_default_user_row(),
+        "authentication_type": "EXTERNAL",
+        "external_name": external_name,
     }
 
 
@@ -1527,6 +1537,193 @@ def test_user_modify_container_data_existing(monkeypatch):
         mod.main()
     ddls = exc.value.args[0]["ddls"]
     assert any("set container_data" in d.lower() for d in ddls)
+
+
+def test_user_modify_container_data_idempotent(monkeypatch):
+    """Existing user already has container_data=ALL → no DDL, changed=False."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(
+            schema_password=None,
+            container="all",
+            container_data="objecttype",
+        )
+
+    row = _default_user_row()
+
+    class _ContainerDataConn(_UserConn):
+        def execute_select_to_dict(self, sql, params=None, fetchone=False, fail_on_error=True):
+            if "container_data" in sql.lower():
+                return {"all_containers": "Y"}
+            return super().execute_select_to_dict(sql, params, fetchone, fail_on_error)
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _ContainerDataConn(m, row), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    payload = exc.value.args[0]
+    assert payload["changed"] is False
+    assert not any("set container_data" in d.lower() for d in payload["ddls"])
+
+
+# ---------------------------------------------------------------------------
+# oracle_user - IDENTIFIED EXTERNALLY [AS 'name']
+# ---------------------------------------------------------------------------
+
+def test_user_creates_external_with_name(monkeypatch):
+    """Create external user with external_name → identified externally as 'name'."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(
+            schema_password=None,
+            authentication_type="external",
+            external_name="CN=app,OU=eng,O=acme",
+        )
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _UserConn(m, None), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    ddls = exc.value.args[0]["ddls"]
+    assert any("identified externally as 'cn=app,ou=eng,o=acme'" in d.lower() for d in ddls)
+
+
+def test_user_external_name_requires_external_auth(monkeypatch):
+    """external_name with authentication_type != external → fail_json."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(authentication_type="password", external_name="CN=x")
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _UserConn(m, None), raising=False)
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "external" in exc.value.args[0]["msg"].lower()
+
+
+def test_user_modify_external_add_name(monkeypatch):
+    """Existing bare-external user, add external_name → alter identified externally as 'name'."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(
+            schema_password=None,
+            authentication_type="external",
+            external_name="CN=x",
+        )
+
+    row = _external_user_row(external_name=None)
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _UserConn(m, row), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    payload = exc.value.args[0]
+    assert payload["changed"] is True
+    assert any("identified externally as 'cn=x'" in d.lower() for d in payload["ddls"])
+
+
+def test_user_modify_external_name_idempotent(monkeypatch):
+    """Existing external AS 'CN=x', set same → no DDL, changed=False."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(
+            schema_password=None,
+            authentication_type="external",
+            external_name="CN=x",
+        )
+
+    row = _external_user_row(external_name="CN=x")
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _UserConn(m, row), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    payload = exc.value.args[0]
+    assert payload["changed"] is False
+    assert not any("identified externally" in d.lower() for d in payload["ddls"])
+
+
+def test_user_modify_external_change_name(monkeypatch):
+    """Existing external AS 'CN=x', set 'CN=y' → alter to new name."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(
+            schema_password=None,
+            authentication_type="external",
+            external_name="CN=y",
+        )
+
+    row = _external_user_row(external_name="CN=x")
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _UserConn(m, row), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    payload = exc.value.args[0]
+    assert payload["changed"] is True
+    assert any("identified externally as 'cn=y'" in d.lower() for d in payload["ddls"])
+
+
+def test_user_modify_external_downgrade_to_bare(monkeypatch):
+    """Existing external AS 'CN=x', omit external_name → downgrade to bare identified externally."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(schema_password=None, authentication_type="external")
+
+    row = _external_user_row(external_name="CN=x")
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _UserConn(m, row), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    payload = exc.value.args[0]
+    assert payload["changed"] is True
+    ddls = [d.lower() for d in payload["ddls"]]
+    assert any("identified externally" in d for d in ddls)
+    assert not any(" as '" in d for d in ddls)
+
+
+def test_user_modify_external_bare_idempotent(monkeypatch):
+    """Existing bare-external user, auth=external no name → no DDL, changed=False."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(schema_password=None, authentication_type="external")
+
+    row = _external_user_row(external_name=None)
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _UserConn(m, row), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    payload = exc.value.args[0]
+    assert payload["changed"] is False
+
+
+def test_user_modify_global_idempotent(monkeypatch):
+    """Existing GLOBAL user, auth=global → no DDL, changed=False."""
+    mod = _load("oracle_user")
+
+    class Mod(BaseFakeModule):
+        params = _user_params(schema_password=None, authentication_type="global")
+
+    row = {**_default_user_row(), "authentication_type": "GLOBAL"}
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection", lambda m: _UserConn(m, row), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is False
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

Two correctness fixes for `oracle_user`, both about idempotency, plus a new capability for externally-identified users.

### 1. `container_data` was never idempotent
`modify_user` ran `ALTER USER ... SET container_data=... CONTAINER=CURRENT` unconditionally whenever `container_data` was set, so `changed` was **always true** on an existing user (the module never checked the current state).

Fix: query `CDB_CONTAINER_DATA` (`DEFAULT_ATTR='Y'`, `OBJECT_NAME IS NULL`) and run the DDL only when `ALL_CONTAINERS` differs from the desired value.

### 2. `EXTERNAL` / `GLOBAL` auth were never idempotent
For external/global users, `modify_user` built the wanted `authentication_type` as `IDENTIFIED EXTERNALLY` / `IDENTIFIED GLOBALLY`. But `DBA_USERS.AUTHENTICATION_TYPE` returns `EXTERNAL` / `GLOBAL`, so the wanted value **never matched** the current value — every run reported `changed` and re-issued the DDL. (`PASSWORD`/`NONE` matched, so only external/global were affected.)

Fix: align the wanted values with the `DBA_USERS` values (`EXTERNAL`, `GLOBAL`). Also removes a dead branch in the modify SQL builder (`elif authentication_type == 'IDENTIFIED GLOBALLY'` added to `wanted_set` instead of building SQL).

### 3. New: `IDENTIFIED EXTERNALLY AS '<name>'`
New `external_name` param to manage the external name (certificate DN / Kerberos principal) of an externally-identified user, in both create and modify. Idempotent via `DBA_USERS.EXTERNAL_NAME`.

| `external_name` | current name | result |
|---|---|---|
| omitted | NULL | no-op |
| omitted | `CN=x` | `IDENTIFIED EXTERNALLY` (clears the name) |
| `CN=x` | NULL | `IDENTIFIED EXTERNALLY AS 'CN=x'` |
| `CN=x` | `CN=x` | no-op |
| `CN=y` | `CN=x` | `IDENTIFIED EXTERNALLY AS 'CN=y'` |

`external_name` requires `authentication_type=external`; otherwise the module fails fast with a clear message.

## Why
Re-running a playbook against an already-converged user must report `ok`, not `changed`. The container_data and external/global paths broke that contract. The `external_name` support is needed for SSL/Kerberos schema accounts (e.g. schema-only accounts) where the bare `IDENTIFIED EXTERNALLY` form is not enough.

## Tests
Unit tests added in `tests/unit/test_crud_modules.py` covering: container_data idempotency, external create with/without name, modify add/change/idempotent/downgrade-to-bare, bare-external idempotency, global idempotency, and the `external_name`-without-external-auth failure. Full unit suite passes (109 in the affected file).

## Notes
- Proxy / `GRANT CONNECT THROUGH` is intentionally **not** added here — it is a two-user relationship better handled via `oracle_sql` gated on `DBA_PROXIES`.
- DOCUMENTATION updated with the new `external_name` param.