### PR TITLE
oracle_dataguard: detect DGMGRL errors and guard add-database (#50, #52)

### DIFF
--- a/plugins/modules/oracle_dataguard.py
+++ b/plugins/modules/oracle_dataguard.py
@@ -487,7 +487,9 @@ def dgmgrl_show_configuration(module, output_format):
     output = '\n'.join([part for part in (stdout, stderr) if part])
     if 'ORA-16532' in output or 'not yet created' in output.lower():
         return {'status': 'NOT_CONFIGURED', 'name': '', 'databases': []}
-    if rc != 0:
+    # DGMGRL may print DGM- errors (e.g. DGM-16901 environment init) while still
+    # exiting rc=0; treat any DGM- code as fatal so the failure is not swallowed.
+    if rc != 0 or re.search(r'\bDGM-\d+', output):
         module.fail_json(
             msg='DGMGRL SHOW CONFIGURATION failed: %s' % output.strip(),
             changed=False,
@@ -1139,7 +1141,11 @@ def _broker_present(module, database_name, output_format):
 
     if database_name and config.get('status') != 'NOT_CONFIGURED':
         existing_dbs = [d['name'] for d in config.get('databases', [])]
-        if database_name.upper() not in [d.upper() for d in existing_dbs]:
+        # Only add the database when connect_identifier is supplied (intent to
+        # add). Without it, fall through to set state / properties on a database
+        # that is already part of the configuration (issue #52).
+        if (database_name.upper() not in [d.upper() for d in existing_dbs]
+                and module.params.get("connect_identifier")):
             dgmgrl_add_database(module)
             changed = True
 

--- a/tests/unit/test_oracle_dataguard.py
+++ b/tests/unit/test_oracle_dataguard.py
@@ -150,6 +150,86 @@ def test_dg_broker_status_fails_on_dgmgrl_error(monkeypatch):
     assert "Unable to initialize environment" in exc.value.args[0]["msg"]
 
 
+def test_dg_broker_status_fails_on_dgmgrl_error_rc0(monkeypatch):
+    """DGMGRL prints a DGM- error but exits rc=0 → must fail, not silently
+    return an empty configuration (issue #50)."""
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(oracle_home="/fake/oracle")
+        _dgmgrl_responses = {
+            'SHOW CONFIGURATION': (
+                0,
+                'DGM-16901: Unable to initialize environment\n'
+                'DGM-17378: You may need to set ORACLE_HOME to your Oracle software directory\n',
+                '',
+            ),
+        }
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(FailJson) as exc:
+        mod.main()
+    assert "DGM-16901" in exc.value.args[0]["msg"]
+
+
+def test_dg_broker_set_state_without_connect_identifier_does_not_add(monkeypatch):
+    """database_state on a db absent from the parsed config, without
+    connect_identifier, must set state rather than fail demanding it (issue #52)."""
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            database_name="STDBY2",  # not present in SHOW_CONFIG_OUTPUT
+            database_state="apply-on",
+        )
+        _dgmgrl_responses = {
+            'EDIT DATABASE': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    Mod._run_command_calls = []
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is True
+    scripts = [kwargs.get('data', '') for _a, kwargs in Mod._run_command_calls]
+    assert any('EDIT DATABASE STDBY2' in s for s in scripts)
+    assert not any('ADD DATABASE' in s.upper() for s in scripts)
+
+
+def test_dg_broker_adds_database_when_connect_identifier_given(monkeypatch):
+    """db absent from config + connect_identifier provided → still adds (regression)."""
+    mod = _load()
+
+    class Mod(_DgBrokerModule):
+        params = _dg_params(
+            oracle_home="/fake/oracle",
+            state="present",
+            database_name="STDBY2",
+            connect_identifier="stdby2-host:1521/STDBY2",
+        )
+        _dgmgrl_responses = {
+            'ADD DATABASE': (0, 'Succeeded.', ''),
+        }
+        _run_command_calls = []
+
+    Mod._run_command_calls = []
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "os", _FakeOs("/fake/oracle"))
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is True
+    scripts = [kwargs.get('data', '') for _a, kwargs in Mod._run_command_calls]
+    assert any('ADD DATABASE STDBY2' in s.upper() for s in scripts)
+
+
 def test_dg_broker_wallet_connect_identifier_is_not_double_prefixed(monkeypatch):
     mod = _load()
 


### PR DESCRIPTION
Fixes #50 and #52 — both broker-mode (`mode_dg: broker`) correctness issues.

## #50 — silent failure
`DGMGRL` can print a `DGM-` error (e.g. `DGM-16901: Unable to initialize environment`, `DGM-17378`) while still **exiting rc=0**. `dgmgrl_show_configuration` only checked `rc != 0`, so the error was swallowed: `SHOW CONFIGURATION` returned an empty config (`databases: []`) with `failed: false`.

Fix: treat any `DGM-<n>` code in the output as fatal (alongside the existing `rc != 0`), after the existing `ORA-16532`/NOT_CONFIGURED allow-check so an unconfigured broker is still reported normally.

## #52 — wrong "add database" path
`_broker_present` added any database not present in the parsed configuration, and `dgmgrl_add_database` hard-requires `connect_identifier`. So setting `database_state` on an **already-configured** database (without `connect_identifier`) failed with:

```
database_name and connect_identifier are required to add a database
```

Fix: only attempt the add when `connect_identifier` is supplied (explicit intent to add). Otherwise execution falls through to set state / properties on the existing database. With #50 fixed, an error-driven empty config now fails loudly instead of mis-routing into the add path.

## Tests
`tests/unit/test_oracle_dataguard.py`:
- `DGM-` error on **rc=0** → `fail_json` (the real silent-fail; the prior test only covered rc=1).
- `database_state` without `connect_identifier` on a db absent from the parsed config → sets state, does **not** add.
- regression: db absent + `connect_identifier` given → still adds.

Full unit suite passes (39 in the dataguard file).

## Not included
The underlying environment-init cause of `DGM-16901` (dgmgrl child needing more than `ORACLE_HOME` exported) is environment-specific and left untouched — this PR converts the silent failure into a clear, actionable error. End-to-end broker behavior needs a live Data Guard configuration to validate.