### PR TITLE
oracle_wallet: idempotent keystore creation when keystore already exists (#45)

### DIFF
--- a/plugins/modules/oracle_wallet.py
+++ b/plugins/modules/oracle_wallet.py
@@ -496,7 +496,12 @@ def ensure_keystore_present(conn, module):
     sql = "ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '%s' IDENTIFIED BY \"%s\"" % (
         loc_esc, pwd_esc
     )
-    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql))
+    # V$ENCRYPTION_WALLET can report NOT_AVAILABLE while a keystore file already
+    # exists on disk (e.g. after an instance restart with WALLET_ROOT set), so the
+    # status-based check above misses it. CREATE KEYSTORE then fails with
+    # ORA-46630 (keystore already at location) or ORA-46633 (password-based
+    # keystore creation failed). Tolerate both so the operation stays idempotent.
+    conn.execute_ddl(sql, ddls_entry=_redact_ddl(sql), ignore_errors=[46630, 46633])
     return get_wallet_status(conn, module.params["container"])
 
 

--- a/tests/unit/test_oracle_wallet.py
+++ b/tests/unit/test_oracle_wallet.py
@@ -141,6 +141,40 @@ def test_wallet_create_when_not_exists(monkeypatch):
     assert "CREATE KEYSTORE" in result["ddls"][0]
 
 
+def test_wallet_create_keystore_already_exists_on_disk_is_idempotent(monkeypatch):
+    """V$ENCRYPTION_WALLET reports NOT_AVAILABLE but a keystore file already exists
+    on disk (e.g. after an instance restart), so CREATE KEYSTORE fails with
+    ORA-46633/ORA-46630. The module must tolerate it instead of failing (issue #45)."""
+    mod = _load()
+
+    class Mod(BaseFakeModule):
+        params = _wallet_params(state="present")
+
+    class _KeystoreExistsConn(_WalletConn):
+        """CREATE KEYSTORE raises ORA-46633 unless the caller ignores it."""
+
+        def execute_ddl(self, request, params=None, no_change=False,
+                        ignore_errors=None, ddls_entry=None):
+            ignore_errors = ignore_errors or []
+            self.ddls.append(ddls_entry if ddls_entry is not None else request)
+            if 'CREATE KEYSTORE' in request.upper():
+                if 46633 not in ignore_errors and 46630 not in ignore_errors:
+                    self.module.fail_json(
+                        msg='ORA-46633: creation of a password-based keystore failed',
+                        code=46633, ddls=self.ddls, changed=self.changed)
+                return  # error ignored → keystore already present, no change
+            if not no_change:
+                self.changed = True
+
+    monkeypatch.setattr(mod, "AnsibleModule", Mod)
+    monkeypatch.setattr(mod, "oracleConnection",
+                        lambda m: _KeystoreExistsConn(m, 'NOT_AVAILABLE'), raising=False)
+
+    with pytest.raises(ExitJson) as exc:
+        mod.main()
+    assert exc.value.args[0]["changed"] is False
+
+
 def test_wallet_create_idempotent_when_exists(monkeypatch):
     mod = _load()
 


### PR DESCRIPTION
Fixes the re-execution failure in #45 (`ORA-46633: creation of a password-based keystore failed`).

## Root cause
`ensure_keystore_present()` decides whether to run `CREATE KEYSTORE` based on `V$ENCRYPTION_WALLET.STATUS` (skips when status is not `NOT_AVAILABLE`). After an instance restart with `WALLET_ROOT` set, that view can report **`NOT_AVAILABLE` while a keystore file already exists on disk**. The status check is missed, `CREATE KEYSTORE` is re-issued, and Oracle fails the task:
- `ORA-46630` — keystore already at location (explicit-location form), or
- `ORA-46633` — creation of a password-based keystore failed (the variant reported on 19c in #45).

So the module is not idempotent across a restart / re-run.

## Fix
Pass `ignore_errors=[46630, 46633]` to the `CREATE KEYSTORE` DDL, mirroring the **existing auto-login keystore handling** in the same module, which already ignores `ORA-46630` for the same reason (V$ENCRYPTION_WALLET reflecting active access method, not on-disk files). A pre-existing keystore is now tolerated and the run reports `changed=false`.

## Reproduced on Oracle Database 23ai Free
Creating a password keystore at a location that already holds one:
```
ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '/tmp/tde_ks' IDENTIFIED BY "...";   -- ok
ADMINISTER KEY MANAGEMENT CREATE KEYSTORE '/tmp/tde_ks' IDENTIFIED BY "...";   -- ORA-46630
```
…while `V$ENCRYPTION_WALLET` reports `STATUS=NOT_AVAILABLE`. (19c surfaces this as `ORA-46633`; both codes are handled.)

## Tests
`tests/unit/test_oracle_wallet.py`: new test where `CREATE KEYSTORE` raises `ORA-46633` and the module must tolerate it (no `fail_json`, `changed=false`). Full wallet suite passes (44).

The `change_password` `no_log` warning also mentioned in #45 was already fixed on `devel`.